### PR TITLE
Generalise script for all frameworks, not just DOS

### DIFF
--- a/dmscripts/export_dos_suppliers.py
+++ b/dmscripts/export_dos_suppliers.py
@@ -1,8 +1,8 @@
+# -*- coding: utf-8 -*-
 import os
 import sys
 from multiprocessing.pool import ThreadPool
 
-from dmapiclient import HTTPError
 from dmscripts.insert_dos_framework_results import (
     CORRECT_DECLARATION_RESPONSE_MUST_BE_TRUE, CORRECT_DECLARATION_RESPONSE_MUST_BE_FALSE,
     CORRECT_DECLARATION_RESPONSE_SHOULD_BE_FALSE, MITIGATING_FACTORS,

--- a/dmscripts/framework_utils.py
+++ b/dmscripts/framework_utils.py
@@ -1,9 +1,24 @@
 from dmapiclient import HTTPError
 
 
+def get_submitted_drafts(client, framework_slug, supplier_id):
+    services = client.find_draft_services(supplier_id, framework=framework_slug)
+    services = services["services"]
+    submitted_services = [service for service in services if service["status"] == "submitted"]
+    return submitted_services
+
+
 def set_framework_result(client, framework_slug, supplier_id, result, user):
     try:
         client.set_framework_result(supplier_id, framework_slug, result, user)
         return "  Result set OK: {} - {}".format(supplier_id, "PASS" if result else "FAIL")
     except HTTPError as e:
         return "  Error inserting result for {} ({}): {}".format(supplier_id, result, str(e))
+
+
+def has_supplier_submitted_services(client, framework_slug, supplier_id):
+    submitted_drafts = get_submitted_drafts(client, framework_slug, supplier_id)
+    if len(submitted_drafts) > 0:
+        return True
+    else:
+        return False

--- a/dmscripts/framework_utils.py
+++ b/dmscripts/framework_utils.py
@@ -2,9 +2,9 @@ from dmapiclient import HTTPError
 
 
 def get_submitted_drafts(client, framework_slug, supplier_id):
-    services = client.find_draft_services(supplier_id, framework=framework_slug)
-    services = services["services"]
-    submitted_services = [service for service in services if service["status"] == "submitted"]
+    draft_services = client.find_draft_services(supplier_id, framework=framework_slug)["services"]
+    submitted_services = [service for service in draft_services if service["status"] == "submitted"
+                          and not service.get('serviceId')]
     return submitted_services
 
 
@@ -29,4 +29,3 @@ def find_suppliers_on_framework(client, framework_slug):
         supplier for supplier in client.find_framework_suppliers(framework_slug)['supplierFrameworks']
         if supplier['onFramework']
     )
-

--- a/dmscripts/framework_utils.py
+++ b/dmscripts/framework_utils.py
@@ -22,3 +22,11 @@ def has_supplier_submitted_services(client, framework_slug, supplier_id):
         return True
     else:
         return False
+
+
+def find_suppliers_on_framework(client, framework_slug):
+    return (
+        supplier for supplier in client.find_framework_suppliers(framework_slug)['supplierFrameworks']
+        if supplier['onFramework']
+    )
+

--- a/dmscripts/framework_utils.py
+++ b/dmscripts/framework_utils.py
@@ -1,0 +1,9 @@
+from dmapiclient import HTTPError
+
+
+def set_framework_result(client, framework_slug, supplier_id, result, user):
+    try:
+        client.set_framework_result(supplier_id, framework_slug, result, user)
+        return "  Result set OK: {} - {}".format(supplier_id, "PASS" if result else "FAIL")
+    except HTTPError as e:
+        return "  Error inserting result for {} ({}): {}".format(supplier_id, result, str(e))

--- a/dmscripts/insert_dos_framework_results.py
+++ b/dmscripts/insert_dos_framework_results.py
@@ -2,6 +2,9 @@
 from __future__ import unicode_literals
 from dmapiclient import HTTPError
 
+
+SERVICE_ESSENTIALS_MUST_BE_TRUE = ['helpGovernmentImproveServices', 'bespokeSystemInformation', 'dataProtocols',
+                                   'openStandardsPrinciples', 'anonymousRecruitment', 'manageIncentives']
 CORRECT_DECLARATION_RESPONSE_MUST_BE_TRUE = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 38, 39, 40, 41, 42,
                                              43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54]
 CORRECT_DECLARATION_RESPONSE_MUST_BE_FALSE = [17, 18, 19, 20]
