### PR TITLE
Skip index creation when alias exists with the same name

### DIFF
--- a/scripts/index-services.py
+++ b/scripts/index-services.py
@@ -72,8 +72,15 @@ class ServiceIndexer(object):
     def create_index(self):
         client = apiclient.SearchAPIClient(self.endpoint, self.access_token)
         logger.info("Creating {index} index", extra={'index': self.index})
-        result = client.create_index(self.index)
-        logger.info("Index creation response: {response}", extra={'response': result})
+
+        try:
+            result = client.create_index(self.index)
+            logger.info("Index creation response: {response}", extra={'response': result})
+        except apiclient.HTTPError as e:
+            if 'already exists as alias' in e.message:
+                logger.info("Skipping index creation for alias {index}", extra={'index': self.index})
+            else:
+                raise
 
 
 def do_index(search_api_url, search_api_access_token, data_api_url, data_api_access_token, serial, index):


### PR DESCRIPTION
index-services is used for nightly index updates, during which it
uses the main alias as the request index. Trying to create an index
fails in this case since an alias with the same name already exists.

Index creation is skipped when --index is set to an alias name. Any
other error response during index creation will abort the script.