### PR TITLE
Generate a CSV file with all the declaration/service questions

### DIFF
--- a/dmscripts/generate_questions_csv.py
+++ b/dmscripts/generate_questions_csv.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+import os
+import unicodecsv
+
+
+MANIFESTS = [{
+    'question_set': 'declaration',
+    'manifest':     'declaration'
+    }, {
+    'question_set': 'services',
+    'manifest':     'edit_submission'
+}]
+
+LOTS = {
+    'g-cloud-7': ['IaaS', 'PaaS', 'SaaS', 'SCS'],
+    'digital-outcomes-and-specialists':
+        ['digital-specialists', 'digital-outcomes', 'user-research-participants', 'user-research-studios']
+}
+
+
+def return_rows_for_content(content):
+    local_rows = []
+
+    for section in content.sections:
+        for question in get_questions(section.questions):
+            row = [
+                question.get('multiquestion_name', section.name),
+                question.get('multiquestion_hint', None),
+                question.get('question'),
+                question.get('hint')
+            ]
+
+            options = []
+            for option in question.get('options', []):
+                if 'label' in option:
+                    options.append(option['label'])
+                    if 'description' in option:
+                        options[-1] = "{} - {}".format(options[-1], option['label'])
+
+            if question.get('type') == 'boolean':
+                options.append('Yes')
+                options.append('No')
+            row.extend(options)
+
+            local_rows.append(row)
+
+    # blank row
+    local_rows.append([''] * 4)
+    return local_rows
+
+
+def get_questions(questions):
+
+    def augment_question_data(question, name, hint):
+        question.multiquestion_name = name
+        if hint:
+            question.multiquestion_hint = hint
+        return question
+
+    def get_question(question):
+        if question.questions:
+            return [
+                augment_question_data(nested_question, question.get('name'), question.get('hint'))
+                for nested_question in question.questions
+            ]
+
+        return [question]
+
+    questions_list = []
+    for question in questions:
+        questions_list += get_question(question)
+
+    return questions_list
+
+
+def generate_csv(output_directory, framework_slug, content_loader):
+
+    if not os.path.exists(output_directory):
+        os.makedirs(output_directory)
+
+    rows = []
+
+    for manifest in MANIFESTS:
+        content_loader.load_manifest(framework_slug, manifest['question_set'], manifest['manifest'])
+
+        if manifest['question_set'] == 'services':
+            if framework_slug in LOTS:
+                for lot in LOTS[framework_slug]:
+                    content = content_loader.get_manifest(
+                        framework_slug, manifest['manifest']).filter({'lot': lot})
+                    rows.extend(return_rows_for_content(content))
+        else:
+            content = content_loader.get_manifest(framework_slug, manifest['manifest'])
+            rows.extend(return_rows_for_content(content))
+
+    # find the longest array
+    max_length = max(len(row) for row in rows)
+    max_length_options = max_length - 4
+
+    # push all arrays to that size
+    for index, row in enumerate(rows):
+        row.extend([''] * (max_length - len(row)))
+
+    with open('{}/{}-questions.csv'.format(output_directory, framework_slug), 'wb') as csvfile:
+        writer = unicodecsv.writer(csvfile, delimiter=',', quotechar='"')
+        header = ["Page title", "Page title hint", "Question", "Hint"]
+        header.extend(
+            ["Answer {}".format(i) for i in range(1, max_length_options+1)]
+        )
+        writer.writerow(header)
+        for row in rows:
+            writer.writerow(row)

--- a/dmscripts/generate_questions_csv.py
+++ b/dmscripts/generate_questions_csv.py
@@ -18,10 +18,34 @@ LOTS = {
 }
 
 
-def return_rows_for_content(content):
+def get_questions(questions):
+
+    def augment_question_data(question, name, hint):
+        question.multiquestion_name = name
+        if hint:
+            question.multiquestion_hint = hint
+        return question
+
+    def get_question(question):
+        if question.questions:
+            return [
+                augment_question_data(nested_question, question.get('name'), question.get('hint'))
+                for nested_question in question.questions
+            ]
+
+        return [question]
+
+    questions_list = []
+    for question in questions:
+        questions_list += get_question(question)
+
+    return questions_list
+
+
+def return_rows_for_sections(sections):
     local_rows = []
 