@@ -13,8 +16,6 @@ CORRECT_DECLARATION_RESPONSES = {14: ["Yes – your organisation has, or will ha
                                       "Not applicable - your organisation does not need employer’s liability "
                                       "insurance because your organisation employs only the owner or close family "
                                       "members."]}
-SERVICE_ESSENTIALS_MUST_BE_TRUE = ['helpGovernmentImproveServices', 'bespokeSystemInformation', 'dataProtocols',
-                                   'openStandardsPrinciples', 'anonymousRecruitment', 'manageIncentives']
 FAIL = "Fail"
 PASS = "Pass"
 DISCRETIONARY = "Discretionary"

--- a/scripts/check-g-cloud-live.py
+++ b/scripts/check-g-cloud-live.py
@@ -16,7 +16,8 @@ import itertools
 import functools
 from multiprocessing.pool import ThreadPool
 from docopt import docopt
-from dmscripts.env import get_api_endpoint_from_stage, get_assets_endpoint_from_stage
+from dmscripts.env import get_api_endpoint_from_stage
+from dmscripts.framework_utils import find_suppliers_on_framework
 from dmscripts.logging import configure_logger
 from dmapiclient import DataAPIClient
 from dmutils.s3 import S3
@@ -28,15 +29,6 @@ DOCUMENT_KEYS = [
 ]
 FRAMEWORK_SLUG = 'g-cloud-7'
 logger = configure_logger()
-
-
-def find_suppliers_on_framework(client, framework_slug):
-    return (
-        supplier
-        for supplier
-        in client.find_framework_suppliers(framework_slug)['supplierFrameworks']
-        if supplier['onFramework']
-    )
 
 
 def find_drafts_for_supplier(client, supplier_id, framework_slug):

--- a/scripts/make-dos-live.py
+++ b/scripts/make-dos-live.py
@@ -8,14 +8,8 @@ sys.path.insert(0, '.')
 
 from docopt import docopt
 from dmscripts.env import get_api_endpoint_from_stage
+from dmscripts.framework_utils import find_suppliers_on_framework
 from dmapiclient import DataAPIClient
-
-
-def find_suppliers_on_framework(client, framework_slug):
-    return (
-        supplier for supplier in client.find_framework_suppliers(framework_slug)['supplierFrameworks']
-        if supplier['onFramework']
-    )
 
 
 def find_submitted_draft_services(client, supplier_id, framework_slug):

