### PR TITLE
[#121427817] Add scripts to set G8 results and export pass/fail/discretionary for CCS

### DIFF
--- a/dmscripts/export_g8_suppliers.py
+++ b/dmscripts/export_g8_suppliers.py
@@ -1,0 +1,358 @@
+import json
+import os
+import sys
+from multiprocessing.pool import ThreadPool
+
+from dmscripts.insert_g8_framework_results import (
+    CORRECT_DECLARATION_RESPONSE_MUST_BE_TRUE, CORRECT_DECLARATION_RESPONSE_MUST_BE_FALSE,
+    CORRECT_DECLARATION_RESPONSE_SHOULD_BE_FALSE, MITIGATING_FACTORS,
+    CORRECT_DECLARATION_RESPONSE_MUST_BE_YES_OR_NA
+)
+
+if sys.version_info[0] < 3:
+    import unicodecsv as csv
+else:
+    import csv
+
+FRAMEWORK_SLUG = 'g-cloud-8'
+DRAFT_STATUSES = [
+    'completed',
+    'draft',
+]
+LOTS = [
+    'saas', 'paas', 'iaas', 'scs',
+]
+
+
+def find_suppliers(client, framework_slug, supplier_ids=None):
+    suppliers = client.get_interested_suppliers(framework_slug)['interestedSuppliers']
+    return ({'supplier_id': supplier_id} for supplier_id in suppliers
+            if (supplier_ids is None) or (supplier_id in supplier_ids))
+
+
+def add_supplier_info(client):
+    def inner(record):
+        supplier = client.get_supplier(record['supplier_id'])
+
+        return dict(record,
+                    supplier=supplier['suppliers'])
+
+    return inner
+
+
+def add_draft_services(client, framework_slug, lot=None, status=None):
+    def inner(record):
+        drafts = client.find_draft_services(record["supplier_id"], framework=framework_slug)
+        drafts = drafts["services"]
+
+        drafts = [
+            draft for draft in drafts
+            if (not lot or draft["lotSlug"] == lot) and (not status or draft["status"] == status)
+        ]
+
+        return dict(record, services=drafts)
+
+    return inner
+
+
+def count_field_in_record(field_id, field_label, record):
+    return sum(1
+               for service in record["services"]
+               if field_label in service.get(field_id, []))
+
+
+def make_field_title(field_id, field_label):
+    return "{} {}".format(field_id, field_label)
+
+
+def make_fields_from_content_question(question, record):
+    if question["type"] == "checkboxes":
+        for option in question.options:
+            # Make a CSV column for each label
+            yield (
+                make_field_title(question.id, option["label"]),
+                count_field_in_record(question.id, option["label"], record)
+            )
+    elif question.fields:
+        for field_id in sorted(question.fields.values()):
+            # Make a CSV column containing all values
+            yield (
+                field_id,
+                "|".join(service.get(field_id, "") for service in record["services"])
+            )
+    else:
+        yield (
+            question["id"],
+            "|".join(str(service.get(question["id"], "")) for service in record["services"])
+        )
+
+
+def make_fields_from_content_questions(questions, record):
+    return [
+        field
+        for question in questions
+        for field in make_fields_from_content_question(question, record)
+    ]
+
+
+def add_framework_info(client, framework_slug):
+    def inner(record):
+        supplier_framework = client.get_supplier_framework_info(record['supplier_id'], framework_slug)
+        supplier_framework = supplier_framework['frameworkInterest']
+        supplier_framework['declaration'] = supplier_framework['declaration'] or {}
+
+        if supplier_framework['declaration'].get('status') != 'complete':
+            assert supplier_framework['onFramework'] is False, \
+                "Incomplete declaration but not failed, have you inserted the framework result?"
+
+        return dict(record,
+                    declaration=supplier_framework['declaration'],
+                    onFramework=supplier_framework['onFramework'])
+
+    return inner
+
+
+def add_draft_counts(client, framework_slug):
+    def inner(record):
+        counts = {status: {lot: 0 for lot in LOTS} for status in DRAFT_STATUSES}
+
+        for draft in client.find_draft_services_iter(record['supplier']['id'], framework=framework_slug):
+            if draft['status'] == 'submitted':
+                counts['completed'][draft['lot']] += 1
+            else:
+                counts['draft'][draft['lot']] += 1
+
+        return dict(record, counts=counts)
+
+    return inner
+
+
+def get_declaration_questions(declaration_content, record):
+    for section in declaration_content:
+        for question in section.questions:
+            yield question, record['declaration'].get(question.id)
+
+
+def is_incorrect_mandatory_question(question, answer):
+    print("CGECKING QUESTION ID: {}".format(question.id))
+    if question.id in CORRECT_DECLARATION_RESPONSE_MUST_BE_TRUE and answer is not True:
+        return True
+    if question.id in CORRECT_DECLARATION_RESPONSE_MUST_BE_FALSE and answer is not False:
+        return True
+    if question.id in CORRECT_DECLARATION_RESPONSE_MUST_BE_YES_OR_NA and answer not in ["Yes", "Not applicable"]:
+            return True
+
+    return False
+
+
+def add_failed_questions(declaration_content):
+    def inner(record):
+        if record['declaration'].get('status') != 'complete':
+            return dict(record,
+                        failed_mandatory=['INCOMPLETE'],
+                        discretionary=[])
+
+        declaration_questions = list(get_declaration_questions(declaration_content, record))
+        print("GOT QUESTIONS: {}".format(declaration_questions))
+        failed_mandatory = [
+            "Q{} - {}".format(question.number, question.id)
+            for question, answer in declaration_questions
+            if is_incorrect_mandatory_question(question, answer)
+        ]
+
+        discretionary = [
+            ("Q{} - {}".format(question.number, question.id), answer)
+            for question, answer in declaration_questions
+            if question.id in CORRECT_DECLARATION_RESPONSE_SHOULD_BE_FALSE + MITIGATING_FACTORS
+        ]
+
+        return dict(record,
+                    failed_mandatory=failed_mandatory,
+                    discretionary=discretionary)
+
+    return inner
+
+
+def find_suppliers_with_details(client, content_loader, framework_slug, supplier_ids=None):
+    pool = ThreadPool(30)
+
+    content_loader.load_manifest(framework_slug, 'declaration', 'declaration')
+    declaration_content = content_loader.get_manifest(framework_slug, 'declaration')
+
+    records = find_suppliers(client, framework_slug, supplier_ids)
+    records = pool.imap(add_supplier_info(client), records)
+    records = pool.imap(add_framework_info(client, framework_slug), records)
+    records = pool.imap(add_draft_counts(client, framework_slug), records)
+    records = map(add_failed_questions(declaration_content), records)
+
+    return records
+
+
+def supplier_info(record):
+    return [
+        ('supplier_name', record['supplier']['name']),
+        ('supplier_id', record['supplier']['id']),
+    ]
+
+
+def failed_mandatory_questions(record):
+    return [
+        ('failed_mandatory', ",".join(question for question in record['failed_mandatory'])),
+    ]
+
+
+def discretionary_questions(record):
+    return [
+        (question, answer) for question, answer in record['discretionary']
+    ]
+
+
+def contact_details(record):
+    return [
+        ('contact_name', record['declaration'].get('primaryContact', '')),
+        ('contact_email', record['declaration'].get('primaryContactEmail', '')),
+    ]
+
+
+def service_counts(record):
+    return [
+        ('{}_{}'.format(status, lot), record['counts'][status][lot])
+        for status in DRAFT_STATUSES
+        for lot in LOTS
+    ]
+
+
+def write_csv(records, make_row, filename):
+    """Write a list of records out to CSV"""
+    def fieldnames(row):
+        return [field[0] for field in row]
+
+    writer = None
+
+    with open(filename, "w+") as f:
+        for record in records:
+            sys.stdout.write(".")
+            sys.stdout.flush()
+            row = make_row(record)
+            if writer is None:
+                writer = csv.DictWriter(f, fieldnames=fieldnames(row))
+                writer.writeheader()
+            writer.writerow(dict(row))
+
+
+class SuccessfulHandler(object):
+    NAME = 'successful'
+
+    def matches(self, record):
+        return record['onFramework'] is True
+
+    def should_write(self, record):
+        return True
+
+    def create_row(self, record):
+        return \
+            supplier_info(record) + \
+            contact_details(record)
+
+
+class FailedHandler(object):
+    NAME = 'failed'
+
+    def matches(self, record):
+        return record['onFramework'] is False
+
+    def should_write(self, record):
+        # Only include failed complete applications, not people who didn't make an application
+        if record.get('failed_mandatory') and 'INCOMPLETE' in record.get('failed_mandatory'):
+            return False
+        completed_count = 0
+        completed = record.get('counts').get('completed')
+        for key in completed:
+            completed_count += completed.get(key)
+        if completed_count == 0:
+            return False
+
+        return True
+
+    def create_row(self, record):
+        return \
+            supplier_info(record) + \
+            failed_mandatory_questions(record) + \
+            contact_details(record)
+
+
+class DiscretionaryHandler(object):
+    NAME = 'discretionary'
+
+    def matches(self, record):
+        return record['onFramework'] is None
+
+    def should_write(self, record):
+        return True
+
+    def create_row(self, record):
+        return \
+            supplier_info(record) + \
+            discretionary_questions(record) + \
+            contact_details(record)
+
+
+class MultiCSVWriter(object):
+    """Manage writing to multiple CSV files"""
+    def __init__(self, output_dir, handlers):
+        self.output_dir = output_dir
+        self.handlers = handlers
+        self._csv_writers = dict()
+        self._csv_files = dict()
+        self._counters = {
+            handler.NAME: 0 for handler in handlers
+        }
+
+    def write_row(self, record):
+        for handler in self.handlers:
+            should_write = handler.should_write(record)
+            if handler.matches(record) and should_write:
+                self._counters[handler.NAME] += 1
+                row = handler.create_row(record)
+                return self.csv_writer(handler, row).writerow(dict(row))
+            elif not should_write:
+                return self.csv_writer
+        raise Exception("record not handled by any handler")
+
+    def csv_writer(self, handler, row):
+        if handler.NAME not in self._csv_writers:
+            fieldnames = [key for key, _ in row]
+            self._csv_writers[handler.NAME] = csv.DictWriter(self._csv_files[handler.NAME], fieldnames=fieldnames)
+            self._csv_writers[handler.NAME].writeheader()
+
+        return self._csv_writers[handler.NAME]
+
+    def csv_path(self, handler):
+        return os.path.join(self.output_dir, handler.NAME + '.csv')
+
+    def __enter__(self):
+        for handler in self.handlers:
+            self._csv_files[handler.NAME] = open(self.csv_path(handler), 'w+')
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for f in self._csv_files.values():
+            f.close()
+
+    def print_counts(self):
+        print(" ".join("{}={}".format(handler.NAME, self._counters[handler.NAME]) for handler in self.handlers))
+
+
+def export_suppliers(client, content_loader, output_dir, supplier_ids=None):
+    records = find_suppliers_with_details(client, content_loader, FRAMEWORK_SLUG, supplier_ids)
+
+    handlers = [SuccessfulHandler(), FailedHandler(), DiscretionaryHandler()]
+
+    with MultiCSVWriter(output_dir, handlers) as writer:
+        for i, record in enumerate(records):
+            writer.write_row(record)
+            if (i + 1) % 100 == 0:
+                writer.print_counts()
+
+        writer.print_counts()
+        print("DONE")

--- a/dmscripts/export_g8_suppliers.py
+++ b/dmscripts/export_g8_suppliers.py
@@ -134,7 +134,6 @@ def get_declaration_questions(declaration_content, record):
 
 
 def is_incorrect_mandatory_question(question, answer):
-    print("CGECKING QUESTION ID: {}".format(question.id))
     if question.id in CORRECT_DECLARATION_RESPONSE_MUST_BE_TRUE and answer is not True:
         return True
     if question.id in CORRECT_DECLARATION_RESPONSE_MUST_BE_FALSE and answer is not False:
@@ -153,7 +152,6 @@ def add_failed_questions(declaration_content):
                         discretionary=[])
 
         declaration_questions = list(get_declaration_questions(declaration_content, record))
