### PR TITLE
Bugfix: Really update draft service status

### DIFF
--- a/dmscripts/insert_dos_framework_results.py
+++ b/dmscripts/insert_dos_framework_results.py
@@ -85,7 +85,7 @@ def process_submitted_drafts(client, supplier_id, user):
         else:
             # Update the draft to be 'failed'
             print("  Service essentials failed for draft {} in lot '{}'".format(draft['id'], draft['lot']))
-            client.update_draft_service(draft['id'], {"status": "failed"}, user)
+            client.update_draft_service_status(draft['id'], "failed", user)
     print("  Supplier has valid service: {}".format("YES" if supplier_has_submitted_services else "NO"))
     return supplier_has_submitted_services
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@15.12.0#egg=digitalmarketplace-utils==15.12.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.0.1#egg=digitalmarketplace-apiclient==1.0.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.3.0#egg=digitalmarketplace-apiclient==1.3.0
 
 unicodecsv==0.14.1
 python-dateutil==2.4.2

--- a/tests/test_insert_dos_framework_results.py
+++ b/tests/test_insert_dos_framework_results.py
@@ -347,7 +347,7 @@ def test_process_submitted_drafts_for_good_services(mock_data_client):
         "services": [COMPLETE_OUTCOMES_DRAFT, COMPLETE_RESEARCH_PARTICIPANTS_DRAFT]
     }
     assert process_submitted_drafts(mock_data_client, 12345, 'user') is True
-    mock_data_client.update_draft_service.assert_not_called()
+    mock_data_client.update_draft_service_status.assert_not_called()
 
 
 def test_process_submitted_drafts_with_bad_service(mock_data_client):
@@ -358,7 +358,7 @@ def test_process_submitted_drafts_with_bad_service(mock_data_client):
         "services": [bad_service]
     }
     assert process_submitted_drafts(mock_data_client, 12345, 'user') is False
-    mock_data_client.update_draft_service.assert_called_with(42, {'status': 'failed'}, 'user')
+    mock_data_client.update_draft_service_status.assert_called_with(42, 'failed', 'user')
 
 
 def test_process_submitted_drafts_with_bad_and_good_service(mock_data_client):
@@ -369,7 +369,7 @@ def test_process_submitted_drafts_with_bad_and_good_service(mock_data_client):
         "services": [bad_service, COMPLETE_STUDIOS_DRAFT]
     }
     assert process_submitted_drafts(mock_data_client, 12345, 'user') is True
-    mock_data_client.update_draft_service.assert_called_with(24, {'status': 'failed'}, 'user')
+    mock_data_client.update_draft_service_status.assert_called_with(24, 'failed', 'user')
 
 
 def test_process_dos_results_for_successful(mock_data_client):


### PR DESCRIPTION
The API Client method `update_draft_service` can't be used to update the status of a service.
The new `update_draft_service_status` method should be used instead.