### PR TITLE
Export DOS applications

### DIFF
--- a/dmscripts/export_dos_suppliers.py
+++ b/dmscripts/export_dos_suppliers.py
@@ -263,7 +263,7 @@ def export_suppliers(client, content_loader, output_dir):
     with MultiCSVWriter(output_dir, handlers) as writer:
         for i, record in enumerate(records):
             writer.write_row(record)
-            if i % 100 == 0:
+            if (i + 1) % 100 == 0:
                 writer.print_counts()
 
         writer.print_counts()

--- a/dmscripts/export_dos_suppliers.py
+++ b/dmscripts/export_dos_suppliers.py
@@ -43,21 +43,17 @@ def add_supplier_info(client):
 
 def add_framework_info(client, framework_slug):
     def inner(record):
-        try:
-            supplier_framework = client.get_supplier_framework_info(record['supplier']['id'], framework_slug)
-            supplier_framework = supplier_framework['frameworkInterest']
-            supplier_framework['declaration'] = supplier_framework['declaration'] or {}
+        supplier_framework = client.get_supplier_framework_info(record['supplier']['id'], framework_slug)
+        supplier_framework = supplier_framework['frameworkInterest']
+        supplier_framework['declaration'] = supplier_framework['declaration'] or {}
 
-            if supplier_framework['declaration'].get('status') != 'complete':
-                assert supplier_framework['onFramework'] is False, \
-                    "Incomplete declaration but not failed, have you inserted the framework result?"
+        if supplier_framework['declaration'].get('status') != 'complete':
+            assert supplier_framework['onFramework'] is False, \
+                "Incomplete declaration but not failed, have you inserted the framework result?"
 
-            return dict(record,
-                        declaration=supplier_framework['declaration'],
-                        onFramework=supplier_framework['onFramework'])
-        except HTTPError as e:
-            if e.status_code != 404:
-                raise
+        return dict(record,
+                    declaration=supplier_framework['declaration'],
+                    onFramework=supplier_framework['onFramework'])
 
     return inner
 
@@ -132,7 +128,6 @@ def find_suppliers_with_details(client, content_loader, framework_slug):
     declaration_content = content_loader.get_manifest(framework_slug, 'declaration')
 
     records = find_suppliers(client, framework_slug)
-    records = filter(None, records)
     records = pool.imap(add_supplier_info(client), records)
     records = pool.imap(add_framework_info(client, framework_slug), records)
     records = pool.imap(add_draft_counts(client, framework_slug), records)