-        print("GOT QUESTIONS: {}".format(declaration_questions))
         failed_mandatory = [
             "Q{} - {}".format(question.number, question.id)
             for question, answer in declaration_questions

--- a/dmscripts/insert_g8_framework_results.py
+++ b/dmscripts/insert_g8_framework_results.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from dmapiclient import HTTPError
+
+CORRECT_DECLARATION_RESPONSE_MUST_BE_TRUE = ["termsOfParticipation",
+                                             "termsAndConditions",
+                                             "readUnderstoodGuidance",
+                                             "understandTool",
+                                             "understandHowToAskQuestions",
+                                             "servicesHaveOrSupport",
+                                             "canProvideCloudServices",
+                                             "skillsAndResources",
+                                             "accuratelyDescribed",
+                                             "proofOfClaims",
+                                             "MI",
+                                             "equalityAndDiversity",
+                                             ]
+CORRECT_DECLARATION_RESPONSE_MUST_BE_YES_OR_NA = ["employersInsurance"]
+CORRECT_DECLARATION_RESPONSE_MUST_BE_FALSE = ["conspiracyCorruptionBribery",
+                                              "fraudAndTheft",
+                                              "terrorism",
+                                              "organisedCrime",
+                                              ]
+
+CORRECT_DECLARATION_RESPONSE_SHOULD_BE_FALSE = ["taxEvasion",
+                                                "environmentalSocialLabourLaw",
+                                                "bankrupt",
+                                                "graveProfessionalMisconduct",
+                                                "distortingCompetition",
+                                                "conflictOfInterest",
+                                                "distortedCompetition",
+                                                "significantOrPersistentDeficiencies",
+                                                "seriousMisrepresentation",
+                                                "witheldSupportingDocuments",
+                                                "influencedContractingAuthority",
+                                                "confidentialInformation",
+                                                "misleadingInformation",
+                                                "unspentTaxConvictions",
+                                                "GAAR",
+                                                ]
+
+MITIGATING_FACTORS = ["mitigatingFactors", "mitigatingFactors2"]
+
+FAIL = "Fail"
+PASS = "Pass"
+DISCRETIONARY = "Discretionary"
+
+
+def insert_result(client, supplier_id, result, user):
+    try:
+        client.set_framework_result(supplier_id, 'g-cloud-8', result, user)
+        return"  Result set OK: {}".format(supplier_id)
+    except HTTPError as e:
+        return"  Error inserting result for {} ({}): {}".format(supplier_id, result, str(e))
+
+
+def get_submitted_drafts(client, supplier_id):
+    services = client.find_draft_services(supplier_id, framework='g-cloud-8')
+    services = services["services"]
+    submitted_services = [service for service in services if service["status"] == "submitted"]
+    return submitted_services
+
+
+def check_declaration_answers(declaration):
+    if declaration['status'] != 'complete':
+        return FAIL
+
+    result = PASS
+    for (field_name) in declaration:
+        if (field_name in CORRECT_DECLARATION_RESPONSE_MUST_BE_TRUE
+           and declaration[field_name] is not True):
+            print(" Question {} must be True but is {}".format(field_name, declaration[field_name]))
+            result = FAIL
+
+        if (field_name in CORRECT_DECLARATION_RESPONSE_MUST_BE_FALSE
+           and declaration[field_name] is not False):
+            print(" Question {} must be False but is {}".format(field_name, declaration[field_name]))
+            result = FAIL
+
+        if (field_name in CORRECT_DECLARATION_RESPONSE_SHOULD_BE_FALSE
+           and declaration[field_name] is not False):
+            print(" Question {} should be False but is {}".format(field_name, declaration[field_name]))
+            if result == PASS:
+                result = DISCRETIONARY
+
+        if (field_name in CORRECT_DECLARATION_RESPONSE_MUST_BE_YES_OR_NA
+           and declaration[field_name] not in ["Yes", "Not applicable"]):
+            print(" Question {} has the wrong answer: {}".format(field_name, declaration[field_name]))
+            result = FAIL
+
+    return result
+
+
+def has_supplier_submitted_services(client, supplier_id):
+    submitted_drafts = get_submitted_drafts(client, supplier_id)
+    if len(submitted_drafts) > 0:
+        return True
+    else:
+        return False
+
+
+def process_g8_results(client, user):
+
+    g8_registered_suppliers = client\
+        .get_interested_suppliers('g-cloud-8')\
+        .get('interestedSuppliers', None)
+
+    for supplier_id in g8_registered_suppliers:
+        print("SUPPLIER: {}".format(supplier_id))
+        declaration = client.get_supplier_declaration(supplier_id, 'g-cloud-8')['declaration']
+        declaration_result = check_declaration_answers(declaration) if declaration else FAIL
+        supplier_has_submitted_services = has_supplier_submitted_services(client, supplier_id)
+        if declaration_result == PASS and supplier_has_submitted_services:
+            print("  PASSED")
+            res = insert_result(client, supplier_id, True, user)
+            print(res)
+
+        elif declaration_result == DISCRETIONARY and supplier_has_submitted_services:
+            print("  DISCRETIONARY")
+            # No-op here: leave result as NULL in the database
+        else:
+            print("  FAILED")
+            res = insert_result(client, supplier_id, False, user)
+            print(res)

--- a/scripts/export-g8-suppliers.py
+++ b/scripts/export-g8-suppliers.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Export G-Cloud 8 supplier information for evaluation
+
+Produces three files;
+ - successful.csv containing suppliers that submitted at least one service and answered
+   all mandatory and discretionary declaration questions correctly.
+ - failed.csv containing suppliers that either failed to submit any services or answered
+   some of the mandatory declaration questions incorrectly.
+ - discretionary.csv containing suppliers that submitted at least one service and answered
+   all mandatory declaration questions correctly but answered some discretionary questions
+   incorrectly.
+
+Usage:
+    scripts/export-g8-suppliers.py [-h] <stage> <api_token> <content_path> <output_dir> [<supplier_id_file>]
+
+Options:
+    -h --help
+"""
+import sys
+sys.path.insert(0, '.')
+
+from docopt import docopt
+from dmscripts.env import get_api_endpoint_from_stage
+from dmscripts.export_g8_suppliers import export_suppliers
+from dmapiclient import DataAPIClient
+from dmutils.content_loader import ContentLoader
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    STAGE = arguments['<stage>']
+    API_TOKEN = arguments['<api_token>']
+    CONTENT_PATH = arguments['<content_path>']
+    OUTPUT_DIR = arguments['<output_dir>']
+
+    client = DataAPIClient(get_api_endpoint_from_stage(STAGE), API_TOKEN)
+    content_loader = ContentLoader(CONTENT_PATH)
+
+    supplier_id_file = arguments['<supplier_id_file>']
+    if supplier_id_file:
+        with open(arguments['<supplier_id_file>'], 'r') as f:
+            supplier_ids = map(int, filter(None, [l.strip() for l in f.readlines()]))
+    else:
+        supplier_ids = None
+
+    export_suppliers(client, content_loader, OUTPUT_DIR, supplier_ids)

--- a/scripts/oneoff/insert-g8-framework-results.py
+++ b/scripts/oneoff/insert-g8-framework-results.py
@@ -1,0 +1,33 @@
+"""
+For each G-Cloud 8 application this script:
+ * gets the supplier declaration
+ * checks whether it is a PASS, FAIL or DISCRETIONARY
+ * updates the `supplier_frameworks` entry for the application accordingly, using the API:
+   - on_framework=true if declaration OK and at least one completed service
+   - on_framework=false if declaration FAILed or there are no completed services
+   - on_framework=NULL (no call to API) if declaration DISCRETIONARY and at least one completed service
+
+Usage:
+    scripts/insert-g8-framework-results.py <stage> --api-token=<data_api_token>
+
+Example:
+    python scripts/insert-dos-framework-results.py dev --api-token=myToken
+"""
+import sys
+sys.path.insert(0, '.')
+
+import getpass
+from dmscripts.env import get_api_endpoint_from_stage
+
+from docopt import docopt
+from dmapiclient import DataAPIClient
+from dmscripts.insert_g8_framework_results import process_g8_results
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    data_api_url = get_api_endpoint_from_stage(arguments['<stage>'], 'api')
+    client = DataAPIClient(data_api_url, arguments['--api-token'])
+    user = getpass.getuser()
+
+    process_g8_results(client, user)

--- a/scripts/oneoff/insert-g8-framework-results.py
+++ b/scripts/oneoff/insert-g8-framework-results.py
@@ -11,7 +11,7 @@ Usage:
     scripts/insert-g8-framework-results.py <stage> --api-token=<data_api_token>
 
 Example:
-    python scripts/insert-dos-framework-results.py dev --api-token=myToken
+    python scripts/insert-g8-framework-results.py dev --api-token=myToken
 """
 import sys
 sys.path.insert(0, '.')

--- a/tests/test_export_g8_suppliers.py
+++ b/tests/test_export_g8_suppliers.py
@@ -1,0 +1,460 @@
+import pytest
+import six
+from mock import Mock, call, patch, ANY, mock_open
+
+from dmscripts import export_g8_suppliers
+from dmapiclient import HTTPError
+from dmutils.content_loader import ContentQuestion
+
+
+def test_find_suppliers_produces_results_with_supplier_ids(mock_data_client):
+    mock_data_client.get_interested_suppliers.return_value = {
+        'interestedSuppliers': [4, 3, 2]
+    }
+
+    records = list(export_g8_suppliers.find_suppliers(mock_data_client, 'framework-slug'))
+
+    mock_data_client.get_interested_suppliers.assert_has_calls([
+        call('framework-slug')
+    ])
+    assert records == [
+        {'supplier_id': 4}, {'supplier_id': 3}, {'supplier_id': 2}
+    ]
+
+
+def test_find_suppliers_filtered_by_supplier_ids(mock_data_client):
+    mock_data_client.get_interested_suppliers.return_value = {
+        'interestedSuppliers': [4, 3, 2]
+    }
+
+    records = list(export_g8_suppliers.find_suppliers(mock_data_client, 'framework-slug', supplier_ids=[2, 4]))
+
+    assert records == [
+        {'supplier_id': 4}, {'supplier_id': 2},
+    ]
+
+
+def test_add_supplier_info(mock_data_client):
+    mock_data_client.get_supplier.side_effect = [
+        {'suppliers': 'supplier 1'},
+        {'suppliers': 'supplier 2'},
+    ]
+
+    supplier_info_adder = export_g8_suppliers.add_supplier_info(mock_data_client)
+    records = [
+        supplier_info_adder({'supplier_id': 1}),
+        supplier_info_adder({'supplier_id': 2}),
+    ]
+
+    mock_data_client.get_supplier.assert_has_calls([
+        call(1), call(2)
+    ])
+    assert records == [
+        {'supplier_id': 1, 'supplier': 'supplier 1'},
+        {'supplier_id': 2, 'supplier': 'supplier 2'},
+    ]
+
+
+def test_add_draft_services(mock_data_client):
+    mock_data_client.find_draft_services.side_effect = [
+        {"services": ["service1", "service2"]},
+        {"services": ["service3", "service4"]},
+    ]
+
+    service_adder = export_g8_suppliers.add_draft_services(mock_data_client, 'framework-slug')
+    in_records = [
+        {"supplier_id": 1},
+        {"supplier_id": 2},
+    ]
+    out_records = list(map(service_adder, in_records))
+
+    mock_data_client.find_draft_services.assert_has_calls([
+        call(1, framework='framework-slug'),
+        call(2, framework='framework-slug'),
+    ])
+    assert out_records == [
+        {"supplier_id": 1, "services": ["service1", "service2"]},
+        {"supplier_id": 2, "services": ["service3", "service4"]},
+    ]
+
+
+def test_add_draft_services_filtered_by_lot(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {
+        "services": [
+            {"lotSlug": "good"},
+            {"lotSlug": "bad"}
+        ]
+    }
+    service_adder = export_g8_suppliers.add_draft_services(
+        mock_data_client, "framework-slug",
+        lot="good")
+    assert service_adder({"supplier_id": 1}) == {
+        "supplier_id": 1,
+        "services": [
+            {"lotSlug": "good"},
+        ]
+    }
+    mock_data_client.find_draft_services.assert_has_calls([
+        call(1, framework='framework-slug'),
+    ])
+
+
+def test_add_draft_services_filtered_by_status(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {
+        "services": [
+            {"status": "submitted"},
+            {"status": "failed"}
+        ]
+    }
+    service_adder = export_g8_suppliers.add_draft_services(
+        mock_data_client, "framework-slug",
+        status="submitted")
+    assert service_adder({"supplier_id": 1}) == {
+        "supplier_id": 1,
+        "services": [
+            {"status": "submitted"},
+        ]
+    }
+    mock_data_client.find_draft_services.assert_has_calls([
+        call(1, framework='framework-slug'),
+    ])
+
+
+@pytest.mark.parametrize('record,count', [
+    ({"services": [
+        {"theId": ["Label", "other"]},
+        {"theId": ["other"]},
+        {"theId": ["Label"]},
+    ]}, 2),
+    ({"services": []}, 0),
+    ({"services": [{}]}, 0),
+])
+def test_count_field_in_record(record, count):
+    assert export_g8_suppliers.count_field_in_record("theId", "Label", record) == count
+
+
+def test_make_fields_from_content_question():
+    questions = [
+        ContentQuestion({"id": "check1",
+                         "type": "checkboxes",
+                         "options": [
+                             {"label": "Option 1"},
+                             {"label": "Option 2"},
+                         ]}),
+        ContentQuestion({"id": "custom",
+                         "type": "custom",
+                         "fields": {
+                             "field1": "field1",
+                             "field2": "field2",
+                         }}),
+        ContentQuestion({"id": "basic",
+                         "type": "boolean"}),
+    ]
+    record = {
+        "services": [
+            {"check1": ["Option 1"],
+             "field1": "Blah",
+             "field2": "Foo",
+             "basic": False},
+            {"check1": ["Option 1", "Option 2"],
+             "field1": "Foo",
+             "basic": True},
+        ]
+    }
+    assert export_g8_suppliers.make_fields_from_content_questions(questions, record) == [
+        ("check1 Option 1", 2),
+        ("check1 Option 2", 1),
+        ("field1", "Blah|Foo"),
+        ("field2", "Foo|"),
+        ("basic", "False|True"),
+    ]
+
+
+def test_add_framework_info(mock_data_client):
+    mock_data_client.get_supplier_framework_info.side_effect = [
+        {'frameworkInterest': {'declaration': {'status': 'complete'}, 'onFramework': True}},
+        {'frameworkInterest': {'declaration': {'status': 'complete'}, 'onFramework': False}},
+    ]
+
+    framework_info_adder = export_g8_suppliers.add_framework_info(mock_data_client, 'framework-slug')
+    records = [
+        framework_info_adder({'supplier_id': 1}),
+        framework_info_adder({'supplier_id': 2}),
+    ]
+
+    mock_data_client.get_supplier_framework_info.assert_has_calls([
+        call(1, 'framework-slug'), call(2, 'framework-slug')
+    ])
+    assert records == [
+        {'supplier_id': 1, 'declaration': {'status': 'complete'}, 'onFramework': True},
+        {'supplier_id': 2, 'declaration': {'status': 'complete'}, 'onFramework': False},
+    ]
+
+
+def test_add_framework_info_fails_on_non_404_error(mock_data_client):
+    mock_data_client.get_supplier_framework_info.side_effect = HTTPError(Mock(status_code=400))
+
+    framework_info_adder = export_g8_suppliers.add_framework_info(mock_data_client, 'framework-slug')
+
+    with pytest.raises(HTTPError):
+        framework_info_adder({'supplier_id': 1})
+
+
+def test_add_framework_info_fails_if_incomplete_declaration_is_not_failed(mock_data_client):
+    mock_data_client.get_supplier_framework_info.return_value = {
+        'frameworkInterest': {'declaration': {'status': 'incomplete'}, 'onFramework': None}
+    }
+
+    framework_info_adder = export_g8_suppliers.add_framework_info(mock_data_client, 'framework-slug')
+
+    with pytest.raises(AssertionError):
+        framework_info_adder({'supplier_id': 1})
+
+
+def test_add_draft_counts(mock_data_client):
+    mock_data_client.find_draft_services_iter.return_value = [
+        {'status': 'submitted', 'lot': 'saas'},
+        {'status': 'submitted', 'lot': 'saas'},
+        {'status': 'submitted', 'lot': 'paas'},
+        {'status': 'not-submitted', 'lot': 'saas'},
+        {'status': 'not-submitted', 'lot': 'paas'},
+        {'status': 'not-submitted', 'lot': 'paas'},
+        {'status': 'not-submitted', 'lot': 'paas'},
+        {'status': 'published', 'lot': 'scs'},  # anything not submitted or failed is considered draft
+    ]
+
+    draft_counts_adder = export_g8_suppliers.add_draft_counts(mock_data_client, 'framework-slug')
+
+    record = draft_counts_adder({'supplier': {'id': 1}})
+    print("COUNTS: {}".format(record['counts']))
+    assert record['counts'] == {
+        'completed': {
+            'saas': 2, 'paas': 1,
+            'iaas': 0, 'scs': 0,
+        },
+        'draft': {
+            'saas': 1, 'paas': 3,
+            'iaas': 0, 'scs': 1,
+        },
+    }
+
+
+def test_get_declaration_questions():
+    q1, q2, q3 = Mock(id='found1'), Mock(id='not_found'), Mock(id='found2')
+
+    questions1 = [q1, q2]
+    questions2 = [q3]
+    sections = [Mock(questions=questions1), Mock(questions=questions2)]
+    record = {'declaration': {'found1': 'value1', 'found2': 'value2', 'extra': 'value3'}}
+
+    answers = list(export_g8_suppliers.get_declaration_questions(sections, record))
+
+    assert answers == [
+        (q1, 'value1'),
+        (q2, None),
+        (q3, 'value2'),
+    ]
+
+
+@patch('dmscripts.export_g8_suppliers.get_declaration_questions')
+def test_add_failed_question_mandatory_false_is_true(get_declaration_questions):
+    get_declaration_questions.return_value = [
+        (Mock(id='termsAndConditions', number=1), False)
+    ]
+
+    failed_questions_adder = export_g8_suppliers.add_failed_questions(None)
+
+    record = failed_questions_adder({'declaration': {'status': 'complete'}})
+    assert record['failed_mandatory'] == ['Q1 - termsAndConditions']
+
+
+@patch('dmscripts.export_g8_suppliers.get_declaration_questions')
+def test_add_failed_question_mandatory_true_is_false(get_declaration_questions):
+    get_declaration_questions.return_value = [
+        (Mock(id='terrorism', number=17), True)
+    ]
+
+    failed_questions_adder = export_g8_suppliers.add_failed_questions(None)
+
+    record = failed_questions_adder({'declaration': {'status': 'complete'}})
+
+    assert record['failed_mandatory'] == ['Q17 - terrorism']
+
+
+@patch('dmscripts.export_g8_suppliers.get_declaration_questions')
+def test_add_failed_question_yes_or_na(get_declaration_questions):
+    get_declaration_questions.return_value = [
+        (Mock(id='employersInsurance', number=14), "Invalid")
+    ]
+
+    failed_questions_adder = export_g8_suppliers.add_failed_questions(None)
+
+    record = failed_questions_adder({'declaration': {'status': 'complete'}})
+
+    assert record['failed_mandatory'] == ['Q14 - employersInsurance']
+
+
+def test_add_failed_questions_incomplete_declaration():
+    failed_questions_adder = export_g8_suppliers.add_failed_questions(None)
+
+    record = failed_questions_adder({'declaration': {'status': 'started'}})
+
+    assert record['failed_mandatory'] == ['INCOMPLETE']
+    assert record['discretionary'] == []
+
+
+def test_service_counts(mock_data_client):
+    # Count services
+    mock_data_client.find_draft_services_iter.return_value = [
+        {'status': 'submitted', 'lot': 'saas'},
+        {'status': 'submitted', 'lot': 'saas'},
+        {'status': 'submitted', 'lot': 'paas'},
+        {'status': 'not-submitted', 'lot': 'scs'},
+        {'status': 'not-submitted', 'lot': 'scs'},
+        {'status': 'not-submitted', 'lot': 'paas'},
+        {'status': 'not-submitted', 'lot': 'paas'},
+        {'status': 'published', 'lot': 'paas'},  # anything not submitted or failed is considered draft
+    ]
+    draft_counts_adder = export_g8_suppliers.add_draft_counts(mock_data_client, 'framework-slug')
+
+    record = draft_counts_adder({'supplier': {'id': 1}})
+
+    counts = export_g8_suppliers.service_counts(record)
+
+    assert counts == [
+        ('completed_saas', 2),
+        ('completed_paas', 1),
+        ('completed_iaas', 0),
+        ('completed_scs', 0),
+        ('draft_saas', 0),
+        ('draft_paas', 3),
+        ('draft_iaas', 0),
+        ('draft_scs', 2),
+    ]
+
+SUCCESSFUL_RECORD = {
+    'onFramework': True,
+    'supplier': {'id': 1,
+                 'name': 'Bluedice Ideas Limited'},
+    'declaration': {'nameOfOrganisation': 'Young Money Franchise LTD',
+                    'primaryContact': 'Yolo Swaggins',
+                    'primaryContactEmail': 'yolo.swaggins@example.com',
+                    'tradingNames': 'Old Money Franchise',
+                    'registeredAddress': 'The house on the street',
+                    'companyNumber': '009900',
+                    'currentRegisteredCountry': 'France'},
+    'counts': {
+        'completed': {
+            'saas': 2, 'paas': 1,
+            'iaas': 0, 'scs': 0,
+        },
+        'failed': {
+            'saas': 2, 'paas': 0,
+            'iaas': 0, 'scs': 0,
+        },
+        'draft': {
+            'saas': 0, 'paas': 3,
+            'iaas': 0, 'scs': 0,
+        },
+    }
+}
+FAILED_RECORD = {
+    'onFramework': False,
+    'supplier': {'id': 1,
+                 'name': 'Bluedice Ideas Limited'},
+    'declaration': {'nameOfOrganisation': 'Young Money Franchise LTD',
+                    'primaryContact': 'Yolo Swaggins',
+                    'primaryContactEmail': 'yolo.swaggins@example.com',
+                    'tradingNames': 'Old Money Franchise',
+                    'registeredAddress': 'The house on the street',
+                    'companyNumber': '009900',
+                    'currentRegisteredCountry': 'France'},
+    'failed_mandatory': ['Q1', 'Q3', 'Q5'],
+    'discretionary': [],
+    'counts': {
+        'completed': {
+            'saas': 2, 'paas': 1,
+            'iaas': 0, 'scs': 0,
+        },
+        'failed': {
+            'saas': 2, 'paas': 0,
+            'iaas': 0, 'scs': 0,
+        },
+        'draft': {
+            'saas': 0, 'paas': 3,
+            'iaas': 0, 'scs': 0,
+        },
+    }
+}
+DISCRETIONARY_RECORD = {
+    'onFramework': None,
+    'supplier': {'id': 1,
+                 'name': 'Bluedice Ideas Limited'},
+    'declaration': {'nameOfOrganisation': 'Young Money Franchise LTD',
+                    'primaryContact': 'Yolo Swaggins',
+                    'primaryContactEmail': 'yolo.swaggins@example.com',
+                    'tradingNames': 'Old Money Franchise',
+                    'registeredAddress': 'The house on the street',
+                    'companyNumber': '009900',
+                    'currentRegisteredCountry': 'France'},
+    'failed_mandatory': [],
+    'discretionary': [
+        ('Q21', 'val1'),
+        ('Q22', 'val2'),
+        ('Q23', 'val3'),
+    ],
+    'counts': {
+        'completed': {
+            'saas': 2, 'paas': 1,
+            'iaas': 0, 'scs': 0,
+        },
+        'failed': {
+            'saas': 2, 'paas': 0,
+            'iaas': 0, 'scs': 0,
+        },
+        'draft': {
+            'saas': 0, 'paas': 3,
+            'iaas': 0, 'scs': 0,
+        },
+    }
+}
+
+
+def test_write_to_csv():
+    # mock_open mocks the open function
+    # if we want to mock multiple files we want the configured MagicMock that mock_open returns
+    successful_file = mock_open()()
+    failed_file = mock_open()()
+    discretionary_file = mock_open()()
+    all_files = [successful_file, failed_file, discretionary_file]
+
+    with patch.object(six.moves.builtins, 'open', side_effect=all_files) as mocked_open:
+        handlers = [
+            export_g8_suppliers.SuccessfulHandler(),
+            export_g8_suppliers.FailedHandler(),
+            export_g8_suppliers.DiscretionaryHandler()
+        ]
+
+        with export_g8_suppliers.MultiCSVWriter('example', handlers) as writer:
+            mocked_open.assert_has_calls([
+                call('example/successful.csv', ANY),
+                call('example/failed.csv', ANY),
+                call('example/discretionary.csv', ANY),
+            ])
+
+            writer.write_row(SUCCESSFUL_RECORD)
+            writer.write_row(FAILED_RECORD)
+            writer.write_row(DISCRETIONARY_RECORD)
+
+            successful_file.write.assert_has_calls([
+                call('supplier_name,supplier_id,contact_name,contact_email\r\n'),
+                call('Bluedice Ideas Limited,1,Yolo Swaggins,yolo.swaggins@example.com\r\n'),
+            ])
+            failed_file.write.assert_has_calls([
+                call('supplier_name,supplier_id,failed_mandatory,contact_name,contact_email\r\n'),
+                call('Bluedice Ideas Limited,1,"Q1,Q3,Q5",Yolo Swaggins,yolo.swaggins@example.com\r\n'),
+            ])
+            discretionary_file.write.assert_has_calls([
+                call('supplier_name,supplier_id,Q21,Q22,Q23,contact_name,contact_email\r\n'),
+                call('Bluedice Ideas Limited,1,val1,val2,val3,Yolo Swaggins,yolo.swaggins@example.com\r\n'),
+            ])

--- a/tests/test_insert_g8_framework_results.py
+++ b/tests/test_insert_g8_framework_results.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from dmscripts.insert_g8_framework_results import insert_result, get_submitted_drafts, check_declaration_answers, \
+    has_supplier_submitted_services, process_g8_results
+from mock import mock
+from dmapiclient import HTTPError
+
+
+VALID_COMPLETE_G8_DECLARATION = {
+    "termsAndConditions": True,
+    "registeredAddressBuilding": "23 Four Street",
+    "understandTool": True,
+    "distortingCompetition": False,
+    "skillsAndResources": True,
+    "significantOrPersistentDeficiencies": False,
+    "cyberEssentials": False,
+    "companyRegistrationNumber": "1234456",
+    "dunsNumber": "123123123",
+    "registeredVATNumber": "543456543",
+    "distortedCompetition": False,
+    "conspiracyCorruptionBribery": False,
+    "contactNameContractNotice": "A.N. Other",
+    "contactEmailContractNotice": "g8-supplier@example.com",
+    "organisationSize": "micro",
+    "graveProfessionalMisconduct": False,
+    "GAAR": False,
+    "canProvideCloudServices": True,
+    "bankrupt": False,
+    "confidentialInformation": False,
+    "seriousMisrepresentation": False,
+    "understandHowToAskQuestions": True,
+    "primaryContactEmail": "g8-supplier@example.com",
+    "taxEvasion": False,
+    "primaryContact": "Primary Contact",
+    "subcontracting": [
+        "yourself without the use of third parties (subcontractors)"
+    ],
+    "tradingStatus": "limited company",
+    "terrorism": False,
+    "conflictOfInterest": False,
+    "proofOfClaims": True,
+    "status": "complete",
+    "witheldSupportingDocuments": False,
+    "registeredAddressTown": "Cardigan",
+    "currentRegisteredCountry": "UK",
+    "misleadingInformation": False,
+    "equalityAndDiversity": True,
+    "nameOfOrganisation": "Cardigan Cardigans Ltd",
+    "fraudAndTheft": False,
+    "firstRegistered": "2001",
+    "employersInsurance": "Yes",
+    "unspentTaxConvictions": False,
+    "establishedInTheUK": True,
+    "servicesHaveOrSupport": True,
+    "influencedContractingAuthority": False,
+    "readUnderstoodGuidance": True,
+    "environmentalSocialLabourLaw": False,
+    "termsOfParticipation": True,
+    "accuratelyDescribed": True,
+    "organisedCrime": False,
+    "MI": True,
+    "cyberEssentialsPlus": False,
+    "registeredAddressPostcode": "CD3 4GH",
+    "tradingNames": "Cardies'r'Us"
+}
+
+
+def test_insert_result_calls_with_correct_arguments(mock_data_client):
+    assert insert_result(mock_data_client, 123456, True, 'user') == '  Result set OK: 123456'
+    mock_data_client.set_framework_result.assert_called_with(123456, 'g-cloud-8', True, 'user')
+
+
+def test_insert_result_returns_error_message_if_update_fails(mock_data_client):
+    mock_data_client.set_framework_result.side_effect = HTTPError()
+    assert insert_result(mock_data_client, 123456, True, 'user') == \
+        '  Error inserting result for 123456 (True): Request failed (status: 503)'
+
+
+def test_get_submitted_drafts_calls_with_correct_arguments(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {'services': []}
+    get_submitted_drafts(mock_data_client, 12345)
+    mock_data_client.find_draft_services.assert_called_with(12345, framework='g-cloud-8')
+
+
+def test_get_submitted_drafts_returns_submitted_services_only(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {'services': [
+                                                        {"id": 1, "status": "not-submitted"},
+                                                        {"id": 2, "status": "submitted"}
+        ]
+    }
+    result = get_submitted_drafts(mock_data_client, 12345)
+    assert (result == [{"id": 2, "status": "submitted"}])
+
+
+def test_check_declaration_fails_incomplete_declaration():
+    declaration = {"status": "started"}
+    assert check_declaration_answers(declaration) == 'Fail'
+
+
+def test_check_declaration_answers_passes_good_declaration():
+    assert check_declaration_answers(VALID_COMPLETE_G8_DECLARATION) == 'Pass'
+
+
+def test_check_declaration_answers_fails_bad_declaration_true_is_false():
+    declaration_content = mock.Mock()
+    question_numbers = mock.PropertyMock(side_effect=[1, 17, 21, -1])
+    type(declaration_content.get_question.return_value).number = question_numbers
+    # Question canProvideCloudServices is incorrectly False so should Fail
+    declaration = VALID_COMPLETE_G8_DECLARATION.copy()
+    declaration['canProvideCloudServices'] = False
+    assert check_declaration_answers(declaration) == 'Fail'
+
+
+def test_check_declaration_answers_fails_bad_declaration_false_is_true():
+    # Question conspiracyCorruptionBribery is incorrectly True so should Fail
+    declaration = VALID_COMPLETE_G8_DECLARATION.copy()
+    declaration['conspiracyCorruptionBribery'] = True
+    assert check_declaration_answers(declaration) == 'Fail'
+
+
+def test_check_declaration_answers_returns_discretionary_for_false_is_true():
+    # Question taxEvasion is incorrectly True so should be Discretionary
+    declaration = VALID_COMPLETE_G8_DECLARATION.copy()
+    declaration['taxEvasion'] = True
+    assert check_declaration_answers(declaration) == 'Discretionary'
+
+
+def test_check_declaration_answers_passes_good_yes_or_na():
+    # Question employersInsurance should pass if 'Yes' or 'Not applicable'
+    declaration = VALID_COMPLETE_G8_DECLARATION.copy()
+    declaration['employersInsurance'] = "Not applicable"
+    assert check_declaration_answers(declaration) == 'Pass'
+
+
+def test_check_declaration_answers_fails_for_bad_yes_or_na():
+    # Question employersInsurance should pass if 'Yes' or 'Not applicable'
+    declaration = VALID_COMPLETE_G8_DECLARATION.copy()
+    declaration['employersInsurance'] = "No"
+    assert check_declaration_answers(declaration) == 'Fail'
+
+
+def test_has_supplier_submitted_services_for_some_services(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {
+        "services": [{"status": "submitted"}, {"status": "submitted"}]
+    }
+    assert has_supplier_submitted_services(mock_data_client, 12345) is True
+
+
+def test_has_supplier_submitted_services_for_no_services(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {
+        "services": [{"status": "not-submitted"}]
+    }
+    assert has_supplier_submitted_services(mock_data_client, 12345) is False
+
+
+def test_process_g8_results_for_successful(mock_data_client):
+    mock_data_client.get_interested_suppliers.return_value = {"interestedSuppliers": [123456]}
+    mock_data_client.get_supplier_declaration.return_value = {"declaration": VALID_COMPLETE_G8_DECLARATION}
+    mock_data_client.find_draft_services.return_value = {
+        "services": [{"status": "submitted"}, {"status": "submitted"}]
+    }
+    process_g8_results(mock_data_client, 'user')
+    mock_data_client.set_framework_result.assert_called_with(123456, 'g-cloud-8', True, 'user')
+
+
+def test_process_g8_results_for_incomplete_declaration(mock_data_client):
+    # Declaration not complete so application should fail
+    declaration = VALID_COMPLETE_G8_DECLARATION.copy()
+    declaration['status'] = 'started'
+    mock_data_client.get_interested_suppliers.return_value = {"interestedSuppliers": [123456]}
+    mock_data_client.get_supplier_declaration.return_value = {"declaration": declaration}
+    mock_data_client.find_draft_services.return_value = {
+        "services": [{"status": "submitted"}, {"status": "submitted"}]
+    }
+    process_g8_results(mock_data_client, 'user')
+    mock_data_client.set_framework_result.assert_called_with(123456, 'g-cloud-8', False, 'user')
+
+
+def test_process_g8_results_for_discretionary(mock_data_client):
+    # Question 'bankrupt' = True is a discretionary fail, so result should be discretionary
+    declaration = VALID_COMPLETE_G8_DECLARATION.copy()
+    declaration['bankrupt'] = True
+    mock_data_client.get_interested_suppliers.return_value = {"interestedSuppliers": [123456]}
+    mock_data_client.get_supplier_declaration.return_value = {"declaration": declaration}
+    mock_data_client.find_draft_services.return_value = {
+        "services": [{"status": "submitted"}, {"status": "submitted"}]
+    }
+    process_g8_results(mock_data_client, 'user')
+    # Discretionary result should not update `supplier_frameworks` at all
+    mock_data_client.set_framework_result.assert_not_called()

--- a/tests/test_insert_g8_framework_results.py
+++ b/tests/test_insert_g8_framework_results.py
@@ -103,9 +103,6 @@ def test_check_declaration_answers_passes_good_declaration():
 
 
 def test_check_declaration_answers_fails_bad_declaration_true_is_false():
-    declaration_content = mock.Mock()
-    question_numbers = mock.PropertyMock(side_effect=[1, 17, 21, -1])
-    type(declaration_content.get_question.return_value).number = question_numbers
     # Question canProvideCloudServices is incorrectly False so should Fail
     declaration = VALID_COMPLETE_G8_DECLARATION.copy()
     declaration['canProvideCloudServices'] = False


### PR DESCRIPTION
Completes this story: https://www.pivotaltracker.com/story/show/121427817
And also: https://www.pivotaltracker.com/story/show/121427955

For each G-Cloud 8 application the first script:
 * gets the supplier declaration
 * checks whether it is a PASS, FAIL or DISCRETIONARY
 * updates the `supplier_frameworks` entry for the application accordingly, using the API:
   - on_framework=true if declaration OK and at least one completed service
   - on_framework=false if declaration FAILed or there are no completed services
   - on_framework=NULL (no call to API) if declaration DISCRETIONARY and at least one completed service

And then the second script generates three CSV files with relevant data for each of passed/failed/discretionary applications.  Suppliers who expressed interest but didn't complete an application are not included in these export files.
* PASSED:
  * Supplier name (Digital Marketplace name)
  * Supplier ID
  * Contact name for application
  * Email address for application



* DISCRETIONARY:
  * Supplier name (Digital Marketplace name)
  * Supplier ID
  * All discretionary question info + supporting text
  * Contact name for application
  * Email address for application



* UNSUCCESSFUL: 
  * Supplier name (Digital Marketplace name)
  * Supplier ID
  * Which questions did they answer incorrectly?
  * Contact name for application
  * Email address for application