--- a/scripts/make-g-cloud-live.py
+++ b/scripts/make-g-cloud-live.py
@@ -27,14 +27,14 @@ DOCUMENT_KEYS = [
 
 
 def assert_equal(one, two):
-    assert one == two, "{} != {}".format(one, two)
+    assert one == two, u"{} != {}".format(one, two)
 
 
 def parse_document_url(url, framework_slug):
     pattern = r'/{}/submissions/(\d+)/(\d+)-(.*)$'.format(re.escape(framework_slug))
     match = re.search(pattern, url)
     if not match:
-        raise ValueError("Could not parse document URL {}".format(url))
+        raise ValueError(u"Could not parse document URL {}".format(url))
     return {
         'supplier_id': match.group(1),
         'draft_id': match.group(2),
@@ -43,57 +43,57 @@ def parse_document_url(url, framework_slug):
 
 
 def get_draft_document_path(parsed_document, framework_slug):
-    return '{framework_slug}/submissions/{supplier_id}/{draft_id}-{document_name}'.format(
+    return u'{framework_slug}/submissions/{supplier_id}/{draft_id}-{document_name}'.format(
         framework_slug=framework_slug,
         **parsed_document)
 
 
 def get_live_document_path(parsed_document, framework_slug, service_id):
-    return '{framework_slug}/documents/{supplier_id}/{service_id}-{document_name}'.format(
+    return u'{framework_slug}/documents/{supplier_id}/{service_id}-{document_name}'.format(
         framework_slug=framework_slug,
         service_id=service_id,
         **parsed_document)
 
 
 def get_live_asset_url(live_document_path):
-    return "{}/{}".format(get_assets_endpoint_from_stage(STAGE), live_document_path)
+    return u"{}/{}".format(get_assets_endpoint_from_stage(STAGE), live_document_path)
 
 
 def document_copier(draft_bucket, documents_bucket, dry_run):
     def copy_document(draft_document_path, live_document_path):
         if not draft_bucket.path_exists(draft_document_path):
-            raise ValueError("Draft document {} does not exist in bucket {}".format(
+            raise ValueError(u"Draft document {} does not exist in bucket {}".format(
                 draft_document_path, draft_bucket.bucket_name))
-        message_suffix = "{}:{} to {}:{}".format(
+        message_suffix = u"{}:{} to {}:{}".format(
             draft_bucket.bucket_name, draft_document_path,
             documents_bucket.bucket_name, live_document_path)
 
         if dry_run:
-            print("    > not copying {}".format(message_suffix))
+            print(u"    > not copying {}".format(message_suffix))
         else:
             key = documents_bucket.bucket.copy_key(live_document_path,
                                                    src_bucket_name=draft_bucket.bucket_name,
                                                    src_key_name=draft_document_path)
             key.set_acl('public-read')
-            print("    > copied {}".format(message_suffix))
+            print(u"    > copied {}".format(message_suffix))
 
     return copy_document
 
 
 def make_draft_service_live(client, copy_document, draft_service, framework_slug, dry_run):
-    print("  > Migrating draft {} - {}".format(draft_service['id'], draft_service['serviceName']))
+    print(u"  > Migrating draft {} - {}".format(draft_service['id'], draft_service['serviceName']))
     if dry_run:
         service_id = random.randint(1000, 10000)
-        print("    > generating random test service ID: {}".format(service_id))
+        print(u"    > generating random test service ID: {}".format(service_id))
     else:
         services = client.publish_draft_service(draft_service['id'], 'make-g-cloud-live script')
         service_id = services['services']['id']
-        print("    > draft service published - new service ID {}".format(service_id))
+        print(u"    > draft service published - new service ID {}".format(service_id))
 
     document_updates = {}
     for document_key in DOCUMENT_KEYS:
         if document_key not in draft_service:
-            print("    > Skipping {}".format(document_key))
+            print(u"    > Skipping {}".format(document_key))
         else:
             parsed_document = parse_document_url(draft_service[document_key], framework_slug)
             assert_equal(str(parsed_document['supplier_id']), str(draft_service['supplierId']))
@@ -106,7 +106,7 @@ def make_draft_service_live(client, copy_document, draft_service, framework_slug
             document_updates[document_key] = get_live_asset_url(live_document_path)
 
     if dry_run:
-        print("    > not updating document URLs {}".format(document_updates))
+        print(u"    > not updating document URLs {}".format(document_updates))
     else:
         client.update_service(service_id, document_updates, 'Moving documents to live bucket')
         print("    > document URLs updated")
@@ -128,7 +128,7 @@ if __name__ == '__main__':
     suppliers = find_suppliers_on_framework(client, FRAMEWORK_SLUG)
 
     for supplier in suppliers:
-        print("Migrating drafts for supplier {} - {}".format(supplier['supplierId'], supplier['supplierName']))
+        print(u"Migrating drafts for supplier {} - {}".format(supplier['supplierId'], supplier['supplierName']))
         draft_services = get_submitted_drafts(client, FRAMEWORK_SLUG, supplier['supplierId'])
 
         for draft_service in draft_services:

--- a/scripts/make-g-cloud-live.py
+++ b/scripts/make-g-cloud-live.py
@@ -1,7 +1,7 @@
 """
 
 Usage:
-    scripts/make-g-cloud-7-live.py <stage> <api_token> <draft_bucket> <documents_bucket> [--dry-run]
+    scripts/make-g-cloud-live.py <framework_slug> <stage> <api_token> <draft_bucket> <documents_bucket> [--dry-run]
 """
 import sys
 sys.path.insert(0, '.')
@@ -23,7 +23,6 @@ DOCUMENT_KEYS = [
     'pricingDocumentURL', 'serviceDefinitionDocumentURL',
     'sfiaRateDocumentURL', 'termsAndConditionsDocumentURL',
 ]
-FRAMEWORK_SLUG = 'g-cloud-7'
 
 
 def assert_equal(one, two):
@@ -32,7 +31,7 @@ def assert_equal(one, two):
 
 def find_suppliers_on_framework(client, framework_slug):
     return (
-        supplier for supplier in client.find_framework_suppliers(FRAMEWORK_SLUG)['supplierFrameworks']
+        supplier for supplier in client.find_framework_suppliers(framework_slug)['supplierFrameworks']
         if supplier['onFramework']
     )
 
@@ -137,6 +136,7 @@ if __name__ == '__main__':
     DRAFT_BUCKET = S3(arguments['<draft_bucket>'])
     DOCUMENTS_BUCKET = S3(arguments['<documents_bucket>'])
     DRY_RUN = arguments['--dry-run']
+    FRAMEWORK_SLUG = arguments['<framework_slug>']
     copy_document = document_copier(DRAFT_BUCKET, DOCUMENTS_BUCKET, DRY_RUN)
 
     suppliers = find_suppliers_on_framework(client, FRAMEWORK_SLUG)

--- a/scripts/make-g-cloud-live.py
+++ b/scripts/make-g-cloud-live.py
@@ -16,6 +16,7 @@ import re
 
 from docopt import docopt
 from dmscripts.env import get_api_endpoint_from_stage, get_assets_endpoint_from_stage
+from dmscripts.framework_utils import find_suppliers_on_framework
 from dmapiclient import DataAPIClient
 from dmutils.s3 import S3
 
@@ -27,13 +28,6 @@ DOCUMENT_KEYS = [
 
 def assert_equal(one, two):
     assert one == two, "{} != {}".format(one, two)
-
-
-def find_suppliers_on_framework(client, framework_slug):
-    return (
-        supplier for supplier in client.find_framework_suppliers(framework_slug)['supplierFrameworks']
-        if supplier['onFramework']
-    )
 
 
 def find_submitted_draft_services(client, supplier, framework_slug):

--- a/scripts/update-framework-results.py
+++ b/scripts/update-framework-results.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 """
-Sets supplier DOS status for all supplier IDs read from file. Each file line should contain one supplier ID.
+Sets supplier "on framework" status for all supplier IDs read from file. Each file line should contain one supplier ID.
 
 Usage:
-    scripts/update-dos-framework-results.py <stage> (--pass | --fail) --api-token=<data_api_token> <supplier_id_file>
+    scripts/update-framework-results.py <framework> <stage> (--pass | --fail) --api-token=<token> <ids_file>
 
 Example:
-    python scripts/update-dos-framework-results.py preview --pass --api-token=myToken 700000 700001
+    python scripts/update-framework-results.py g-cloud-8 preview --pass --api-token=myToken ./g8-suppliers.txt
 
 """
 
@@ -23,7 +23,7 @@ from dmapiclient import DataAPIClient
 
 from dmscripts.env import get_api_endpoint_from_stage
 from dmscripts.logging import configure_logger
-from dmscripts.insert_dos_framework_results import insert_result
+from dmscripts.framework_utils import set_framework_result
 
 
 logger = configure_logger()
@@ -31,13 +31,15 @@ logger = configure_logger()
 if __name__ == '__main__':
     arguments = docopt(__doc__)
 
+    framework_slug = arguments['<framework>']
     data_api_url = get_api_endpoint_from_stage(arguments['<stage>'], 'api')
     client = DataAPIClient(data_api_url, arguments['--api-token'])
     user = getpass.getuser()
     result = True if arguments['--pass'] else False
 
-    with open(arguments['<supplier_id_file>'], 'r') as f:
+    with open(arguments['<ids_file>'], 'r') as f:
         supplier_ids = filter(None, [l.strip() for l in f.readlines()])
 
     for supplier_id in supplier_ids:
-        logger.info(insert_result(client, supplier_id, result, user))
+        logger.info(set_framework_result(client, framework_slug, supplier_id, result, user))
+    logger.info("DONE")

--- a/tests/test_framework_utils.py
+++ b/tests/test_framework_utils.py
@@ -8,7 +8,7 @@ def test_get_submitted_drafts_calls_with_correct_arguments(mock_data_client):
     mock_data_client.find_draft_services.assert_called_with(12345, framework='digital-biscuits-and-cakes')
 
 
-def test_get_submitted_drafts_returns_submitted_services_only(mock_data_client):
+def test_get_submitted_drafts_returns_submitted_draft_services_only(mock_data_client):
     mock_data_client.find_draft_services.return_value = {'services': [
         {"id": 1, "status": "not-submitted"},
         {"id": 2, "status": "submitted"}
@@ -16,6 +16,17 @@ def test_get_submitted_drafts_returns_submitted_services_only(mock_data_client):
     }
     result = get_submitted_drafts(mock_data_client, 12345, 'digital-biscuits-and-cakes')
     assert (result == [{"id": 2, "status": "submitted"}])
+
+
+def test_get_submitted_drafts_returns_submitted_draft_services_without_service_ids_only(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {'services': [
+        {"id": 1, "status": "not-submitted"},
+        {"id": 2, "status": "submitted", "serviceId": "ALREADY_A_LIVE_SERVICE"},
+        {"id": 3, "status": "submitted"},
+    ]
+    }
+    result = get_submitted_drafts(mock_data_client, 12345, 'digital-biscuits-and-cakes')
+    assert (result == [{"id": 3, "status": "submitted"}])
 
 
 def test_set_framework_result_calls_with_correct_arguments(mock_data_client):

--- a/tests/test_framework_utils.py
+++ b/tests/test_framework_utils.py
@@ -1,0 +1,44 @@
+from dmapiclient import HTTPError
+from dmscripts.framework_utils import get_submitted_drafts, has_supplier_submitted_services, set_framework_result
+
+
+def test_get_submitted_drafts_calls_with_correct_arguments(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {'services': []}
+    get_submitted_drafts(mock_data_client, 'digital-biscuits-and-cakes', 12345)
+    mock_data_client.find_draft_services.assert_called_with(12345, framework='digital-biscuits-and-cakes')
+
+
+def test_get_submitted_drafts_returns_submitted_services_only(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {'services': [
+        {"id": 1, "status": "not-submitted"},
+        {"id": 2, "status": "submitted"}
+    ]
+    }
+    result = get_submitted_drafts(mock_data_client, 12345, 'digital-biscuits-and-cakes')
+    assert (result == [{"id": 2, "status": "submitted"}])
+
+
+def test_set_framework_result_calls_with_correct_arguments(mock_data_client):
+    assert set_framework_result(mock_data_client, 'g-whizz-6', 123456, True, 'user') == \
+        '  Result set OK: 123456 - PASS'
+    mock_data_client.set_framework_result.assert_called_with(123456, 'g-whizz-6', True, 'user')
+
+
+def test_set_framework_result_returns_error_message_if_update_fails(mock_data_client):
+    mock_data_client.set_framework_result.side_effect = HTTPError()
+    assert set_framework_result(mock_data_client, 'g-whizz-6', 123456, True, 'user') == \
+        '  Error inserting result for 123456 (True): Request failed (status: 503)'
+
+
+def test_has_supplier_submitted_services_for_some_services(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {
+        "services": [{"status": "submitted"}, {"status": "submitted"}]
+    }
+    assert has_supplier_submitted_services(mock_data_client, 'g-spot-7', 12345) is True
+
+
+def test_has_supplier_submitted_services_for_no_services(mock_data_client):
+    mock_data_client.find_draft_services.return_value = {
+        "services": [{"status": "not-submitted"}]
+    }
+    assert has_supplier_submitted_services(mock_data_client, 'g-spot-7', 12345) is False

--- a/tests/test_insert_dos_framework_results.py
+++ b/tests/test_insert_dos_framework_results.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import pytest
 
 from collections import OrderedDict
-from dmscripts.insert_dos_framework_results import insert_result, check_service_essentials, get_submitted_drafts, \
-    check_declaration_answers, process_submitted_drafts, process_dos_results
+from dmscripts.insert_dos_framework_results import check_service_essentials, check_declaration_answers, \
+    process_submitted_drafts, process_dos_results
 from mock import mock
-from dmapiclient import HTTPError
 
 
 VALID_COMPLETE_DOS_DECLARATION = {
@@ -223,33 +221,6 @@ COMPLETE_RESEARCH_PARTICIPANTS_DRAFT = {
     "createdAt": "2016-01-19T09:25:27.006661Z",
     "anonymousRecruitment": True
 }
-
-
-def test_insert_result_calls_with_correct_arguments(mock_data_client):
-    assert insert_result(mock_data_client, 123456, True, 'user') == '  Result set OK: 123456'
-    mock_data_client.set_framework_result.assert_called_with(123456, 'digital-outcomes-and-specialists', True, 'user')
-
-
-def test_insert_result_returns_error_message_if_update_fails(mock_data_client):
-    mock_data_client.set_framework_result.side_effect = HTTPError()
-    assert insert_result(mock_data_client, 123456, True, 'user') == \
-        '  Error inserting result for 123456 (True): Request failed (status: 503)'
-
-
-def test_get_submitted_drafts_calls_with_correct_arguments(mock_data_client):
-    mock_data_client.find_draft_services.return_value = {'services': []}
-    get_submitted_drafts(mock_data_client, 12345)
-    mock_data_client.find_draft_services.assert_called_with(12345, framework='digital-outcomes-and-specialists')
-
-
-def test_get_submitted_drafts_returns_submitted_services_only(mock_data_client):
-    mock_data_client.find_draft_services.return_value = {'services': [
-                                                        {"id": 1, "status": "not-submitted"},
-                                                        {"id": 2, "status": "submitted"}
-        ]
-    }
-    result = get_submitted_drafts(mock_data_client, 12345)
-    assert (result == [{"id": 2, "status": "submitted"}])
 
 
 def test_check_service_essentials_passes_good_drafts():

--- a/tests/test_insert_g8_framework_results.py
+++ b/tests/test_insert_g8_framework_results.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from dmscripts.insert_g8_framework_results import insert_result, get_submitted_drafts, check_declaration_answers, \
-    has_supplier_submitted_services, process_g8_results
-from mock import mock
-from dmapiclient import HTTPError
+from dmscripts.insert_g8_framework_results import check_declaration_answers, process_g8_results
 
 
 VALID_COMPLETE_G8_DECLARATION = {
@@ -66,33 +63,6 @@ VALID_COMPLETE_G8_DECLARATION = {
 }
 
 
-def test_insert_result_calls_with_correct_arguments(mock_data_client):
-    assert insert_result(mock_data_client, 123456, True, 'user') == '  Result set OK: 123456'
-    mock_data_client.set_framework_result.assert_called_with(123456, 'g-cloud-8', True, 'user')
-
-
-def test_insert_result_returns_error_message_if_update_fails(mock_data_client):
-    mock_data_client.set_framework_result.side_effect = HTTPError()
-    assert insert_result(mock_data_client, 123456, True, 'user') == \
-        '  Error inserting result for 123456 (True): Request failed (status: 503)'
-
-
-def test_get_submitted_drafts_calls_with_correct_arguments(mock_data_client):
-    mock_data_client.find_draft_services.return_value = {'services': []}
-    get_submitted_drafts(mock_data_client, 12345)
-    mock_data_client.find_draft_services.assert_called_with(12345, framework='g-cloud-8')
-
-
-def test_get_submitted_drafts_returns_submitted_services_only(mock_data_client):
-    mock_data_client.find_draft_services.return_value = {'services': [
-                                                        {"id": 1, "status": "not-submitted"},
-                                                        {"id": 2, "status": "submitted"}
-        ]
-    }
-    result = get_submitted_drafts(mock_data_client, 12345)
-    assert (result == [{"id": 2, "status": "submitted"}])
-
-
 def test_check_declaration_fails_incomplete_declaration():
     declaration = {"status": "started"}
     assert check_declaration_answers(declaration) == 'Fail'
@@ -135,20 +105,6 @@ def test_check_declaration_answers_fails_for_bad_yes_or_na():
     declaration = VALID_COMPLETE_G8_DECLARATION.copy()
     declaration['employersInsurance'] = "No"
     assert check_declaration_answers(declaration) == 'Fail'
-
-
-def test_has_supplier_submitted_services_for_some_services(mock_data_client):
-    mock_data_client.find_draft_services.return_value = {
-        "services": [{"status": "submitted"}, {"status": "submitted"}]
-    }
-    assert has_supplier_submitted_services(mock_data_client, 12345) is True
-
-
-def test_has_supplier_submitted_services_for_no_services(mock_data_client):
-    mock_data_client.find_draft_services.return_value = {
-        "services": [{"status": "not-submitted"}]
-    }
-    assert has_supplier_submitted_services(mock_data_client, 12345) is False
 
 
 def test_process_g8_results_for_successful(mock_data_client):


### PR DESCRIPTION
~~The previous version of this script only updated results for DOS.  This can now be used for any framework.~~

Useful for completing these chores: 
https://www.pivotaltracker.com/story/show/126020263
https://www.pivotaltracker.com/story/show/126119097

This has grown a bit since initial PR- I've extracted some common methods into a  `framework_utils` file and adjusted existing scripts accordingly, and also tweaked the `make-g-cloud-live` script to work for the new document paths for G-Cloud 8 (this is legit because it should be the same for new frameworks going forward).