### PR TITLE
Use dmapiclient

### DIFF
--- a/dmscripts/generate_framework_agreement_data.py
+++ b/dmscripts/generate_framework_agreement_data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
-from dmutils.apiclient.errors import HTTPError
+from dmapiclient import HTTPError
 from dmutils.documents import sanitise_supplier_name
 
 import sys

--- a/dmscripts/generate_user_email_list_applications.py
+++ b/dmscripts/generate_user_email_list_applications.py
@@ -2,7 +2,7 @@ from functools import partial
 import time
 from multiprocessing.pool import ThreadPool
 
-from dmutils.apiclient.errors import HTTPError
+from dmapiclient import HTTPError
 
 import sys
 if sys.version_info > (3, 0):

--- a/dmscripts/generate_user_email_list_declarations.py
+++ b/dmscripts/generate_user_email_list_declarations.py
@@ -1,5 +1,5 @@
 from multiprocessing.pool import ThreadPool
-from dmutils.apiclient.errors import HTTPError
+from dmapiclient import HTTPError
 import sys
 if sys.version_info > (3, 0):
     import csv

--- a/dmscripts/insert_framework_results.py
+++ b/dmscripts/insert_framework_results.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from dmutils.apiclient.errors import HTTPError
+from dmapiclient import HTTPError
 
 import sys
 if sys.version_info > (3, 0):

--- a/dmscripts/logging.py
+++ b/dmscripts/logging.py
@@ -35,6 +35,7 @@ def configure_logger(log_levels=None):
 def merge_log_levels(added_log_levels):
     log_levels = {
         'dmutils': INFO,
+        'dmapiclient': INFO,
         'script': INFO,
     }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@15.9.1#egg=digitalmarketplace-utils==15.9.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.0.1#egg=digitalmarketplace-apiclient==1.0.1
 
 unicodecsv==0.14.1
 python-dateutil==2.4.2

--- a/scripts/bad_words.py
+++ b/scripts/bad_words.py
@@ -14,7 +14,7 @@ else:
 import six
 import re
 from docopt import docopt
-from dmutils.apiclient import DataAPIClient
+from dmapiclient import DataAPIClient
 
 
 def main(data_api_url, data_api_token, bad_words_path, framework_slug, output_dir):

--- a/scripts/check-g-cloud-live.py
+++ b/scripts/check-g-cloud-live.py
@@ -18,7 +18,7 @@ from multiprocessing.pool import ThreadPool
 from docopt import docopt
 from dmscripts.env import get_api_endpoint_from_stage, get_assets_endpoint_from_stage
 from dmscripts.logging import configure_logger
-from dmutils.apiclient import DataAPIClient
+from dmapiclient import DataAPIClient
 from dmutils.s3 import S3
 import requests
 

--- a/scripts/generate-framework-agreement-data.py
+++ b/scripts/generate-framework-agreement-data.py
@@ -12,7 +12,7 @@ sys.path.insert(0, '.')
 from docopt import docopt
 from dmscripts.generate_framework_agreement_data import check_lots_csv, read_csv, \
     check_declarations_csv, build_framework_agreements
-from dmutils.apiclient import DataAPIClient
+from dmapiclient import DataAPIClient
 
 if __name__ == '__main__':
 

--- a/scripts/generate-user-email-list-applications.py
+++ b/scripts/generate-user-email-list-applications.py
@@ -12,7 +12,7 @@ sys.path.insert(0, '.')
 
 import six
 from docopt import docopt
-from dmutils.apiclient import DataAPIClient
+from dmapiclient import DataAPIClient
 from dmscripts.generate_user_email_list_applications import list_users
 
 

--- a/scripts/generate-user-email-list-declarations.py
+++ b/scripts/generate-user-email-list-declarations.py
@@ -8,7 +8,7 @@ import sys
 sys.path.insert(0, '.')
 
 from docopt import docopt
-from dmutils.apiclient import DataAPIClient
+from dmapiclient import DataAPIClient
 from dmscripts.generate_user_email_list_declarations import list_users
 
 

