### PR TITLE
Notify buyers when briefs close

### DIFF
--- a/dmscripts/email.py
+++ b/dmscripts/email.py
@@ -1,14 +1,4 @@
-import io
-from jinja2 import Template
-
 from mandrill import Mandrill
-
-
-def render_html(template_path, data=None):
-    with io.open(template_path, encoding='UTF-8') as htmlfile:
-        html = htmlfile.read()
-        template = Template(html)
-        return template.render(data or {})
 
 
 def get_sent_emails(mandrill_api_key, tags, date_from=None):

--- a/dmscripts/email.py
+++ b/dmscripts/email.py
@@ -1,0 +1,11 @@
+import io
+from jinja2 import Template
+
+from mandrill import Mandrill
+
+
+def render_html(template_path, data=None):
+    with io.open(template_path, encoding='UTF-8') as htmlfile:
+        html = htmlfile.read()
+        template = Template(html)
+        return template.render(data or {})

--- a/dmscripts/email.py
+++ b/dmscripts/email.py
@@ -9,3 +9,9 @@ def render_html(template_path, data=None):
         html = htmlfile.read()
         template = Template(html)
         return template.render(data or {})
+
+
+def get_sent_emails(mandrill_api_key, tags, date_from=None):
+    mandrill_client = Mandrill(mandrill_api_key)
+
+    return mandrill_client.messages.search(tags=tags, date_from=date_from, limit=1000)

--- a/dmscripts/generate_agreement_signature_pages.py
+++ b/dmscripts/generate_agreement_signature_pages.py
@@ -3,14 +3,8 @@ import io
 import shutil
 import re
 import subprocess
-from jinja2 import Template
 
-
-def render_html(data, template_path):
-    with io.open(template_path, encoding='UTF-8') as htmlfile:
-        html = htmlfile.read()
-        template = Template(html)
-        return template.render(data)
+from .email import render_html
 
 
 def save_page(html, supplier_id, output_dir):
