### PR TITLE
Script to update API with pass/fail for suppliers

### DIFF
--- a/dmscripts/insert_framework_results.py
+++ b/dmscripts/insert_framework_results.py
@@ -1,0 +1,32 @@
+from __future__ import unicode_literals
+import unicodecsv as csv
+
+from dmutils.apiclient.errors import HTTPError
+
+
+def insert_result(client, supplier_id, framework_slug, result, user):
+    try:
+        client.set_framework_result(supplier_id, framework_slug, result, user)
+        return "OK: {}\n".format(supplier_id)
+    except HTTPError as e:
+        return "Error inserting result for {} ({}): {}\n".format(supplier_id, result, str(e))
+
+
+def insert_results(client, output, framework_slug, filename, user):
+    with open(filename, 'rb') as csvfile:
+        reader = csv.reader(csvfile)
+        for index, row in enumerate(reader, start=1):
+            try:
+                supplier_id = int(row[0])
+                result = row[1].strip().lower()
+                if result == 'pass':
+                    result = True
+                elif result == 'fail':
+                    result = False
+                else:
+                    raise Exception("Result must be 'pass' or 'fail', not '{}'".format(result))
+            except Exception as e:
+                output.write("Error: {}; Bad line: {}\n".format(str(e), index))
+                continue
+
+            output.write(insert_result(client, supplier_id, framework_slug, result, user))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@11.1.0#egg=digitalmarketplace-utils==11.1.0
+unicodecsv==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@10.5.0#egg=digitalmarketplace-utils==10.5.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@11.1.0#egg=digitalmarketplace-utils==11.1.0

--- a/scripts/insert-framework-results.py
+++ b/scripts/insert-framework-results.py
@@ -1,0 +1,30 @@
+"""
+Takes a CSV file with rows in the format: Supplier ID, Result
+e.g:
+123456, pass
+123212, fail
+234567, pass
+
+Usage:
+    scripts/record-pass-fail-results-for-framework.py <framework_slug> <data_api_url> <data_api_token> <filename>
+"""
+
+import getpass
+import sys
+sys.path.insert(0, '.')
+
+from docopt import docopt
+from dmutils.apiclient import DataAPIClient
+from dmscripts.insert_framework_results import insert_results
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    client = DataAPIClient(arguments['<data_api_url>'], arguments['<data_api_token>'])
+    output = sys.stdout
+    framework_slug = arguments['<framework_slug>']
+    filename = arguments['<filename>']
+    user = getpass.getuser()
+
+    insert_results(client, output, framework_slug, filename, user)

--- a/tests/fixtures/framework_results.csv
+++ b/tests/fixtures/framework_results.csv
@@ -1,0 +1,7 @@
+123,pass
+234,fail
+345, PASS
+456, FAIL
+567, Yes
+Company Name,pass
+678,PasS

--- a/tests/test_insert_framework_results.py
+++ b/tests/test_insert_framework_results.py
@@ -1,0 +1,49 @@
+import pytest
+
+from dmscripts.insert_framework_results import insert_result, insert_results
+from mock import mock, call
+from dmutils.apiclient.errors import HTTPError
+
+
+@pytest.fixture
+def mock_data_client():
+    return mock.Mock()
+
+
+def test_insert_result(mock_data_client):
+    mock_data_client.set_framework_result.return_value = {'on_framework': True}
+
+    assert insert_result(mock_data_client, 123456, 'g-cloud-7', True, 'user') == 'OK: 123456\n'
+    mock_data_client.set_framework_result.assert_called_with(123456, 'g-cloud-7', True, 'user')
+
+
+def test_insert_results(mock_data_client):
+    out_mock = mock.Mock()
+    insert_results(mock_data_client, out_mock, 'g-cloud-7', 'tests/fixtures/framework_results.csv', 'user')
+
+    mock_data_client.set_framework_result.assert_has_calls([
+        call(123, 'g-cloud-7', True, 'user'),
+        call(234, 'g-cloud-7', False, 'user'),
+        call(345, 'g-cloud-7', True, 'user'),
+        call(456, 'g-cloud-7', False, 'user'),
+        call(678, 'g-cloud-7', True, 'user')
+        ], any_order=False
+    )
+
+    out_mock.write.assert_has_calls([
+        call("OK: 123\n"),
+        call("OK: 234\n"),
+        call("OK: 345\n"),
+        call("OK: 456\n"),
+        call("Error: Result must be 'pass' or 'fail', not 'yes'; Bad line: 5\n"),
+        call("Error: invalid literal for int() with base 10: 'Company Name'; Bad line: 6\n"),
+        call("OK: 678\n")
+        ], any_order=False
+    )
+
+
+def test_http_error_handling(mock_data_client):
+    mock_data_client.set_framework_result.side_effect = HTTPError()
+
+    result = insert_result(mock_data_client, 123456, 'g-cloud-7', True, 'user')
+    assert result == 'Error inserting result for 123456 (True): Request failed (status: 503)\n'


### PR DESCRIPTION
For use when the pass/fail results for suppliers come in from CCS.

The script here may be subject to change as we don't yet know the format of data we'll get from CCS - this assumes a basic CSV with just `supplier_id` and `pass/fail` per row.  If we also get supplier name it would be good to modify the script to check the supplier name matches the ID before updating, as a sanity check.