--- a/dmscripts/export_dos_suppliers.py
+++ b/dmscripts/export_dos_suppliers.py
@@ -1,0 +1,275 @@
+import os
+import sys
+from multiprocessing.pool import ThreadPool
+
+from dmapiclient import HTTPError
+from dmscripts.insert_dos_framework_results import (
+    CORRECT_DECLARATION_RESPONSE_MUST_BE_TRUE, CORRECT_DECLARATION_RESPONSE_MUST_BE_FALSE,
+    CORRECT_DECLARATION_RESPONSE_SHOULD_BE_FALSE, MITIGATING_FACTORS,
+    CORRECT_DECLARATION_RESPONSES
+)
+
+if sys.version_info[0] < 3:
+    import unicodecsv as csv
+else:
+    import csv
+
+FRAMEWORK_SLUG = 'digital-outcomes-and-specialists'
+DRAFT_STATUSES = [
+    'completed',
+    'failed',
+    'draft',
+]
+LOTS = [
+    'digital-outcomes', 'digital-specialists',
+    'user-research-studios', 'user-research-participants',
+]
+
+
+def find_suppliers(client, framework_slug):
+    suppliers = client.get_interested_suppliers(framework_slug)['interestedSuppliers']
+    return ({'supplier_id': supplier_id} for supplier_id in suppliers)
+
+
+def add_supplier_info(client):
+    def inner(record):
+        supplier = client.get_supplier(record['supplier_id'])
+
+        return dict(record,
+                    supplier=supplier['suppliers'])
+
+    return inner
+
+
+def add_framework_info(client, framework_slug):
+    def inner(record):
+        try:
+            supplier_framework = client.get_supplier_framework_info(record['supplier']['id'], framework_slug)
+            supplier_framework = supplier_framework['frameworkInterest']
+            supplier_framework['declaration'] = supplier_framework['declaration'] or {}
+
+            if supplier_framework['declaration'].get('status') != 'complete':
+                assert supplier_framework['onFramework'] is False, \
+                    "Incomplete declaration but not failed, have you inserted the framework result?"
+
+            return dict(record,
+                        declaration=supplier_framework['declaration'],
+                        onFramework=supplier_framework['onFramework'])
+        except HTTPError as e:
+            if e.status_code != 404:
+                raise
+
+    return inner
+
+
+def add_draft_counts(client, framework_slug):
+    def inner(record):
+        counts = {status: {lot: 0 for lot in LOTS} for status in DRAFT_STATUSES}
+
+        for draft in client.find_draft_services_iter(record['supplier']['id'], framework=framework_slug):
+            if draft['status'] == 'submitted':
+                counts['completed'][draft['lot']] += 1
+            elif draft['status'] == 'failed':
+                counts['failed'][draft['lot']] += 1
+            else:
+                counts['draft'][draft['lot']] += 1
+
+        return dict(record, counts=counts)
+
+    return inner
+
+
+def get_declaration_questions(declaration_content, record):
+    for section in declaration_content:
+        for question in section.questions:
+            yield question, record['declaration'].get(question.id)
+
+
+def is_incorrect_mandatory_question(question, answer):
+    if question.number in CORRECT_DECLARATION_RESPONSE_MUST_BE_TRUE and answer is not True:
+        return True
+    if question.number in CORRECT_DECLARATION_RESPONSE_MUST_BE_FALSE and answer is not False:
+        return True
+    if question.number in CORRECT_DECLARATION_RESPONSES:
+        if answer not in CORRECT_DECLARATION_RESPONSES[question.number]:
+            return True
+
+    return False
+
+
+def add_failed_questions(declaration_content):
+    def inner(record):
+        if record['declaration'].get('status') != 'complete':
+            return dict(record,
+                        failed_mandatory=['INCOMPLETE'],
+                        discretionary=[])
+
+        declaration_questions = list(get_declaration_questions(declaration_content, record))
+
+        failed_mandatory = [
+            "Q{}".format(question.number)
+            for question, answer in declaration_questions
+            if is_incorrect_mandatory_question(question, answer)
+        ]
+
+        discretionary = [
+            ("Q{}".format(question.number), answer)
+            for question, answer in declaration_questions
+            if question.number in CORRECT_DECLARATION_RESPONSE_SHOULD_BE_FALSE + MITIGATING_FACTORS
+        ]
+
+        return dict(record,
+                    failed_mandatory=failed_mandatory,
+                    discretionary=discretionary)
+
+    return inner
+
+
+def find_suppliers_with_details(client, content_loader, framework_slug):
+    pool = ThreadPool(30)
+
+    content_loader.load_manifest(framework_slug, 'declaration', 'declaration')
+    declaration_content = content_loader.get_manifest(framework_slug, 'declaration')
+
+    records = find_suppliers(client, framework_slug)
+    records = filter(None, records)
+    records = pool.imap(add_supplier_info(client), records)
+    records = pool.imap(add_framework_info(client, framework_slug), records)
+    records = pool.imap(add_draft_counts(client, framework_slug), records)
+    records = map(add_failed_questions(declaration_content), records)
+
+    return records
+
+
+def supplier_info(record):
+    return [
+        ('supplier_name', record['supplier']['name']),
+        ('supplier_declaration_name', record['declaration'].get('nameOfOrganisation', 'ERROR')),
+        ('supplier_id', record['supplier']['id']),
+    ]
+
+
+def failed_mandatory_questions(record):
+    return [
+        ('failed_mandatory', ",".join(question for question in record['failed_mandatory'])),
+    ]
+
+
+def discretionary_questions(record):
+    return [
+        (question, answer) for question, answer in record['discretionary']
+    ]
+
+
+def contact_details(record):
+    return [
+        ('contact_name', record['declaration'].get('primaryContact', 'ERROR')),
+        ('contact_email', record['declaration'].get('primaryContactEmail', 'ERROR')),
+    ]
+
+
+def service_counts(record):
+    return [
+        ('{}_{}'.format(status, lot), record['counts'][status][lot])
+        for status in DRAFT_STATUSES
+        for lot in LOTS
+    ]
+
+
+class SuccessfulHandler(object):
+    NAME = 'successful'
+
+    def matches(self, record):
+        return record['onFramework'] is True
+
+    def create_row(self, record):
+        return \
+            supplier_info(record) + \
+            contact_details(record) + \
+            service_counts(record)
+
+
+class FailedHandler(object):
+    NAME = 'failed'
+
+    def matches(self, record):
+        return record['onFramework'] is False
+
+    def create_row(self, record):
+        return \
+            supplier_info(record) + \
+            failed_mandatory_questions(record) + \
+            contact_details(record) + \
+            service_counts(record)
+
+
+class DiscretionaryHandler(object):
+    NAME = 'discretionary'
+
+    def matches(self, record):
+        return record['onFramework'] is None
+
+    def create_row(self, record):
+        return \
+            supplier_info(record) + \
+            discretionary_questions(record) + \
+            contact_details(record) + \
+            service_counts(record)
+
+
+class MultiCSVWriter(object):
+    """Manage writing to multiple CSV files"""
+    def __init__(self, output_dir, handlers):
+        self.output_dir = output_dir
+        self.handlers = handlers
+        self._csv_writers = dict()
+        self._csv_files = dict()
+        self._counters = {
+            handler.NAME: 0 for handler in handlers
+        }
+
+    def write_row(self, record):
+        for handler in self.handlers:
+            if handler.matches(record):
+                self._counters[handler.NAME] += 1
+                row = handler.create_row(record)
+                return self.csv_writer(handler, row).writerow(dict(row))
+        raise Exception("record not handled by any handler")
+
+    def csv_writer(self, handler, row):
+        if handler.NAME not in self._csv_writers:
+            fieldnames = [key for key, _ in row]
+            self._csv_writers[handler.NAME] = csv.DictWriter(self._csv_files[handler.NAME], fieldnames=fieldnames)
+            self._csv_writers[handler.NAME].writeheader()
+
+        return self._csv_writers[handler.NAME]
+
+    def csv_path(self, handler):
+        return os.path.join(self.output_dir, handler.NAME + '.csv')
+
+    def __enter__(self):
+        for handler in self.handlers:
+            self._csv_files[handler.NAME] = open(self.csv_path(handler), 'w+')
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for f in self._csv_files.values():
+            f.close()
+
+    def print_counts(self):
+        print(" ".join("{}={}".format(handler.NAME, self._counters[handler.NAME]) for handler in self.handlers))
+
+
+def export_suppliers(client, content_loader, output_dir):
+    records = find_suppliers_with_details(client, content_loader, FRAMEWORK_SLUG)
+
+    handlers = [SuccessfulHandler(), FailedHandler(), DiscretionaryHandler()]
+
+    with MultiCSVWriter(output_dir, handlers) as writer:
+        for i, record in enumerate(records):
+            writer.write_row(record)
+            if i % 100 == 0:
+                writer.print_counts()
+
+        writer.print_counts()
+        print("DONE")

