### PR TITLE
Allow agreements to be cleared individually

### DIFF
--- a/scripts/clear-signed-agreements.py
+++ b/scripts/clear-signed-agreements.py
@@ -62,13 +62,18 @@ def main(stage, framework_slug, api_token, user, supplier_ids=None):
         api_client.unset_framework_agreement_returned(supplier_id, framework_slug, user)
 
     signed_agreements = filter(
-        lambda x: x['path'] in ['{}-signed-framework-agreement.pdf'.format(id) for id in supplier_ids],
+        lambda x: match_signed_agreements(supplier_ids, x['path']),
         agreements_bucket.list('{}/agreements/'.format(framework_slug))
     )
 
     for document in signed_agreements:
         logger.info("Deleting {path}", extra={'path': document['path']})
         agreements_bucket.delete_key(document['path'])
+
+
+def match_signed_agreements(supplier_ids, path):
+    match = re.search(r'/(\d+)-signed-framework-agreement', path)
+    return match and match.group(1) in supplier_ids
 
 
 if __name__ == '__main__':

--- a/scripts/clear-signed-agreements.py
+++ b/scripts/clear-signed-agreements.py
@@ -49,12 +49,9 @@ def main(stage, framework_slug, api_token, user, supplier_ids=None):
     suppliers = api_client.find_framework_suppliers(framework_slug, agreement_returned=True)['supplierFrameworks']
 
     if supplier_ids is not None:
-        supplier_ids = [
-            str(supplier['supplierId']) for supplier in suppliers
-            if str(supplier['supplierId']) in supplier_ids.split(',')
-        ]
+        supplier_ids = validate_entered_ids(supplier_ids, suppliers)
     else:
-        supplier_ids = [str(supplier['supplierId']) for supplier in suppliers]
+        supplier_ids = [supplier['supplierId'] for supplier in suppliers]
 
     for supplier_id in supplier_ids:
         logger.info("Resetting agreement returned flag for supplier {supplier_id}",
@@ -71,9 +68,31 @@ def main(stage, framework_slug, api_token, user, supplier_ids=None):
         agreements_bucket.delete_key(document['path'])
 
 
+def validate_entered_ids(entered_ids, suppliers):
+    def match_format(id):
+        match = re.match('^\d+$', id)
+        if match:
+            return True
+        else:
+            sys.exit("{} is the wrong format for a supplier id".format(id))
+
+    def match_supplier(id):
+        supplier = filter(
+            lambda x: x['supplierId'] == int(id),
+            suppliers
+        )
+        if supplier:
+            return True
+        else:
+            sys.exit("{} is not a valid supplier who has signed the agreement".format(id))
+            return False
+
+    return [int(id) for id in entered_ids.split(',') if match_format(id) and match_supplier(id)]
+
+
 def match_signed_agreements(supplier_ids, path):
     match = re.search(r'/(\d+)-signed-framework-agreement', path)
-    return match and match.group(1) in supplier_ids
+    return match and int(match.group(1)) in supplier_ids
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The existing `clear-signed-agreements.py` script
will delete all the agreements for each supplier
in the given framework.

This adds the ability to specify certain suppliers
in that framework to target.

Related to the story to upload 2 new framework agreements: https://www.pivotaltracker.com/story/show/119371899