### PR TITLE
Add index-services script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+sudo: false
+python:
+  - "2.7"
+  - "3.4"
+install:
+  - pip install -r requirements_for_test.txt
+script:
+  - pep8 .
+  - py.test
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 This repository is where all scripts that interact with the Digital Marketplace APIs (
 [data API](https://github.com/alphagov/digitalmarketplace-api) and
 [search-api](https://github.com/alphagov/digitalmarketplace-search-api)]).
+
+* `scripts/generate-user-email-list.py`
+  script for generating a CSV of user email addresses and
+  details in the Digital Marketplace.
+
+* `scripts/index-services.py`
+  Reads services from the API endpoint and writes to search-api for indexing.

--- a/dmscripts/env.py
+++ b/dmscripts/env.py
@@ -1,0 +1,26 @@
+def get_api_endpoint_from_stage(stage, app='api'):
+    """Return the full URL of given API or Search API environment.
+
+    :param stage: environment name. Can be one of 'preview', 'staging',
+                  'production' or 'dev' (aliases: 'local', 'development').
+    :param app: should be either 'api' or 'search-api'
+
+    """
+
+    stage_prefixes = {
+        'preview': 'preview-{}.development'.format(app),
+        'staging': 'staging-{}'.format(app),
+        'production': app
+    }
+
+    dev_ports = {
+        'api': 5000,
+        'search-api': 5001,
+    }
+
+    if stage in ['local', 'dev', 'development']:
+        return 'http://localhost:{}'.format(dev_ports[app])
+
+    return "https://{}.digitalmarketplace.service.gov.uk".format(
+        stage_prefixes[stage]
+    )

--- a/dmscripts/logging.py
+++ b/dmscripts/logging.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+
+import sys
+import logging
+from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL  # noqa
+
+from dmutils.logging import CustomLogFormatter
+
+LOG_FORMAT = '%(asctime)s %(name)s %(levelname)s %(message)s'
+
+
+def configure_logger(log_levels=None):
+    """Configure logging handlers and return a configured 'script' logger
+
+    :param log_levels: a dictionary of logger name and corresponding log
+                       levels. Can be used to silence or add additional log
+                       output from other packages. By default configures
+                       'script' and 'dmutils' loggers with INFO level.
+
+    :return: 'script' logger object
+
+    """
+    log_levels = merge_log_levels(log_levels or {})
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(CustomLogFormatter(LOG_FORMAT))
+
+    for logger_name, level in log_levels.items():
+        logging.getLogger(logger_name).addHandler(handler)
+        logging.getLogger(logger_name).setLevel(level)
+
+    return logging.getLogger('script')
+
+
+def merge_log_levels(added_log_levels):
+    log_levels = {
+        'dmutils': INFO,
+        'script': INFO,
+    }
+
+    log_levels.update(added_log_levels)
+
+    return log_levels

--- a/scripts/index-services.py
+++ b/scripts/index-services.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+"""Read services from the API endpoint and write to search-api for indexing.
+
+Usage:
+    index-services.py <stage> --api-token=<api_access_token> --search-api-token=<search_api_access_token> [options]
+
+    --serial        Do not run in parallel (useful for debugging)
+    --index=<index>  Search API index name [default: g-cloud]
+
+Example:
+    ./index-services.py dev --api-token=myToken --search-api-token=myToken
+"""
+
+import sys
+import multiprocessing
+from six.moves import map
+from datetime import datetime
+
+import backoff
+from docopt import docopt
+from dmutils import apiclient
+
+sys.path.insert(0, '.')
+from dmscripts.env import get_api_endpoint_from_stage
+from dmscripts import logging
+
+logger = logging.configure_logger({'dmutils': logging.WARNING})
+
+
+def request_services(api_url, api_access_token, page=1):
+
+    data_client = apiclient.DataAPIClient(
+        api_url,
+        api_access_token
+    )
+
+    for service in data_client.find_services_iter():
+        yield service
+
+
+def print_progress(counter, start_time):
+    if counter % 100 == 0:
+        time_delta = datetime.utcnow() - start_time
+        logger.info("{counter} in {time} ({rps}/s)", extra={
+            'counter': counter, 'time': time_delta, 'rps': counter / time_delta.total_seconds()
+        })
+
+
+class ServiceIndexer(object):
+    def __init__(self, endpoint, access_token, index):
+        self.endpoint = endpoint
+        self.access_token = access_token
+        self.index = index
+
+    def __call__(self, service):
+        client = apiclient.SearchAPIClient(self.endpoint, self.access_token)
+
+        try:
+            self.index_service(client, service)
+            return True
+        except apiclient.APIError:
+            logger.exception("{service_id} not indexed", extra={'service_id': service.get('id')})
+            return False
+
+    @backoff.on_exception(backoff.expo, apiclient.HTTPError, max_tries=5)
+    def index_service(self, client, service):
+        if service['status'] == 'published':
+            client.index(service['id'], service, index=self.index)
+        else:
+            client.delete(service['id'], index=self.index)
+
+    def create_index(self):
+        client = apiclient.SearchAPIClient(self.endpoint, self.access_token)
+        logger.info("Creating {index} index", extra={'index': self.index})
+        result = client.create_index(self.index)
+        logger.info("Index creation response: {response}", extra={'response': result})
+
+
+def do_index(search_api_url, search_api_access_token, data_api_url, data_api_access_token, serial, index):
+    logger.info("Search API URL: {search_api_url}", extra={'search_api_url': search_api_url})
+    logger.info("Data API URL: {data_api_url}", extra={'data_api_url': data_api_url})
+
+    if serial:
+        pool = None
+        mapper = map
+    else:
+        pool = multiprocessing.Pool(10)
+        mapper = pool.imap
+
+    indexer = ServiceIndexer(search_api_url, search_api_access_token, index)
+    indexer.create_index()
+
+    counter = 0
+    start_time = datetime.utcnow()
+    status = True
+
+    services = request_services(data_api_url, data_api_access_token)
+    for result in mapper(indexer, services):
+        counter += 1
+        status = status and result
+        print_progress(counter, start_time)
+
+    return status
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+    ok = do_index(
+        data_api_url=get_api_endpoint_from_stage(arguments['<stage>'], 'api'),
+        data_api_access_token=arguments['--api-token'],
+        search_api_url=get_api_endpoint_from_stage(arguments['<stage>'], 'search-api'),
+        search_api_access_token=arguments['--search-api-token'],
+        serial=arguments['--serial'],
+        index=arguments['--index'],
+    )
+
+    if not ok:
+        sys.exit(1)


### PR DESCRIPTION
### Add index-services script
Updated version of the index_services.py scripts from
digitalmarketplace-api repository. New version:

* supports retries for all list services and indexing requests
* takes environment name instead of the two API endpoints
* can use any index name instead of the `g-cloud` default
* uses `dmutils` logging format

#### Add dmscripts.env helper to get API endpoint for given stage
Takes a stage name and returns the full API endpoint for Data or
Search APIs.

#### Add helper dmscript.logging functions
Used to configure 'dmutils' and 'script' logger with dmutils logging
handler. Logging levels can be modified for any additional loggers.