--- a/scripts/export-dos-suppliers.py
+++ b/scripts/export-dos-suppliers.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Export DOS supplier information for evaluation
+
+Produces three files;
+ - successful.csv containing suppliers that submitted at least one service and answered
+   all mandatory and discretionary declaration questions correctly.
+ - failed.csv containing suppliers that either failed to submit any services or answered
+   some of the mandatory declaration questions incorrectly.
+ - discretionary.csv containing suppliers that submitted at least one service and answered
+   all mandatory declaration questions correctly but answered some discretionary questions
+   incorrectly.
+
+Usage:
+    scripts/export-suppliers.py <stage> <api_token> <content_path> <output_dir>
+"""
+import sys
+sys.path.insert(0, '.')
+
+from docopt import docopt
+from dmscripts.env import get_api_endpoint_from_stage
+from dmscripts.export_dos_suppliers import export_suppliers
+from dmapiclient import DataAPIClient
+from dmutils.content_loader import ContentLoader
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    STAGE = arguments['<stage>']
+    API_TOKEN = arguments['<api_token>']
+    CONTENT_PATH = arguments['<content_path>']
+    OUTPUT_DIR = arguments['<output_dir>']
+
+    client = DataAPIClient(get_api_endpoint_from_stage(STAGE), API_TOKEN)
+    content_loader = ContentLoader(CONTENT_PATH)
+
+    export_suppliers(client, content_loader, OUTPUT_DIR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from mock import Mock
+
+
+@pytest.fixture
+def mock_data_client():
+    return Mock()

--- a/tests/test_export_dos_suppliers.py
+++ b/tests/test_export_dos_suppliers.py
@@ -9,12 +9,6 @@ from dmscripts.insert_dos_framework_results import CORRECT_DECLARATION_RESPONSES
 from dmapiclient import HTTPError
 
 
-# TODO: move to conftest
-@pytest.fixture
-def mock_data_client():
-    return Mock()
-
-
 def test_find_suppliers_produces_results_with_supplier_ids(mock_data_client):
     mock_data_client.get_interested_suppliers.return_value = {
         'interestedSuppliers': [4, 3, 2]

--- a/tests/test_export_dos_suppliers.py
+++ b/tests/test_export_dos_suppliers.py
@@ -240,7 +240,7 @@ SUCCESSFUL_RECORD = {
                  'name': 'Bluedice Ideas Limited'},
     'declaration': {'nameOfOrganisation': 'Young Money Franchise LTD',
                     'primaryContact': 'Yolo Swaggins',
-                    'primaryContactEmail': 'yolo.swagins@example.com'},
+                    'primaryContactEmail': 'yolo.swaggins@example.com'},
     'counts': {
         'completed': {
             'digital-outcomes': 2, 'digital-specialists': 1,
@@ -262,7 +262,7 @@ FAILED_RECORD = {
                  'name': 'Bluedice Ideas Limited'},
     'declaration': {'nameOfOrganisation': 'Young Money Franchise LTD',
                     'primaryContact': 'Yolo Swaggins',
-                    'primaryContactEmail': 'yolo.swagins@example.com'},
+                    'primaryContactEmail': 'yolo.swaggins@example.com'},
     'failed_mandatory': ['Q1', 'Q3', 'Q5'],
     'discretionary': [],
     'counts': {
@@ -286,7 +286,7 @@ DISCRETIONARY_RECORD = {
                  'name': 'Bluedice Ideas Limited'},
     'declaration': {'nameOfOrganisation': 'Young Money Franchise LTD',
                     'primaryContact': 'Yolo Swaggins',
-                    'primaryContactEmail': 'yolo.swagins@example.com'},
+                    'primaryContactEmail': 'yolo.swaggins@example.com'},
     'failed_mandatory': [],
     'discretionary': [
         ('Q21', 'val1'),
@@ -338,13 +338,13 @@ def test_write_to_csv():
 
             successful_file.write.assert_has_calls([
                 call('supplier_name,supplier_declaration_name,supplier_id,contact_name,contact_email,completed_digital-outcomes,completed_digital-specialists,completed_user-research-studios,completed_user-research-participants,failed_digital-outcomes,failed_digital-specialists,failed_user-research-studios,failed_user-research-participants,draft_digital-outcomes,draft_digital-specialists,draft_user-research-studios,draft_user-research-participants\r\n'),  # noqa
-                call('Bluedice Ideas Limited,Young Money Franchise LTD,1,Yolo Swaggins,yolo.swagins@example.com,2,1,0,0,2,0,0,0,0,3,0,0\r\n'),  # noqa
+                call('Bluedice Ideas Limited,Young Money Franchise LTD,1,Yolo Swaggins,yolo.swaggins@example.com,2,1,0,0,2,0,0,0,0,3,0,0\r\n'),  # noqa
             ])
             failed_file.write.assert_has_calls([
                 call('supplier_name,supplier_declaration_name,supplier_id,failed_mandatory,contact_name,contact_email,completed_digital-outcomes,completed_digital-specialists,completed_user-research-studios,completed_user-research-participants,failed_digital-outcomes,failed_digital-specialists,failed_user-research-studios,failed_user-research-participants,draft_digital-outcomes,draft_digital-specialists,draft_user-research-studios,draft_user-research-participants\r\n'),  # noqa
-                call('Bluedice Ideas Limited,Young Money Franchise LTD,1,"Q1,Q3,Q5",Yolo Swaggins,yolo.swagins@example.com,2,1,0,0,2,0,0,0,0,3,0,0\r\n'),  # noqa
+                call('Bluedice Ideas Limited,Young Money Franchise LTD,1,"Q1,Q3,Q5",Yolo Swaggins,yolo.swaggins@example.com,2,1,0,0,2,0,0,0,0,3,0,0\r\n'),  # noqa
             ])
             discretionary_file.write.assert_has_calls([
                 call('supplier_name,supplier_declaration_name,supplier_id,Q21,Q22,Q23,contact_name,contact_email,completed_digital-outcomes,completed_digital-specialists,completed_user-research-studios,completed_user-research-participants,failed_digital-outcomes,failed_digital-specialists,failed_user-research-studios,failed_user-research-participants,draft_digital-outcomes,draft_digital-specialists,draft_user-research-studios,draft_user-research-participants\r\n'),  # noqa
-                call('Bluedice Ideas Limited,Young Money Franchise LTD,1,val1,val2,val3,Yolo Swaggins,yolo.swagins@example.com,2,1,0,0,2,0,0,0,0,3,0,0\r\n'),  # noqa
+                call('Bluedice Ideas Limited,Young Money Franchise LTD,1,val1,val2,val3,Yolo Swaggins,yolo.swaggins@example.com,2,1,0,0,2,0,0,0,0,3,0,0\r\n'),  # noqa
             ])

--- a/tests/test_export_dos_suppliers.py
+++ b/tests/test_export_dos_suppliers.py
@@ -1,0 +1,364 @@
+from itertools import chain
+
+import pytest
+import six
+from mock import Mock, call, patch, ANY, mock_open
+
+from dmscripts import export_dos_suppliers
+from dmscripts.insert_dos_framework_results import CORRECT_DECLARATION_RESPONSES
+from dmapiclient import HTTPError
+
+
+# TODO: move to conftest
+@pytest.fixture
+def mock_data_client():
+    return Mock()
+
+
+def test_find_suppliers_produces_results_with_supplier_ids(mock_data_client):
+    mock_data_client.get_interested_suppliers.return_value = {
+        'interestedSuppliers': [4, 3, 2]
+    }
+
+    records = list(export_dos_suppliers.find_suppliers(mock_data_client, 'framework-slug'))
+
+    mock_data_client.get_interested_suppliers.assert_has_calls([
+        call('framework-slug')
+    ])
+    assert records == [
+        {'supplier_id': 4}, {'supplier_id': 3}, {'supplier_id': 2}
+    ]
+
+
+def test_add_supplier_info(mock_data_client):
+    mock_data_client.get_supplier.side_effect = [
+        {'suppliers': 'supplier 1'},
+        {'suppliers': 'supplier 2'},
+    ]
+
+    supplier_info_adder = export_dos_suppliers.add_supplier_info(mock_data_client)
+    records = [
+        supplier_info_adder({'supplier_id': 1}),
+        supplier_info_adder({'supplier_id': 2}),
+    ]
+
+    mock_data_client.get_supplier.assert_has_calls([
+        call(1), call(2)
+    ])
+    assert records == [
+        {'supplier_id': 1, 'supplier': 'supplier 1'},
+        {'supplier_id': 2, 'supplier': 'supplier 2'},
+    ]
+
+
+def test_add_framework_info(mock_data_client):
+    mock_data_client.get_supplier_framework_info.side_effect = [
+        {'frameworkInterest': {'declaration': {'status': 'complete'}, 'onFramework': True}},
+        {'frameworkInterest': {'declaration': {'status': 'complete'}, 'onFramework': False}},
+    ]
+
+    framework_info_adder = export_dos_suppliers.add_framework_info(mock_data_client, 'framework-slug')
+    records = [
+        framework_info_adder({'supplier': {'id': 1}}),
+        framework_info_adder({'supplier': {'id': 2}}),
+    ]
+
+    mock_data_client.get_supplier_framework_info.assert_has_calls([
+        call(1, 'framework-slug'), call(2, 'framework-slug')
+    ])
+    assert records == [
+        {'supplier': {'id': 1}, 'declaration': {'status': 'complete'}, 'onFramework': True},
+        {'supplier': {'id': 2}, 'declaration': {'status': 'complete'}, 'onFramework': False},
+    ]
+
+
+def test_add_framework_info_skips_404_error(mock_data_client):
+    mock_data_client.get_supplier_framework_info.side_effect = HTTPError(Mock(status_code=404))
+
+    framework_info_adder = export_dos_suppliers.add_framework_info(mock_data_client, 'framework-slug')
+
+    assert framework_info_adder({'supplier': {'id': 1}}) is None
+
+
+def test_add_framework_info_fails_on_non_404_error(mock_data_client):
+    mock_data_client.get_supplier_framework_info.side_effect = HTTPError(Mock(status_code=400))
+
+    framework_info_adder = export_dos_suppliers.add_framework_info(mock_data_client, 'framework-slug')
+
+    with pytest.raises(HTTPError):
+        framework_info_adder({'supplier': {'id': 1}})
+
+
+def test_add_framework_info_fails_if_incomplete_declaration_is_not_failed(mock_data_client):
+    mock_data_client.get_supplier_framework_info.return_value = {
+        'frameworkInterest': {'declaration': {'status': 'incomplete'}, 'onFramework': None}
+    }
+
+    framework_info_adder = export_dos_suppliers.add_framework_info(mock_data_client, 'framework-slug')
+
+    with pytest.raises(AssertionError):
+        framework_info_adder({'supplier': {'id': 1}})
+
+
+def test_add_draft_counts(mock_data_client):
+    mock_data_client.find_draft_services_iter.return_value = [
+        {'status': 'submitted', 'lot': 'digital-outcomes'},
+        {'status': 'submitted', 'lot': 'digital-outcomes'},
+        {'status': 'submitted', 'lot': 'digital-specialists'},
+        {'status': 'failed', 'lot': 'digital-outcomes'},
+        {'status': 'failed', 'lot': 'digital-outcomes'},
+        {'status': 'not-submitted', 'lot': 'digital-specialists'},
+        {'status': 'not-submitted', 'lot': 'digital-specialists'},
+        {'status': 'published', 'lot': 'digital-specialists'},  # anything not submitted or failed is considered draft
+    ]
+
+    draft_counts_adder = export_dos_suppliers.add_draft_counts(mock_data_client, 'framework-slug')
+
+    record = draft_counts_adder({'supplier': {'id': 1}})
+
+    assert record['counts'] == {
+        'completed': {
+            'digital-outcomes': 2, 'digital-specialists': 1,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+        'failed': {
+            'digital-outcomes': 2, 'digital-specialists': 0,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+        'draft': {
+            'digital-outcomes': 0, 'digital-specialists': 3,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+    }
+
+
+def test_get_declaration_questions():
+    q1, q2, q3 = Mock(id='found1'), Mock(id='not_found'), Mock(id='found2')
+
+    questions1 = [q1, q2]
+    questions2 = [q3]
+    sections = [Mock(questions=questions1), Mock(questions=questions2)]
+    record = {'declaration': {'found1': 'value1', 'found2': 'value2', 'extra': 'value3'}}
+
+    answers = list(export_dos_suppliers.get_declaration_questions(sections, record))
+
+    assert answers == [
+        (q1, 'value1'),
+        (q2, None),
+        (q3, 'value2'),
+    ]
+
+
+@patch('dmscripts.export_dos_suppliers.get_declaration_questions')
+def test_add_failed_questions(get_declaration_questions):
+    get_declaration_questions.return_value = [
+        (Mock(number=i), True) for i in chain(range(1, 14), range(15, 17), range(38, 55))
+    ] + [
+        (Mock(number=i), False) for i in chain(range(17, 21), range(21, 37))
+    ] + [
+        (Mock(number=14), CORRECT_DECLARATION_RESPONSES[14][0])
+    ]
+
+    failed_questions_adder = export_dos_suppliers.add_failed_questions(None)
+
+    record = failed_questions_adder({'declaration': {'status': 'complete'}})
+
+    assert record['failed_mandatory'] == []
+    assert len(record['discretionary']) == 16
+
+
+@patch('dmscripts.export_dos_suppliers.get_declaration_questions')
+def test_add_failed_question_mandatory_false_is_true(get_declaration_questions):
+    get_declaration_questions.return_value = [
+        (Mock(number=1), False)
+    ]
+
+    failed_questions_adder = export_dos_suppliers.add_failed_questions(None)
+
+    record = failed_questions_adder({'declaration': {'status': 'complete'}})
+
+    assert record['failed_mandatory'] == ['Q1']
+
+
+@patch('dmscripts.export_dos_suppliers.get_declaration_questions')
+def test_add_failed_question_mandatory_true_is_false(get_declaration_questions):
+    get_declaration_questions.return_value = [
+        (Mock(number=17), True)
+    ]
+
+    failed_questions_adder = export_dos_suppliers.add_failed_questions(None)
+
+    record = failed_questions_adder({'declaration': {'status': 'complete'}})
+
+    assert record['failed_mandatory'] == ['Q17']
+
+
+@patch('dmscripts.export_dos_suppliers.get_declaration_questions')
+def test_add_failed_question_mandatory_liability_insurance(get_declaration_questions):
+    get_declaration_questions.return_value = [
+        (Mock(number=14), "Invalid")
+    ]
+
+    failed_questions_adder = export_dos_suppliers.add_failed_questions(None)
+
+    record = failed_questions_adder({'declaration': {'status': 'complete'}})
+
+    assert record['failed_mandatory'] == ['Q14']
+
+
+def test_add_failed_questions_incomplete_declaration():
+    failed_questions_adder = export_dos_suppliers.add_failed_questions(None)
+
+    record = failed_questions_adder({'declaration': {'status': 'started'}})
+
+    assert record['failed_mandatory'] == ['INCOMPLETE']
+    assert record['discretionary'] == []
+
+
+def test_service_counts(mock_data_client):
+    # Count services
+    mock_data_client.find_draft_services_iter.return_value = [
+        {'status': 'submitted', 'lot': 'digital-outcomes'},
+        {'status': 'submitted', 'lot': 'digital-outcomes'},
+        {'status': 'submitted', 'lot': 'digital-specialists'},
+        {'status': 'failed', 'lot': 'digital-outcomes'},
+        {'status': 'failed', 'lot': 'digital-outcomes'},
+        {'status': 'not-submitted', 'lot': 'digital-specialists'},
+        {'status': 'not-submitted', 'lot': 'digital-specialists'},
+        {'status': 'published', 'lot': 'digital-specialists'},  # anything not submitted or failed is considered draft
+    ]
+    draft_counts_adder = export_dos_suppliers.add_draft_counts(mock_data_client, 'framework-slug')
+
+    record = draft_counts_adder({'supplier': {'id': 1}})
+
+    counts = export_dos_suppliers.service_counts(record)
+
+    assert counts == [
+        ('completed_digital-outcomes', 2),
+        ('completed_digital-specialists', 1),
+        ('completed_user-research-studios', 0),
+        ('completed_user-research-participants', 0),
+        ('failed_digital-outcomes', 2),
+        ('failed_digital-specialists', 0),
+        ('failed_user-research-studios', 0),
+        ('failed_user-research-participants', 0),
+        ('draft_digital-outcomes', 0),
+        ('draft_digital-specialists', 3),
+        ('draft_user-research-studios', 0),
+        ('draft_user-research-participants', 0),
+    ]
+
+SUCCESSFUL_RECORD = {
+    'onFramework': True,
+    'supplier': {'id': 1,
+                 'name': 'Bluedice Ideas Limited'},
+    'declaration': {'nameOfOrganisation': 'Young Money Franchise LTD',
+                    'primaryContact': 'Yolo Swaggins',
+                    'primaryContactEmail': 'yolo.swagins@example.com'},
+    'counts': {
+        'completed': {
+            'digital-outcomes': 2, 'digital-specialists': 1,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+        'failed': {
+            'digital-outcomes': 2, 'digital-specialists': 0,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+        'draft': {
+            'digital-outcomes': 0, 'digital-specialists': 3,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+    }
+}
+FAILED_RECORD = {
+    'onFramework': False,
+    'supplier': {'id': 1,
+                 'name': 'Bluedice Ideas Limited'},
+    'declaration': {'nameOfOrganisation': 'Young Money Franchise LTD',
+                    'primaryContact': 'Yolo Swaggins',
+                    'primaryContactEmail': 'yolo.swagins@example.com'},
+    'failed_mandatory': ['Q1', 'Q3', 'Q5'],
+    'discretionary': [],
+    'counts': {
+        'completed': {
+            'digital-outcomes': 2, 'digital-specialists': 1,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+        'failed': {
+            'digital-outcomes': 2, 'digital-specialists': 0,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+        'draft': {
+            'digital-outcomes': 0, 'digital-specialists': 3,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+    }
+}
+DISCRETIONARY_RECORD = {
+    'onFramework': None,
+    'supplier': {'id': 1,
+                 'name': 'Bluedice Ideas Limited'},
+    'declaration': {'nameOfOrganisation': 'Young Money Franchise LTD',
+                    'primaryContact': 'Yolo Swaggins',
+                    'primaryContactEmail': 'yolo.swagins@example.com'},
+    'failed_mandatory': [],
+    'discretionary': [
+        ('Q21', 'val1'),
+        ('Q22', 'val2'),
+        ('Q23', 'val3'),
+    ],
+    'counts': {
+        'completed': {
+            'digital-outcomes': 2, 'digital-specialists': 1,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+        'failed': {
+            'digital-outcomes': 2, 'digital-specialists': 0,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+        'draft': {
+            'digital-outcomes': 0, 'digital-specialists': 3,
+            'user-research-studios': 0, 'user-research-participants': 0,
+        },
+    }
+}
+
+
+def test_write_to_csv():
+    # mock_open mocks the open function
+    # if we want to mock multiple files we want the configured MagicMock that mock_open returns
+    successful_file = mock_open()()
+    failed_file = mock_open()()
+    discretionary_file = mock_open()()
+    all_files = [successful_file, failed_file, discretionary_file]
+
+    with patch.object(six.moves.builtins, 'open', side_effect=all_files) as mocked_open:
+        handlers = [
+            export_dos_suppliers.SuccessfulHandler(),
+            export_dos_suppliers.FailedHandler(),
+            export_dos_suppliers.DiscretionaryHandler()
+        ]
+
+        with export_dos_suppliers.MultiCSVWriter('example', handlers) as writer:
+            mocked_open.assert_has_calls([
+                call('example/successful.csv', ANY),
+                call('example/failed.csv', ANY),
+                call('example/discretionary.csv', ANY),
+            ])
+
+            writer.write_row(SUCCESSFUL_RECORD)
+            writer.write_row(FAILED_RECORD)
+            writer.write_row(DISCRETIONARY_RECORD)
+
+            successful_file.write.assert_has_calls([
+                call('supplier_name,supplier_declaration_name,supplier_id,contact_name,contact_email,completed_digital-outcomes,completed_digital-specialists,completed_user-research-studios,completed_user-research-participants,failed_digital-outcomes,failed_digital-specialists,failed_user-research-studios,failed_user-research-participants,draft_digital-outcomes,draft_digital-specialists,draft_user-research-studios,draft_user-research-participants\r\n'),  # noqa
+                call('Bluedice Ideas Limited,Young Money Franchise LTD,1,Yolo Swaggins,yolo.swagins@example.com,2,1,0,0,2,0,0,0,0,3,0,0\r\n'),  # noqa
+            ])
+            failed_file.write.assert_has_calls([
+                call('supplier_name,supplier_declaration_name,supplier_id,failed_mandatory,contact_name,contact_email,completed_digital-outcomes,completed_digital-specialists,completed_user-research-studios,completed_user-research-participants,failed_digital-outcomes,failed_digital-specialists,failed_user-research-studios,failed_user-research-participants,draft_digital-outcomes,draft_digital-specialists,draft_user-research-studios,draft_user-research-participants\r\n'),  # noqa
+                call('Bluedice Ideas Limited,Young Money Franchise LTD,1,"Q1,Q3,Q5",Yolo Swaggins,yolo.swagins@example.com,2,1,0,0,2,0,0,0,0,3,0,0\r\n'),  # noqa
+            ])
+            discretionary_file.write.assert_has_calls([
+                call('supplier_name,supplier_declaration_name,supplier_id,Q21,Q22,Q23,contact_name,contact_email,completed_digital-outcomes,completed_digital-specialists,completed_user-research-studios,completed_user-research-participants,failed_digital-outcomes,failed_digital-specialists,failed_user-research-studios,failed_user-research-participants,draft_digital-outcomes,draft_digital-specialists,draft_user-research-studios,draft_user-research-participants\r\n'),  # noqa
+                call('Bluedice Ideas Limited,Young Money Franchise LTD,1,val1,val2,val3,Yolo Swaggins,yolo.swagins@example.com,2,1,0,0,2,0,0,0,0,3,0,0\r\n'),  # noqa
+            ])

--- a/tests/test_export_dos_suppliers.py
+++ b/tests/test_export_dos_suppliers.py
@@ -66,14 +66,6 @@ def test_add_framework_info(mock_data_client):
     ]
 
 
-def test_add_framework_info_skips_404_error(mock_data_client):
-    mock_data_client.get_supplier_framework_info.side_effect = HTTPError(Mock(status_code=404))
-
-    framework_info_adder = export_dos_suppliers.add_framework_info(mock_data_client, 'framework-slug')
-
-    assert framework_info_adder({'supplier': {'id': 1}}) is None
-
-
 def test_add_framework_info_fails_on_non_404_error(mock_data_client):
     mock_data_client.get_supplier_framework_info.side_effect = HTTPError(Mock(status_code=400))
 

--- a/tests/test_insert_dos_framework_results.py
+++ b/tests/test_insert_dos_framework_results.py
@@ -225,11 +225,6 @@ COMPLETE_RESEARCH_PARTICIPANTS_DRAFT = {
 }
 
 
-@pytest.fixture
-def mock_data_client():
-    return mock.Mock()
-
-
 def test_insert_result_calls_with_correct_arguments(mock_data_client):
     assert insert_result(mock_data_client, 123456, True, 'user') == '  Result set OK: 123456'
     mock_data_client.set_framework_result.assert_called_with(123456, 'digital-outcomes-and-specialists', True, 'user')


### PR DESCRIPTION
Export DOS application information into three CSV files for successful,
failed and discretionary applications.

This script assumes that `insert-dos-framework-results.py` has already
been run and will fail with an assertion error if it has not (when it
comes across a declaration that is not complete while the supplier is
not marked as failed.

The file of successful applicants contains supplier information, contact
details and counts for completed, failed and draft services.
The file of failed applicants contains supplier information, a list of
failed mandatory questions, contact details and counts for completed,
failed and draft services.
The file of discretionary applicants contains supplier information,
discretionary questions and their answers, contact details and counts
for completed, failed and draft services.

Service level failed questions are not included in these reports.