### PR TITLE
Update clear-signed-agreements script

### DIFF
--- a/scripts/clear-signed-agreements.py
+++ b/scripts/clear-signed-agreements.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
 
     if arguments.get('<supplier_id_file>'):
         with open(arguments['<supplier_id_file>'], 'r') as f:
-            supplier_ids = filter(None, [int(l.strip()) for l in f.readlines()])
+            supplier_ids = list(filter(None, [int(l.strip()) for l in f.readlines()]))
     else:
         supplier_ids = None
 

--- a/scripts/clear-signed-agreements.py
+++ b/scripts/clear-signed-agreements.py
@@ -12,12 +12,15 @@ This should be run before the new agreements are uploaded: this way there's no r
 new agreements signed by the suppliers.
 
 Usage:
-    scripts/oneoff/clear-signed-agreements.py <stage> <framework_slug> --api-token=<api_access_token>
-        [--supplier_ids=<supplier_ids>]
+    scripts/clear-signed-agreements.py <stage> <framework_slug> --api-token=<api_access_token>
+    [<supplier_id_file>] [<cutoff_time>]
+
+Arguments:
+    <cutoff_time>  if set, the script will only remove agreements uploaded before the given timestamp.
+                   This should be a valid ISO 8601 string (eg 2016-08-22T00:00:00.00000Z)
 
 Options:
     --api-token=<api_access_token>  API token
-    --supplier_ids=<supplier_ids>   Suppliers to target (comma-separated)
 
 """
 import sys
@@ -25,7 +28,6 @@ sys.path.insert(0, '.')
 
 import re
 import getpass
-import csv
 
 from docopt import docopt
 
@@ -37,7 +39,7 @@ from dmscripts.env import get_api_endpoint_from_stage
 logger = logging.configure_logger()
 
 
-def main(stage, framework_slug, api_token, user, supplier_ids=None):
+def main(stage, framework_slug, api_token, user, supplier_ids=None, cutoff_time=None):
     agreements_bucket_name = 'digitalmarketplace-agreements-{0}-{0}'.format(stage)
     agreements_bucket = S3(agreements_bucket_name)
 
@@ -46,27 +48,31 @@ def main(stage, framework_slug, api_token, user, supplier_ids=None):
         api_token
     )
 
-    if supplier_ids is not None:
-        supplier_ids = [int(supplier_id.strip()) for supplier_id in supplier_ids.split(',')]
-
     suppliers = api_client.find_framework_suppliers(framework_slug, agreement_returned=True)['supplierFrameworks']
 
     if supplier_ids is not None:
-        missing_supplier_ids = set(supplier_ids) - set(supplier['supplierId'] for supplier in suppliers)
-        if missing_supplier_ids:
-            raise Exception("Invalid supplier IDs: {}".format(', '.join(str(x) for x in missing_supplier_ids)))
-    else:
-        supplier_ids = set(supplier['supplierId'] for supplier in suppliers)
+        suppliers = [
+            supplier for supplier in suppliers
+            if supplier['supplierId'] in supplier_ids
+            and (not cutoff_time or supplier['agreementReturnedAt'] < cutoff_time)
+        ]
+        supplier_ids = [supplier['supplierId'] for supplier in suppliers]
 
-    for supplier_id in supplier_ids:
-        logger.info("Resetting agreement returned flag for supplier {supplier_id}",
-                    extra={'supplier_id': supplier_id})
-        api_client.unset_framework_agreement_returned(supplier_id, framework_slug, user)
+    for supplier in suppliers:
+        logger.info("Resetting agreement returned flag for supplier {supplier_id} returned at {returned_at}",
+                    extra={'supplier_id': supplier['supplierId'], 'returned_at': supplier['agreementReturnedAt']})
+        api_client.unset_framework_agreement_returned(supplier['supplierId'], framework_slug, user)
 
     signed_agreements = filter(
-        lambda x: match_signed_agreements(supplier_ids, x['path']),
+        lambda x: re.search(r'/(\d+)-signed-framework-agreement.', x['path']),
         agreements_bucket.list('{}/agreements/'.format(framework_slug))
     )
+
+    if supplier_ids is not None:
+        signed_agreements = [
+            agreement for agreement in signed_agreements
+            if int(re.search(r'/(\d+)-signed-framework-agreement', agreement['path']).group(1)) in supplier_ids
+        ]
 
     for document in signed_agreements:
         logger.info("Deleting {path}", extra={'path': document['path']})
@@ -83,8 +89,13 @@ if __name__ == '__main__':
     stage = arguments['<stage>']
     framework_slug = arguments['<framework_slug>']
     data_api_access_token = arguments['--api-token']
-    supplier_ids = arguments['--supplier_ids']
 
     user = getpass.getuser()
 
-    main(stage, framework_slug, data_api_access_token, user, supplier_ids)
+    if arguments.get('<supplier_id_file>'):
+        with open(arguments['<supplier_id_file>'], 'r') as f:
+            supplier_ids = filter(None, [int(l.strip()) for l in f.readlines()])
+    else:
+        supplier_ids = None
+
+    main(stage, framework_slug, data_api_access_token, user, supplier_ids, arguments.get('<cutoff_time>'))


### PR DESCRIPTION
This is the version we've run to remove G8 signed agreements after
fixing lot numbering. It adds <cutoff_time> support to only remove
agreements uploaded before given time.