-    for section in content.sections:
+    for section in sections:
         for question in get_questions(section.questions):
             row = [
                 question.get('multiquestion_name', section.name),
@@ -49,30 +73,6 @@ def return_rows_for_content(content):
     return local_rows
 
 
-def get_questions(questions):
-
-    def augment_question_data(question, name, hint):
-        question.multiquestion_name = name
-        if hint:
-            question.multiquestion_hint = hint
-        return question
-
-    def get_question(question):
-        if question.questions:
-            return [
-                augment_question_data(nested_question, question.get('name'), question.get('hint'))
-                for nested_question in question.questions
-            ]
-
-        return [question]
-
-    questions_list = []
-    for question in questions:
-        questions_list += get_question(question)
-
-    return questions_list
-
-
 def generate_csv(output_directory, framework_slug, content_loader):
 
     if not os.path.exists(output_directory):
@@ -88,10 +88,10 @@ def generate_csv(output_directory, framework_slug, content_loader):
                 for lot in LOTS[framework_slug]:
                     content = content_loader.get_manifest(
                         framework_slug, manifest['manifest']).filter({'lot': lot})
-                    rows.extend(return_rows_for_content(content))
+                    rows.extend(return_rows_for_sections(content.sections))
         else:
             content = content_loader.get_manifest(framework_slug, manifest['manifest'])
-            rows.extend(return_rows_for_content(content))
+            rows.extend(return_rows_for_sections(content.sections))
 
     # find the longest array
     max_length = max(len(row) for row in rows)

--- a/dmscripts/generate_questions_csv.py
+++ b/dmscripts/generate_questions_csv.py
@@ -59,7 +59,7 @@ def return_rows_for_sections(sections):
                 if 'label' in option:
                     options.append(option['label'])
                     if 'description' in option:
-                        options[-1] = "{} - {}".format(options[-1], option['label'])
+                        options[-1] = "{} - {}".format(options[-1], option['description'])
 
             if question.get('type') == 'boolean':
                 options.append('Yes')

--- a/scripts/generate-questions-csv.py
+++ b/scripts/generate-questions-csv.py
@@ -1,0 +1,29 @@
+"""
+This script generates a CSV file for the questions in each lot.
+
+The order of fields in the generated file is the same as we had for G-Cloud-6:
+"Page title", "Question", "Hint", "Answer 1", "Answer 2", ...
+
+Before running this you will need to:
+pip install -r requirements_for_script.txt
+
+Usage:
+    scripts/generate-csv.py <path_to_manifest> <output_directory> --framework=<slug>
+"""
+import sys
+sys.path.insert(0, '.')
+
+from docopt import docopt
+from dmutils.content_loader import ContentLoader
+from dmscripts.generate_questions_csv import generate_csv
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    path_to_manifest = arguments['<path_to_manifest>']
+    content_loader = ContentLoader(path_to_manifest)
+
+    output_directory = arguments['<output_directory>']
+    framework_slug = arguments.get('--framework')
+
+    generate_csv(output_directory, framework_slug, content_loader)

--- a/tests/test_generate_questions_csv.py
+++ b/tests/test_generate_questions_csv.py
@@ -1,0 +1,164 @@
+from dmutils.content_loader import ContentSection
+from dmscripts.generate_questions_csv import get_questions, return_rows_for_sections
+
+
+def get_question(question_type, question_id):
+
+    questions = {
+        'text': {
+            'question': 'Please type in an option',
+            'type': 'text',
+            'hint': 'Hint: please type in an option'
+        },
+        'boolean': {
+            'question': 'Please confirm you can click options',
+            'type': 'boolean',
+        },
+        'checkboxes': {
+            'question': 'Which options can you click?',
+            'type': 'checkboxes',
+            'options': [
+                {'label': 'Option 1', 'description': 'Description for option 1'},
+                {'label': 'Option 2', 'description': 'Description for option 2'},
+                {'label': 'Option 3', 'description': 'Description for option 3'}
+            ]
+        }
+    }
+    questions[question_type]['id'] = question_id
+    return questions[question_type]
+
+
+def get_section(questions=None, multiquestions=None):
+
+    multiquestion = {
+        'type': 'multiquestion',
+        'questions': [],
+        'question': 'Options',
+        'name': 'Options',
+        'id': 'options',
+        'slug': 'options',
+        'hint': 'Please indicate your preferred options'
+    }
+
+    section = {
+        'editable': False,
+        'description': None,
+        'summary_page_description': 'You must be able to provide at least one option',
+        'name': 'Options',
+        'questions': [],
+        'edit_questions': True,
+        'id': 'options',
+        'slug': 'options'
+    }
+
+    if questions is None:
+        questions = []
+
+    if multiquestions is None:
+        multiquestions = []
+
+    for index, question_type in enumerate(multiquestions):
+
+        multiquestion['questions'].append(
+            get_question(
+                question_type,
+                "multiquestion_{}".format(index)
+            )
+        )
+
+    for index, question_type in enumerate(questions):
+
+        section['questions'].append(
+            get_question(
+                question_type,
+                "question_{}".format(index)
+            ))
+
+    if multiquestion['questions']:
+        section['questions'].append(multiquestion)
+
+    return section
+
+
+def return_row_and_question(question_type, is_multiquestion=False):
+
+    if is_multiquestion:
+        section = ContentSection.create(section=get_section(
+            multiquestions=[question_type],
+        ))
+    else:
+        section = ContentSection.create(section=get_section(
+            questions=[question_type],
+        ))
+
+    rows = return_rows_for_sections([section])
+    question = get_question(question_type, '0')
+    assert len(rows) == 2
+    assert rows[0][0] == 'Options'
+    assert rows[0][2] == question['question']
+    if is_multiquestion:
+        assert rows[0][1] == 'Please indicate your preferred options'
+
+    return rows[0], question
+
+
+def test_get_questions_unpacks_multiquestions():
+
+    section = ContentSection.create(section=get_section(
+        questions=['checkboxes', 'boolean'],
+        multiquestions=['checkboxes', 'boolean']
+    ))
+    assert section.id == 'options'
+
+    # should be a flat list with 4 entries
+    questions = get_questions(section.questions)
+    assert len(questions) == 4
+
+
+def test_get_questions_sets_multiquestion_names_and_hints():
+
+    section = ContentSection.create(section=get_section(
+        multiquestions=['checkboxes', 'boolean']
+    ))
+    assert section.id == 'options'
+
+    # hint and name of multiquestion should be preserved in nested_questions
+    for question in get_questions(section.questions):
+        if question.get('id').startswith('multiquestion_'):
+            assert question.get('multiquestion_name') == 'Options'
+            assert question.get('multiquestion_hint') == 'Please indicate your preferred options'
+
+
+def test_return_row_for_text_question():
+
+    question_row, question = return_row_and_question('text')
+    multiquestion_row, question = return_row_and_question('text', is_multiquestion=True)
+
+    for row in [question_row, multiquestion_row]:
+        assert len(row) == 4
+        assert row[3] == 'Hint: please type in an option'
+
+
+def test_return_row_for_boolean_question():
+
+    question_row, question = return_row_and_question('boolean')
+    multiquestion_row, question = return_row_and_question('boolean', is_multiquestion=True)
+
+    for row in [question_row, multiquestion_row]:
+        assert len(row) == 6
+        assert row[-2] == 'Yes'
+        assert row[-1] == 'No'
+
+
+def test_return_row_for_checkboxes_question():
+
+    question_row, question = return_row_and_question('checkboxes')
+    multiquestion_row, question = return_row_and_question('checkboxes', is_multiquestion=True)
+
+    for row in [question_row, multiquestion_row]:
+        assert (len(question_row) - 4) == len(question['options'])
+        for index in range(len(question['options'])):
+            assert question_row[index + 4] == "{} - {}".format(
+                question['options'][index]['label'],
+                question['options'][index]['description']
+            )


### PR DESCRIPTION
Port over the script that generates a CSV file with all the declaration questions followed by all of the service questions (lots are separated by a blank line).  If [question hints](https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/digital-outcomes-and-specialists/questions/declaration/canProvideFromDayOne.yml#L4) or [multiquestion hints](https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/digital-outcomes-and-specialists/questions/services/agileCoach.yml#L16) are present, they'll be included.
[Checkbox descriptions](https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/digital-outcomes-and-specialists/questions/services/userExperienceAndDesignTypes.yml#L9), if they exist, are appended to labels.

Output looks [like this](https://docs.google.com/a/digital.cabinet-office.gov.uk/spreadsheets/d/1GbNwm-J3OFn3CTNGspALF6m0M2_5yyRcmOZJWQX2p0E/edit?usp=sharing).

Didn't want to include all or part of the content folder to mock out the whole process, so I figured I would just test some of the logic. Tests are written that make sure multiquestions are parsed properly and that output rows are in a format we expect.