@@ -28,7 +22,7 @@ def render_html_for_successful_suppliers(rows, framework, template_dir, output_d
         if data['on_framework'] is False:
             continue
         data['appliedLots'] = filter(lambda lot: int(data[lot]) > 0, ['saas', 'paas', 'iaas', 'scs'])
-        html = render_html(data, template_path)
+        html = render_html(template_path, data)
         save_page(html, data['supplier_id'], output_dir)
     shutil.copyfile(template_css_path, os.path.join(output_dir, '{}-signature-page.css'.format(framework)))
 

--- a/dmscripts/generate_agreement_signature_pages.py
+++ b/dmscripts/generate_agreement_signature_pages.py
@@ -4,7 +4,7 @@ import shutil
 import re
 import subprocess
 
-from .email import render_html
+from .html import render_html
 
 
 def save_page(html, supplier_id, output_dir):

--- a/dmscripts/html.py
+++ b/dmscripts/html.py
@@ -1,0 +1,9 @@
+import io
+from jinja2 import Template
+
+
+def render_html(template_path, data=None):
+    with io.open(template_path, encoding='UTF-8') as htmlfile:
+        html = htmlfile.read()
+        template = Template(html)
+        return template.render(data or {})

--- a/dmscripts/notify_buyers_when_requirements_close.py
+++ b/dmscripts/notify_buyers_when_requirements_close.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime, timedelta
+
+import dmapiclient
+from dmutils.formats import DATE_FORMAT, DATETIME_FORMAT
+from dmutils.email import send_email, MandrillException
+
+from .email import render_html, get_sent_emails
+
+from . import logging
+
+logger = logging.configure_logger({'dmapiclient': logging.INFO})
+
+
+def get_closed_briefs(data_api_client, closed_at):
+    return [
+        brief for brief in data_api_client.find_briefs_iter(status='closed', with_users=True)
+        if datetime.strptime(brief['applicationsClosedAt'], DATETIME_FORMAT).date() == closed_at
+    ]
+
+
+def notify_users(email_api_key, brief):
+    logger.info("Notifying users about brief ID: {brief_id} - '{brief_title}'",
+                extra={'brief_title': brief['title'], 'brief_id': brief['id']})
+    for user in brief['users']:
+        try:
+            email_body = render_html('email_templates/requirements_closed.html', data={
+                'brief_id': brief['id'],
+                'brief_title': brief['title'],
+                'lot_slug': brief['lotSlug'],
+                'framework_slug': brief['frameworkSlug']
+            })
+            send_email(
+                [user['emailAddress'] for user in brief['users'] if user['active']],
+                email_body,
+                email_api_key,
+                u'Next steps for your ‘{}’ requirements'.format(brief['title']),
+                'enquiries@digitalmarketplace.service.gov.uk',
+                'Digital Marketplace Admin',
+                ['requirements-closed'],
+                metadata={'brief_id': brief['id']},
+                logger=logger
+            )
+
+            return True
+        except MandrillException as e:
+            logger.error(
+                "Email failed to send for brief_id: {brief_id}",
+                extra={'error': e, 'brief_id': brief['id']}
+            )
+
+            return False
+
+
+def get_closed_at(closed_at):
+    if closed_at is None:
+        return (datetime.utcnow() - timedelta(days=1)).date()
+    else:
+        return datetime.strptime(closed_at, DATE_FORMAT).date()
+
+
+def get_notified_briefs(email_api_key, closed_at):
+    return set(
+        email['metadata']['brief_id']
+        for email in get_sent_emails(email_api_key, ['requirements-closed'], date_from=closed_at.isoformat())
+        if 'brief_id' in (email.get('metadata') or {})
+    )
+
+
+def main(data_api_url, data_api_access_token, email_api_key, closed_at, dry_run):
+    logger.info("Data API URL: {data_api_url}", extra={'data_api_url': data_api_url})
+
+    closed_at = get_closed_at(closed_at)
+    if closed_at < (datetime.utcnow() - timedelta(days=8)).date():
+        logger.error('Not allowed to notify about briefs that closed more than a week ago')
+        return False
+
+    data_api_client = dmapiclient.DataAPIClient(data_api_url, data_api_access_token)
+
+    closed_briefs = get_closed_briefs(data_api_client, closed_at)
+    if not closed_briefs:
+        logger.info("No briefs closed on {closed_at}", extra={"closed_at": closed_at})
+        return True
+
+    logger.info("Notifying users about {briefs_count} closed briefs", extra={'briefs_count': len(closed_briefs)})
+
+    notified_briefs = get_notified_briefs(email_api_key, closed_at)
+
+    logger.info('Brief notifications sent since {closed_at}: {notified_briefs_count}',
+                extra={'closed_at': closed_at, 'notified_briefs_count': len(notified_briefs)})
+
+    for brief in closed_briefs:
+        if brief['id'] in notified_briefs:
+            logger.info('Brief notification already sent for brief ID: {brief_id}', extra={'brief_id': brief['id']})
+        elif dry_run:
+            logger.info("Would notify users about brief ID: {brief_id}", extra={'brief_id': brief['id']})
+        else:
+            status = notify_users(email_api_key, brief)
+            if not status:
+                return False
+
+    return True

--- a/dmscripts/notify_buyers_when_requirements_close.py
+++ b/dmscripts/notify_buyers_when_requirements_close.py
@@ -6,7 +6,8 @@ import dmapiclient
 from dmutils.formats import DATE_FORMAT, DATETIME_FORMAT
 from dmutils.email import send_email, MandrillException
 
-from .email import render_html, get_sent_emails
+from .email import get_sent_emails
+from .html import render_html
 
 from . import logging
 

--- a/dmscripts/notify_buyers_when_requirements_close.py
+++ b/dmscripts/notify_buyers_when_requirements_close.py
@@ -14,10 +14,10 @@ from . import logging
 logger = logging.configure_logger({'dmapiclient': logging.INFO})
 
 
-def get_closed_briefs(data_api_client, closed_at):
+def get_closed_briefs(data_api_client, date_closed):
     return [
         brief for brief in data_api_client.find_briefs_iter(status='closed', with_users=True)
-        if datetime.strptime(brief['applicationsClosedAt'], DATETIME_FORMAT).date() == closed_at
+        if datetime.strptime(brief['applicationsClosedAt'], DATETIME_FORMAT).date() == date_closed
     ]
 
 
@@ -54,42 +54,42 @@ def notify_users(email_api_key, brief):
             return False
 
 
-def get_closed_at(closed_at):
-    if closed_at is None:
+def get_date_closed(date_closed):
+    if date_closed is None:
         return (datetime.utcnow() - timedelta(days=1)).date()
     else:
-        return datetime.strptime(closed_at, DATE_FORMAT).date()
+        return datetime.strptime(date_closed, DATE_FORMAT).date()
 
 
-def get_notified_briefs(email_api_key, closed_at):
+def get_notified_briefs(email_api_key, date_closed):
     return set(
         email['metadata']['brief_id']
-        for email in get_sent_emails(email_api_key, ['requirements-closed'], date_from=closed_at.isoformat())
+        for email in get_sent_emails(email_api_key, ['requirements-closed'], date_from=date_closed.isoformat())
         if 'brief_id' in (email.get('metadata') or {})
     )
 
 
-def main(data_api_url, data_api_access_token, email_api_key, closed_at, dry_run):
+def main(data_api_url, data_api_access_token, email_api_key, date_closed, dry_run):
     logger.info("Data API URL: {data_api_url}", extra={'data_api_url': data_api_url})
 
-    closed_at = get_closed_at(closed_at)
-    if closed_at < (datetime.utcnow() - timedelta(days=8)).date():
+    date_closed = get_date_closed(date_closed)
+    if date_closed < (datetime.utcnow() - timedelta(days=8)).date():
         logger.error('Not allowed to notify about briefs that closed more than a week ago')
         return False
 
     data_api_client = dmapiclient.DataAPIClient(data_api_url, data_api_access_token)
 
-    closed_briefs = get_closed_briefs(data_api_client, closed_at)
+    closed_briefs = get_closed_briefs(data_api_client, date_closed)
     if not closed_briefs:
-        logger.info("No briefs closed on {closed_at}", extra={"closed_at": closed_at})
+        logger.info("No briefs closed on {date_closed}", extra={"date_closed": date_closed})
         return True
 
     logger.info("Notifying users about {briefs_count} closed briefs", extra={'briefs_count': len(closed_briefs)})
 
-    notified_briefs = get_notified_briefs(email_api_key, closed_at)
+    notified_briefs = get_notified_briefs(email_api_key, date_closed)
 
-    logger.info('Brief notifications sent since {closed_at}: {notified_briefs_count}',
-                extra={'closed_at': closed_at, 'notified_briefs_count': len(notified_briefs)})
+    logger.info('Brief notifications sent since {date_closed}: {notified_briefs_count}',
+                extra={'date_closed': date_closed, 'notified_briefs_count': len(notified_briefs)})
 
     for brief in closed_briefs:
         if brief['id'] in notified_briefs:

--- a/email_templates/requirements_closed.html
+++ b/email_templates/requirements_closed.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+</head>
+<body>
+Dear buyer,
+<br /><br />
+Your '{{ brief_title }}' requirements are now closed for applications.
+<br /><br />
+You can see a list of the suppliers that met all your essential skills and experience at: <a href="https://www.digitalmarketplace.service.gov.uk/buyers/frameworks/{{ framework_slug }}/requirements/{{ lot_slug }}/{{ brief_id }}/responses">https://www.digitalmarketplace.service.gov.uk/buyers/frameworks/{{ framework_slug }}/requirements/{{ lot_slug }}/{{ brief_id }}/responses</a>
+<br /><br />
+Next, you'll need to shortlist and evaluate them.
+<br /><br />
+Read about:
+<br /><br />
+how to shortlist suppliers at: <a href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers</a> <br />
+how to evaluate suppliers at: <a href="https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers">https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers</a> <br />
+ways to assess suppliers at: <a href="https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers">https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers</a> <br />
+how to score suppliers at: <a href="https://www.gov.uk/guidance/how-to-score-digital-outcomes-and-specialists-suppliers">https://www.gov.uk/guidance/how-to-score-digital-outcomes-and-specialists-suppliers</a>
+<br /><br />
+You can find templates to help you at: <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-templates-and-legal-documents">https://www.gov.uk/guidance/digital-outcomes-and-specialists-templates-and-legal-documents</a>
+<br /><br />
+Make sure you notify any unsuccessful suppliers who don't make it through to the next stage.
+<br /><br />
+Thanks, <br />
+The Digital Marketplace team
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.3.0#egg=digitalmarketplace-utils==19.3.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.3.0#egg=digitalmarketplace-apiclient==3.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@21.7.0#egg=digitalmarketplace-utils==21.7.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.2.0#egg=digitalmarketplace-apiclient==6.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.0#egg=digitalmarketplace-content-loader==1.0.0
 
 unicodecsv==0.14.1
 python-dateutil==2.4.2

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,3 +2,4 @@
 pytest==2.7.0
 pep8==1.5.7
 mock==1.3.0
+freezegun==0.3.7

--- a/scripts/export-dos-outcomes.py
+++ b/scripts/export-dos-outcomes.py
@@ -18,7 +18,7 @@ from dmscripts.export_dos_suppliers import (
     find_services_by_lot, FRAMEWORK_SLUG, make_fields_from_content_questions, write_csv
 )
 from dmapiclient import DataAPIClient
-from dmutils.content_loader import ContentLoader
+from dmcontent.content_loader import ContentLoader
 
 
 def find_all_outcomes(client):

--- a/scripts/export-dos-participants.py
+++ b/scripts/export-dos-participants.py
@@ -14,7 +14,7 @@ from dmscripts.export_dos_suppliers import (
     FRAMEWORK_SLUG, find_services_by_lot, make_fields_from_content_questions, write_csv
 )
 from dmapiclient import DataAPIClient
-from dmutils.content_loader import ContentLoader
+from dmcontent.content_loader import ContentLoader
 from dmscripts.logging import configure_logger, WARNING
 
 logger = configure_logger({"dmapiclient": WARNING})

--- a/scripts/export-dos-specialists.py
+++ b/scripts/export-dos-specialists.py
@@ -20,7 +20,7 @@ from dmscripts.export_dos_suppliers import (
     find_services_by_lot, FRAMEWORK_SLUG, make_fields_from_content_questions, write_csv
 )
 from dmapiclient import DataAPIClient
-from dmutils.content_loader import ContentLoader
+from dmcontent.content_loader import ContentLoader
 from dmscripts.logging import configure_logger, WARNING
 
 logger = configure_logger({"dmapiclient": WARNING})

--- a/scripts/export-dos-suppliers.py
+++ b/scripts/export-dos-suppliers.py
@@ -23,7 +23,7 @@ from docopt import docopt
 from dmscripts.env import get_api_endpoint_from_stage
 from dmscripts.export_dos_suppliers import export_suppliers
 from dmapiclient import DataAPIClient
-from dmutils.content_loader import ContentLoader
+from dmcontent.content_loader import ContentLoader
 
 
 if __name__ == '__main__':

--- a/scripts/export-g8-suppliers.py
+++ b/scripts/export-g8-suppliers.py
@@ -23,7 +23,7 @@ from docopt import docopt
 from dmscripts.env import get_api_endpoint_from_stage
 from dmscripts.export_g8_suppliers import export_suppliers
 from dmapiclient import DataAPIClient
-from dmutils.content_loader import ContentLoader
+from dmcontent.content_loader import ContentLoader
 
 
 if __name__ == '__main__':

--- a/scripts/generate-questions-csv.py
+++ b/scripts/generate-questions-csv.py
@@ -14,7 +14,7 @@ import sys
 sys.path.insert(0, '.')
 
 from docopt import docopt
-from dmutils.content_loader import ContentLoader
+from dmcontent.content_loader import ContentLoader
 from dmscripts.generate_questions_csv import generate_csv
 
 if __name__ == '__main__':

--- a/scripts/notify-buyers-when-requirements-close.py
+++ b/scripts/notify-buyers-when-requirements-close.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+"""Send email notifications to buyer users about closed requirements.
+
+Usage:
+    notify-buyers-when-requirements-close.py <stage> --api-token=<api_access_token>
+                                                     --email-api-key=<email_api_key> [options]
+
+    --closed-at=<date>  Notify about requirements that closed on the given date (date format: YYYY-MM-DD)
+    --dry-run  List notifications that would be sent without sending the emails
+
+"""
+
+import sys
+
+from docopt import docopt
+
+sys.path.insert(0, '.')
+from dmscripts.env import get_api_endpoint_from_stage
+from dmscripts.notify_buyers_when_requirements_close import main
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+    ok = main(
+        data_api_url=get_api_endpoint_from_stage(arguments['<stage>'], 'api'),
+        data_api_access_token=arguments['--api-token'],
+        email_api_key=arguments['--email-api-key'],
+        closed_at=arguments['--closed-at'],
+        dry_run=arguments['--dry-run']
+    )
+
+    if not ok:
+        sys.exit(1)

--- a/scripts/notify-buyers-when-requirements-close.py
+++ b/scripts/notify-buyers-when-requirements-close.py
@@ -6,7 +6,7 @@ Usage:
     notify-buyers-when-requirements-close.py <stage> --api-token=<api_access_token>
                                                      --email-api-key=<email_api_key> [options]
 
-    --closed-at=<date>  Notify about requirements that closed on the given date (date format: YYYY-MM-DD)
+    --date-closed=<date>  Notify about requirements that closed on the given date (date format: YYYY-MM-DD)
     --dry-run  List notifications that would be sent without sending the emails
 
 """
@@ -26,7 +26,7 @@ if __name__ == "__main__":
         data_api_url=get_api_endpoint_from_stage(arguments['<stage>'], 'api'),
         data_api_access_token=arguments['--api-token'],
         email_api_key=arguments['--email-api-key'],
-        closed_at=arguments['--closed-at'],
+        date_closed=arguments['--date-closed'],
         dry_run=arguments['--dry-run']
     )
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,14 @@
+class FakeMail(object):
+    """An object that equals strings containing all of the given substrings
+
+    Can be used in mock.call comparisons (eg to verify email templates).
+
+    """
+    def __init__(self, *substrings):
+        self.substrings = substrings
+
+    def __eq__(self, other):
+        return all(substring in other for substring in self.substrings)
+
+    def __repr__(self):
+        return "<FakeMail: {}>".format(self.substrings)

--- a/tests/test_export_dos_suppliers.py
+++ b/tests/test_export_dos_suppliers.py
@@ -7,7 +7,7 @@ from mock import Mock, call, patch, ANY, mock_open
 from dmscripts import export_dos_suppliers
 from dmscripts.insert_dos_framework_results import CORRECT_DECLARATION_RESPONSES
 from dmapiclient import HTTPError
-from dmutils.content_loader import ContentQuestion
+from dmcontent.content_loader import ContentQuestion
 
 
 def test_find_suppliers_produces_results_with_supplier_ids(mock_data_client):

--- a/tests/test_export_g8_suppliers.py
+++ b/tests/test_export_g8_suppliers.py
@@ -4,7 +4,7 @@ from mock import Mock, call, patch, ANY, mock_open
 
 from dmscripts import export_g8_suppliers
 from dmapiclient import HTTPError
-from dmutils.content_loader import ContentQuestion
+from dmcontent.content_loader import ContentQuestion
 
 
 def test_find_suppliers_produces_results_with_supplier_ids(mock_data_client):

--- a/tests/test_generate_questions_csv.py
+++ b/tests/test_generate_questions_csv.py
@@ -1,4 +1,4 @@
-from dmutils.content_loader import ContentSection
+from dmcontent.content_loader import ContentSection
 from dmscripts.generate_questions_csv import get_questions, return_rows_for_sections
 
 

--- a/tests/test_notify_buyers_when_requirements_close.py
+++ b/tests/test_notify_buyers_when_requirements_close.py
@@ -1,0 +1,186 @@
+import pytest
+import mock
+from freezegun import freeze_time
+
+import datetime
+
+from dmscripts.notify_buyers_when_requirements_close import (
+    get_closed_briefs,
+    get_closed_at,
+    get_notified_briefs,
+    notify_users,
+    MandrillException,
+    main
+)
+
+from .helpers import FakeMail
+
+
+def test_get_closed_briefs_filters_by_closed_at():
+    api_client = mock.Mock()
+    api_client.find_briefs_iter.return_value = iter([
+        {"applicationsClosedAt": "2016-09-03T23:59:59.000000Z", "status": "closed"},
+        {"applicationsClosedAt": "2016-09-04T23:59:59.000000Z", "status": "closed"},
+        {"applicationsClosedAt": "2016-09-05T23:59:59.000000Z", "status": "closed"},
+        {"applicationsClosedAt": "2016-09-06T23:59:59.000000Z", "status": "closed"},
+        {"applicationsClosedAt": "2016-09-07T23:59:59.000000Z", "status": "closed"},
+        {"applicationsClosedAt": "2016-09-08T23:59:59.000000Z", "status": "closed"},
+        {"applicationsClosedAt": "2016-09-05T23:59:59.000000Z", "status": "closed"},
+        {"applicationsClosedAt": "2016-09-09T23:59:59.000000Z", "status": "closed"},
+        {"applicationsClosedAt": "2016-09-05T23:59:59.000000Z", "status": "closed"},
+    ])
+
+    assert get_closed_briefs(api_client, datetime.date(2016, 9, 5)) == [
+        {"applicationsClosedAt": "2016-09-05T23:59:59.000000Z", "status": "closed"},
+        {"applicationsClosedAt": "2016-09-05T23:59:59.000000Z", "status": "closed"},
+        {"applicationsClosedAt": "2016-09-05T23:59:59.000000Z", "status": "closed"},
+    ]
+
+
+def test_get_closed_at():
+    def check_closed_at(value, expected):
+        with freeze_time('2015-01-02 03:04:05'):
+            assert get_closed_at(value) == expected
+
+    for value, expected in [
+        (None, datetime.date(2015, 1, 1)),
+        ('2016-01-02', datetime.date(2016, 1, 2))
+    ]:
+        yield check_closed_at, value, expected
+
+
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_sent_emails')
+def test_get_notified_briefs(get_sent_emails):
+    get_sent_emails.return_value = [
+        {},
+        {'metadata': {'brief_id': 100}},
+        {'metadata': {'brief_id': 200}},
+        {'metadata': {'brief_id': 300}},
+        {'metadata': None},
+    ]
+
+    assert get_notified_briefs('KEY', datetime.date(2015, 1, 2)) == set([100, 200, 300])
+    get_sent_emails.assert_called_once_with('KEY', ['requirements-closed'], date_from='2015-01-02')
+
+
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.send_email')
+def test_notify_users(send_email):
+    notify_users('KEY', {
+        'id': 100,
+        'title': 'My brief title',
+        'lotSlug': 'lot-slug',
+        'frameworkSlug': 'framework-slug',
+        'users': [
+            {'emailAddress': 'a@example.com', 'active': True},
+            {'emailAddress': 'b@example.com', 'active': False},
+            {'emailAddress': 'c@example.com', 'active': True},
+        ],
+    })
+
+    send_email.assert_called_once_with(
+        ['a@example.com', 'c@example.com'],
+        FakeMail(
+            'My brief title',
+            '/buyers/frameworks/framework-slug/requirements/lot-slug/100/responses'
+        ),
+        'KEY',
+        u'Next steps for your \u2018My brief title\u2019 requirements',
+        'enquiries@digitalmarketplace.service.gov.uk',
+        'Digital Marketplace Admin',
+        ['requirements-closed'],
+        logger=mock.ANY,
+        metadata={'brief_id': 100}
+    )
+
+
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.send_email')
+def test_notify_users_returns_false_on_error(send_email):
+    send_email.side_effect = MandrillException('Error')
+    assert not notify_users('KEY', {
+        'id': 100,
+        'title': 'My brief title',
+        'lotSlug': 'lot-slug',
+        'frameworkSlug': 'framework-slug',
+        'users': [
+            {'emailAddress': 'a@example.com', 'active': True},
+            {'emailAddress': 'b@example.com', 'active': False},
+            {'emailAddress': 'c@example.com', 'active': True},
+        ],
+    })
+
+
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.notify_users')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_notified_briefs')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_closed_briefs')
+def test_main(get_closed_briefs, get_notified_briefs, notify_users):
+    get_notified_briefs.return_value = set([200])
+    get_closed_briefs.return_value = [
+        {'id': 100},
+        {'id': 200},
+        {'id': 300},
+    ]
+
+    notify_users.return_value = True
+
+    with freeze_time('2016-01-02 03:04:05'):
+        assert main('URL', 'API_KEY', 'KEY', '2016-01-02', False)
+    get_closed_briefs.assert_called_once_with(mock.ANY, datetime.date(2016, 1, 2))
+    get_notified_briefs.assert_called_once_with('KEY', datetime.date(2016, 1, 2))
+    notify_users.assert_has_calls([
+        mock.call('KEY', {'id': 100}),
+        mock.call('KEY', {'id': 300}),
+    ])
+
+
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.notify_users')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_notified_briefs')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_closed_briefs')
+def test_main_fails_when_notify_users_fails(get_closed_briefs, get_notified_briefs, notify_users):
+    get_closed_briefs.return_value = [
+        {'id': 100},
+        {'id': 200},
+    ]
+
+    notify_users.return_value = False
+
+    assert not main('URL', 'API_KEY', 'KEY', None, False)
+
+
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.notify_users')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_notified_briefs')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_closed_briefs')
+def test_main_with_no_briefs(get_closed_briefs, get_notified_briefs, notify_users):
+    get_closed_briefs.return_value = []
+
+    assert main('URL', 'API_KEY', 'KEY', None, False)
+    get_notified_briefs.assert_not_called()
+    notify_users.assert_not_called()
+
+
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.notify_users')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_notified_briefs')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_closed_briefs')
+def test_main_doesnt_allow_old_closed_at(get_closed_briefs, get_notified_briefs, notify_users):
+    get_closed_briefs.return_value = [
+        {'id': 100},
+        {'id': 200},
+    ]
+
+    with freeze_time('2016-01-12 03:04:05'):
+        assert not main('URL', 'API_KEY', 'KEY', '2016-01-02', False)
+
+    get_notified_briefs.assert_not_called()
+    notify_users.assert_not_called()
+
+
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.notify_users')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_notified_briefs')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.get_closed_briefs')
+def test_main_dry_run(get_closed_briefs, get_notified_briefs, notify_users):
+    get_closed_briefs.return_value = [
+        {'id': 100},
+        {'id': 200},
+    ]
+
+    assert main('URL', 'API_KEY', 'KEY', None, True)
+    notify_users.assert_not_called()

--- a/tests/test_notify_buyers_when_requirements_close.py
+++ b/tests/test_notify_buyers_when_requirements_close.py
@@ -6,7 +6,7 @@ import datetime
 
 from dmscripts.notify_buyers_when_requirements_close import (
     get_closed_briefs,
-    get_closed_at,
+    get_date_closed,
     get_notified_briefs,
     notify_users,
     MandrillException,
@@ -16,7 +16,7 @@ from dmscripts.notify_buyers_when_requirements_close import (
 from .helpers import FakeMail
 
 
-def test_get_closed_briefs_filters_by_closed_at():
+def test_get_closed_briefs_filters_by_date_closed():
     api_client = mock.Mock()
     api_client.find_briefs_iter.return_value = iter([
         {"applicationsClosedAt": "2016-09-03T23:59:59.000000Z", "status": "closed"},
@@ -37,16 +37,16 @@ def test_get_closed_briefs_filters_by_closed_at():
     ]
 
 
-def test_get_closed_at():
-    def check_closed_at(value, expected):
+def test_get_date_closed():
+    def check_date_closed(value, expected):
         with freeze_time('2015-01-02 03:04:05'):
-            assert get_closed_at(value) == expected
+            assert get_date_closed(value) == expected
 
     for value, expected in [
         (None, datetime.date(2015, 1, 1)),
         ('2016-01-02', datetime.date(2016, 1, 2))
     ]:
-        yield check_closed_at, value, expected
+        yield check_date_closed, value, expected
 
 
 @mock.patch('dmscripts.notify_buyers_when_requirements_close.get_sent_emails')
@@ -160,7 +160,7 @@ def test_main_with_no_briefs(get_closed_briefs, get_notified_briefs, notify_user
 @mock.patch('dmscripts.notify_buyers_when_requirements_close.notify_users')
 @mock.patch('dmscripts.notify_buyers_when_requirements_close.get_notified_briefs')
 @mock.patch('dmscripts.notify_buyers_when_requirements_close.get_closed_briefs')
-def test_main_doesnt_allow_old_closed_at(get_closed_briefs, get_notified_briefs, notify_users):
+def test_main_doesnt_allow_old_date_closed(get_closed_briefs, get_notified_briefs, notify_users):
     get_closed_briefs.return_value = [
         {'id': 100},
         {'id': 200},


### PR DESCRIPTION
* [x] Requires https://github.com/alphagov/digitalmarketplace-utils/pull/279

### Move render_html to dmscripts.email
Rendering html is required for emails, so moving the function from a script-specific dmscripts module.

### Update dmutils and dmapiclient
Includes briefs `with_users` request and `send_email` custom logger. Content loader has been split up since the last time utils were updated, so this adds dmcontent as a new dependency and updates all import paths.

Using 1.0.0 version of content-loader since the latest one breaks tests.

### Add a function to search sent Mandrill messages
Requests tagged messages from Mandrill history. Mandrill stores sent messages for 7 days and filtered by tag we don't expect to send more than 1000 messages so we can avoid adding pagination for now.

Note that messages don't appear in Mandrill search API response until they've been delivered, so rerunning the send script right away will probably end up sending duplicate emails.

### Add a script to notify buyers when requirement closes

![screen shot 2016-08-25 at 17 19 28](https://cloud.githubusercontent.com/assets/246664/18001833/adb16e44-6b7c-11e6-87fc-a8989ce48d8e.png)
![screen shot 2016-08-25 at 17 18 59](https://cloud.githubusercontent.com/assets/246664/18001839/bab682c8-6b7c-11e6-9026-0bf9ea283251.png)

Gets the list of briefs that closed on a given date (yesterday by default) from the API, checks brief IDs against Mandrill history of sent 'requirements-closed' emails and sends notification to brief users for briefs that don't have an email history in Mandrill.

Since briefs aren't ordered by close date we need to download all closed briefs from the API. There are only few pages at the moment, so this shouldn't be a problem for now.

Sent emails don't appear in mandrill history until the message has been delivered, so rerunning the script right away could result in duplicate emails.

Doesn't allow to send notifications for briefs that closed more than a week ago. We probably don't need to notify users about something that happened a long time ago and this helps to avoid typos.

Yesterday is determined from UTC time, so running the script at midnight UTC+1 could be a bit confusing.