--- a/scripts/index-services.py
+++ b/scripts/index-services.py
@@ -13,7 +13,7 @@ Example:
 """
 
 import sys
-import multiprocessing
+from multiprocessing.pool import ThreadPool
 from six.moves import map
 from datetime import datetime
 
@@ -92,8 +92,8 @@ def do_index(search_api_url, search_api_access_token, data_api_url, data_api_acc
         pool = None
         mapper = map
     else:
-        pool = multiprocessing.Pool(10)
-        mapper = pool.imap
+        pool = ThreadPool(10)
+        mapper = pool.imap_unordered
 
     indexer = ServiceIndexer(search_api_url, search_api_access_token, index)
     indexer.create_index()

--- a/scripts/insert-framework-results.py
+++ b/scripts/insert-framework-results.py
@@ -14,7 +14,7 @@ import sys
 sys.path.insert(0, '.')
 
 from docopt import docopt
-from dmutils.apiclient import DataAPIClient
+from dmapiclient import DataAPIClient
 from dmscripts.insert_framework_results import insert_results
 
 

--- a/scripts/make-g-cloud-7-live.py
+++ b/scripts/make-g-cloud-7-live.py
@@ -16,7 +16,7 @@ import re
 
 from docopt import docopt
 from dmscripts.env import get_api_endpoint_from_stage, get_assets_endpoint_from_stage
-from dmutils.apiclient import DataAPIClient
+from dmapiclient import DataAPIClient
 from dmutils.s3 import S3
 
 DOCUMENT_KEYS = [

--- a/scripts/oneoff/fix-agreement-extensions.py
+++ b/scripts/oneoff/fix-agreement-extensions.py
@@ -12,7 +12,7 @@ import re
 import magic
 from docopt import docopt
 
-from dmutils.apiclient import DataAPIClient
+from dmapiclient import DataAPIClient
 from dmutils.s3 import S3
 from dmscripts.env import get_api_endpoint_from_stage
 

--- a/scripts/oneoff/rename-west-england.py
+++ b/scripts/oneoff/rename-west-england.py
@@ -12,7 +12,7 @@ from multiprocessing.pool import ThreadPool
 import itertools
 import json
 from docopt import docopt
-from dmutils.apiclient import DataAPIClient
+from dmapiclient import DataAPIClient
 from dmscripts.env import get_api_endpoint_from_stage
 
 OLD_LOCATION = "West England"

--- a/scripts/set-search-alias.py
+++ b/scripts/set-search-alias.py
@@ -10,7 +10,7 @@ from docopt import docopt
 
 sys.path.insert(0, '.')
 from dmscripts.env import get_api_endpoint_from_stage
-from dmutils.apiclient import SearchAPIClient
+from dmapiclient import SearchAPIClient
 
 
 if __name__ == '__main__':

--- a/tests/test_generate_framework_agreement_data.py
+++ b/tests/test_generate_framework_agreement_data.py
@@ -1,7 +1,7 @@
 import pytest
 import mock
 
-from dmutils.apiclient import HTTPError
+from dmapiclient import HTTPError
 
 from dmscripts.generate_framework_agreement_data import (
     make_filename_key,

--- a/tests/test_generate_user_email_list_applications.py
+++ b/tests/test_generate_user_email_list_applications.py
@@ -4,7 +4,7 @@ except ImportError:
     from io import StringIO
 import pytest
 import mock
-from dmutils.apiclient import HTTPError
+from dmapiclient import HTTPError
 
 from dmscripts.generate_user_email_list_applications import (
     filter_list_of_dicts_by_value,

--- a/tests/test_generate_user_email_list_declarations.py
+++ b/tests/test_generate_user_email_list_declarations.py
@@ -5,7 +5,7 @@ except ImportError:
 import pytest
 import mock
 
-from dmutils.apiclient import HTTPError
+from dmapiclient import HTTPError
 
 from dmscripts.generate_user_email_list_declarations import (
     selection_status, find_supplier_users, list_users

--- a/tests/test_insert_framework_results.py
+++ b/tests/test_insert_framework_results.py
@@ -2,7 +2,7 @@ import pytest
 
 from dmscripts.insert_framework_results import insert_result, insert_results
 from mock import mock, call
-from dmutils.apiclient.errors import HTTPError
+from dmapiclient import HTTPError
 
 
 @pytest.fixture


### PR DESCRIPTION
### Use new dmapiclient package instead of dmutils.apiclient
Adds digitalmarketplace-apiclient to the list of requirements and
changes all `dmutils.apiclient` imports to `dmapiclient`.

Since apiclient is using a logger with the package name this also
requires changing the configured loggers in dmscripts/logging and
individual scripts to include `dmapiclient`.

API client `1.0.1` retries 504 responses.

### Fix iter_services not raising an exception when used with Pool.imap
Multiprocessing `Pool.imap` doesn't raise an exception if the iterator
fails to produce any results 👽👽👽 (ie when the first API request fails),
making the process exit with a 0 status. This will mark the CI job
as successful when the indexing failed to run.

Replacing `Pool` with `ThreadPool` seems to fix the problem, and other
scripts are already using `ThreadPool`. Also replacing `.imap` with
`.imap_unordered` since we don't really care about the response order.