### PR TITLE
Get back model data and output to CSV

### DIFF
--- a/dmscripts/models/modeltrawler.py
+++ b/dmscripts/models/modeltrawler.py
@@ -1,0 +1,85 @@
+import time
+import itertools
+import re
+
+
+class ModelTrawler():
+
+    def __init__(self, model, client):
+        self.start = time.time()
+        self.client = client
+        self.model = model
+
+        model_iter_method = "find_{}_iter".format(self.model)
+        if not callable(getattr(self.client, model_iter_method, None)):
+            raise AttributeError(
+                "No model called '{}'. Allowed models are: {}".format(
+                    self.model, list(self._get_allowed_models())
+                )
+            )
+
+        self.model_iter_method = model_iter_method
+
+    def _get_allowed_models(self):
+        r = re.compile('^find_(\w*)_iter$')
+        return (r.match(attr).group(1) for attr in dir(self.client) if r.match(attr))
+
+    def _model_iter(self, **kwargs):
+        for model in getattr(self.client, self.model_iter_method)(**kwargs):
+            yield model
+
+    def _filter_keys(self, _keys=None):
+
+        def _get_nested_values(nested_keys, val):
+            try:
+                return val if not len(nested_keys) else _get_nested_values(nested_keys, val[nested_keys.pop(0)])
+            except (KeyError, IndexError):
+                # objects/arrays might be empty for some returned models
+                return ''
+
+        def _filter_keys_inner(model_dict):
+            """Takes a python dictionary and strips out non-specified keys
+
+            --> IN -->
+            _keys = (
+                'id',
+                ('user', 'emailAddress')
+            )
+            model_dict = {
+                'id': 1,
+                'name': 'Super cloud brief',
+                'user': {'id': 101, 'emailAddress': 'user@gov.uk'}
+            }
+
+            <-- OUT <--
+            {
+                'id': 1,
+                'emailAddress': 'user@gov.uk'
+            }
+
+            """
+
+            if _keys is None:
+                return model_dict
+
+            filtered_dict = {}
+            for key in _keys:
+                if isinstance(key, (list, tuple)):
+                    filtered_dict[key[len(key)-1]] = _get_nested_values(list(key), model_dict)
+                else:
+                    filtered_dict[key] = model_dict.get(key, '')
+
+            return filtered_dict
+
+        return _filter_keys_inner
+
+    def get_data(self, keys=None, limit=None, **kwargs):
+        models = self._model_iter(**kwargs)
+
+        if limit is not None:
+            models = itertools.islice(models, limit)
+
+        return map(self._filter_keys(keys), models)
+
+    def get_time_running(self):
+        return time.time() - self.start

--- a/dmscripts/models/process_rules.py
+++ b/dmscripts/models/process_rules.py
@@ -1,0 +1,6 @@
+from datetime import datetime
+from dmutils.formats import DATE_FORMAT, DATETIME_FORMAT
+
+
+format_datetime_string_as_date = lambda x: datetime.strptime(x, DATETIME_FORMAT).strftime(DATE_FORMAT)
+remove_username_from_email_address = lambda x: '{}'.format(x.split('@').pop())

--- a/dmscripts/models/utils.py
+++ b/dmscripts/models/utils.py
@@ -1,0 +1,34 @@
+import operator
+
+
+def process_collection(rules, collection):
+    if not rules:
+        return collection
+
+    for c in collection:
+        for k, v in rules.items():
+            if c.get(k):
+                c[k] = v(c[k])
+
+
+def return_filtered_collection(rules, collection):
+    if not rules:
+        return collection
+
+    # `contains` would be trickier to include because it switches the argument order
+    ops = {
+        '>': operator.gt,
+        '<': operator.lt,
+        '>=': operator.ge,
+        '<=': operator.le,
+        '==': operator.eq
+    }
+
+    for key, op, to_compare in rules:
+        collection = list(filter(lambda x: ops[op](x[key], to_compare), collection))
+
+    return collection
+
+
+def return_sorted_collection(_key, collection):
+    return sorted(collection, key=lambda x: x[_key]) if _key else collection

--- a/dmscripts/models/writecsv.py
+++ b/dmscripts/models/writecsv.py
@@ -1,0 +1,28 @@
+import sys
+import os
+if sys.version_info[0] < 3:
+    import unicodecsv as csv
+else:
+    import csv
+
+
+def csv_path(output_dir, _filename):
+    return os.path.join(output_dir, '{}.csv'.format(_filename))
+
+
+def write_csv(filename, models, keys=None):
+    if keys is None:
+        keys = sorted(models[0].keys())
+
+    keys = [k[len(k)-1] if isinstance(k, (tuple, list)) else k for k in keys]
+
+    csv_writer = csv.DictWriter(
+        open(filename, 'w+'),
+        fieldnames=keys,
+        delimiter=',',
+        lineterminator='\n',
+        quotechar='"'
+    )
+    csv_writer.writeheader()
+    for m in models:
+        csv_writer.writerow(m)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.7.0#egg=digitalmarketplace-utils==21.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.7.0#egg=digitalmarketplace-apiclient==6.7.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.5.0#egg=digitalmarketplace-apiclient==7.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.0#egg=digitalmarketplace-content-loader==1.0.0
 
 unicodecsv==0.14.1

--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -32,10 +32,11 @@ from dmscripts import logging
 CONFIGS = {
     'buyers': {
         'base_model': 'users',
-        'keys': ('id', 'createdAt', 'role'),
+        'keys': ('id', 'emailAddress', 'createdAt', 'role'),
         'get_data_kwargs': {},
         'process_rules': {
-            'createdAt': format_datetime_string_as_date
+            'emailAddress': remove_username_from_email_address,
+            'createdAt': format_datetime_string_as_date,
         },
         'filter_rules': [
             ('role', '==', 'buyer'),

--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Export a CSV of all models or something
+
+Looks for a corresponding find_{model}_iter() method in the api client and returns
+all of the results in a CSV with only requested keys being used as columns
+Before generating the final csv, it is possible to:
+- filter the list, looking for only those entries with a particular value
+- do some additional processing on a value
+- sort the list
+
+Usage:
+    scripts/get-model-data.py [-h] <stage> <api_token> <model> <output_dir> [--limit=<limit>][-v]
+
+Options:
+    -h --help       Show this screen.
+    -v --verbose    Print apiclient INFO messages.
+"""
+import sys
+sys.path.insert(0, '.')
+
+from docopt import docopt
+from dmapiclient import DataAPIClient
+from dmscripts.env import get_api_endpoint_from_stage
+from dmscripts.models.modeltrawler import ModelTrawler
+from dmscripts.models.utils import process_collection, return_filtered_collection, return_sorted_collection
+from dmscripts.models.process_rules import format_datetime_string_as_date, remove_username_from_email_address
+from dmscripts.models.writecsv import csv_path, write_csv
+
+from dmscripts import logging
+
+
+CONFIGS = {
+    'buyers': {
+        'base_model': 'users',
+        'keys': ('id', 'createdAt', 'role'),
+        'get_data_kwargs': {},
+        'process_rules': {
+            'createdAt': format_datetime_string_as_date
+        },
+        'filter_rules': [
+            ('role', '==', 'buyer'),
+            ('createdAt', '>=', '2016-04-25')
+        ],
+        'sort_by': 'createdAt'
+    },
+    'suppliers': {
+        'base_model': 'users',
+        'keys': ('id', ('supplier', 'supplierId'), 'createdAt', 'role'),
+        'get_data_kwargs': {},
+        'process_rules': {
+            'createdAt': format_datetime_string_as_date
+        },
+        'filter_rules': [
+            ('role', '==', 'supplier'),
+            ('createdAt', '>=', '2016-04-25')
+        ],
+        'sort_by': 'createdAt'
+    },
+    'briefs': {
+        'base_model': 'briefs',
+        'keys': (
+            'id',
+            'createdAt',
+            'lot',
+            'title',
+            'organisation',
+            ('users', 0, 'emailAddress'),
+            'location',
+            'status',
+            'publishedAt',
+            'requirementsLength',
+            'specialistRole'
+        ),
+        'get_data_kwargs': {'with_users': 'true'},
+        'process_rules': {
+            'createdAt': format_datetime_string_as_date,
+            'publishedAt': format_datetime_string_as_date,
+            'emailAddress': remove_username_from_email_address,
+        },
+        'filter_rules': [],
+        'sort_by': 'createdAt'
+    },
+    'brief_responses': {
+        'base_model': 'brief_responses',
+        'keys': (
+            'briefId',
+            'supplierId',
+            'createdAt'
+        ),
+        'get_data_kwargs': {},
+        'process_rules': {
+            'createdAt': format_datetime_string_as_date,
+        },
+        'filter_rules': [],
+        'sort_by': 'createdAt'
+    }
+}
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    STAGE = arguments['<stage>']
+    API_TOKEN = arguments['<api_token>']
+    OUTPUT_DIR = arguments['<output_dir>']
+    MODEL = arguments['<model>']
+
+    limit = int(arguments.get('--limit')) if arguments.get('--limit') else None
+    logging_config = {'dmapiclient': logging.INFO} if bool(arguments.get('--verbose')) \
+        else {'dmapiclient': logging.WARNING}
+    logger = logging.configure_logger(logging_config)
+
+    client = DataAPIClient(get_api_endpoint_from_stage(STAGE), API_TOKEN)
+    config = CONFIGS[MODEL]
+
+    mt = ModelTrawler(config['base_model'], client)
+
+    # run stuff
+    data = list(mt.get_data(keys=config['keys'], limit=limit, **config['get_data_kwargs']))
+    logger.info('{} {} returned after {}s'.format(len(data), config['base_model'], mt.get_time_running()))
+
+    # filter out things we don't want
+    data = return_filtered_collection(config['filter_rules'], data)
+    if 'filter_rules' in config and config['filter_rules']:
+        logger.info('{} {} remaining after filtering collection'.format(len(data), config['base_model']))
+
+    # transform values that we want to transform
+    process_collection(config['process_rules'], data)
+
+    # sort list by some dict value
+    data = return_sorted_collection(config['sort_by'], data)
+
+    # write up your CSV
+    filename = csv_path(OUTPUT_DIR, MODEL)
+    write_csv(filename, data, keys=config['keys'])
+    logger.info('Printed `{}` with {} rows'.format(filename, len(data)))

--- a/tests/models/test_modeltrawler.py
+++ b/tests/models/test_modeltrawler.py
@@ -1,0 +1,105 @@
+import pytest
+import mock
+from dmscripts.models.modeltrawler import ModelTrawler
+
+
+class FakeClient:
+
+    def find_fake_table_iter(self):
+        return True
+
+
+class TestModelTrawlerInit:
+
+    def test_correct_initiation(self):
+        mt = ModelTrawler('fake_table', FakeClient())
+        assert mt.model == 'fake_table'
+        assert mt.model_iter_method == 'find_fake_table_iter'
+
+    def test_cannot_initiate_with_incorrect_model_name(self):
+        with pytest.raises(AttributeError) as excinfo:
+            mt = ModelTrawler('real_table', FakeClient())
+
+    def test_get_allowed_models_returns_allowed_models(self):
+        mt = ModelTrawler('fake_table', FakeClient())
+        assert set(mt._get_allowed_models()) == set(['fake_table'])
+
+
+class TestModelTrawlerMethods:
+
+    model_data = (
+        {
+            'id': 1,
+            'name': 'Super cloud brief',
+            'supplier': {'id': 100, 'name': 'Super cloud supplier'},
+            'users': [{'id': 101, 'emailAddress': 'user@gov.uk', 'name': 'Super cloud user'}]
+        }, {
+            'id': 2,
+            'name': 'Super cloud brief 2',
+            'supplier': {'id': 200, 'name': 'Super cloud supplier 2'},
+            'users': [{'id': 201, 'emailAddress': 'user2@gov.uk', 'name': 'Super cloud user 2'}]
+        }
+    )
+
+    def test_filter_keys(self):
+        keys = (
+            'id',
+            ('supplier', 'name'),
+            ('users', 0, 'emailAddress')
+        )
+
+        initial_model_dict = self.model_data[0].copy()
+
+        expected_model_dict = {
+            'id': 1,
+            'name': 'Super cloud supplier',
+            'emailAddress': 'user@gov.uk'
+        }
+
+        mt = ModelTrawler('fake_table', FakeClient())
+        assert mt._filter_keys(keys)(initial_model_dict) == expected_model_dict
+
+    def test_get_data(self):
+        keys = (
+            'id',
+            ('users', 0, 'emailAddress')
+        )
+
+        expected_model_data = (
+            {'id': 1, 'emailAddress': 'user@gov.uk'},
+            {'id': 2, 'emailAddress': 'user2@gov.uk'}
+        )
+
+        with mock.patch.object(
+            FakeClient, 'find_fake_table_iter', return_value=(m for m in self.model_data)
+        ) as mock_method:
+            mt = ModelTrawler('fake_table', FakeClient())
+            assert tuple(mt.get_data(keys)) == expected_model_data
+
+    def test_get_data_with_limit(self):
+        keys = (
+            'id',
+            ('users', 0, 'emailAddress')
+        )
+
+        expected_model_data = ({'id': 1, 'emailAddress': 'user@gov.uk'},)
+
+        with mock.patch.object(
+            FakeClient, 'find_fake_table_iter', return_value=(m for m in self.model_data)
+        ) as mock_method:
+            mt = ModelTrawler('fake_table', FakeClient())
+            assert tuple(mt.get_data(keys, limit=1)) == expected_model_data
+
+    def test_get_data_with_kwargs(self):
+        _kwargs = {
+            'something_true': True,
+            'something_false': False
+        }
+
+        with mock.patch.object(
+            FakeClient, 'find_fake_table_iter', return_value=(m for m in ({'id': 1}, {'id': 2}))
+        ) as mock_method:
+            mt = ModelTrawler('fake_table', FakeClient())
+            data = list(mt.get_data(('id',), limit=1, **_kwargs))
+            # note that `limit` isn't included as a keyword argument
+            mock_method.assert_called_once_with(something_true=True, something_false=False)

--- a/tests/models/test_process_rules.py
+++ b/tests/models/test_process_rules.py
@@ -1,0 +1,29 @@
+import pytest
+from dmscripts.models.process_rules import format_datetime_string_as_date, remove_username_from_email_address
+
+
+def test_format_datetime_string_as_date():
+    initial_date = "2016-10-08T12:00:00.00000Z"
+    formatted_date = "2016-10-08"
+    assert format_datetime_string_as_date(initial_date) == formatted_date
+
+
+def test_format_datetime_string_as_date_raises_error_if_initial_date_format_incorrect():
+    initial_dates = (
+        "2016-10-08T12:00:00.00000",
+        "2016-10-08T12:00:00",
+        "2016-10-08"
+    )
+    formatted_date = "2016-10-08"
+
+    for date in initial_dates:
+        with pytest.raises(ValueError) as excinfo:
+            format_datetime_string_as_date(date)
+
+        assert "time data '{}' does not match format".format(date) in str(excinfo.value)
+
+
+def test_remove_username_from_email_address():
+    initial_email_address = "user.name@domain.com"
+    formatted_email_address = "domain.com"
+    assert remove_username_from_email_address(initial_email_address) == formatted_email_address

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -1,0 +1,70 @@
+import pytest
+import copy
+from dmscripts.models.utils import process_collection, return_filtered_collection, return_sorted_collection
+
+
+COLLECTION = (
+    {"id": 1, "name": "Don"},
+    {"id": 3, "name": "Peggy"},
+    {"id": 5, "name": "Pete"},
+    {"id": 2, "name": "Betty"},
+    {"id": 4, "name": "Roger"},
+    {"id": 6, "name": "Joan"}
+)
+
+# process_collection tests
+
+
+def test_process_collection():
+    rules = {'id': lambda x: int(x) * 10}
+    processed_collection = copy.deepcopy(COLLECTION)
+    process_collection(rules, processed_collection)
+
+    assert (10, 30, 50, 20, 40, 60) == tuple((i['id'] for i in processed_collection))
+
+
+def test_process_collection_if_rules_are_none():
+    processed_collection = copy.deepcopy(COLLECTION)
+    process_collection({}, processed_collection)
+
+    assert COLLECTION == processed_collection
+
+# return_filtered_collection tests
+
+
+def test_return_filtered_collection():
+    rules = [('id', '>', 3)]
+    filtered_collection = return_filtered_collection(rules, COLLECTION)
+
+    # remove numbers less than 4 from sequence: 1,3,5,2,4,6
+    assert (5, 4, 6) == tuple((i['id'] for i in filtered_collection))
+
+
+def test_return_filtered_collection_if_rules_are_none():
+    assert COLLECTION == return_filtered_collection(None, COLLECTION)
+
+
+def test_return_filtered_collection_if_operator_invalid():
+    rules = [('id', 'contains', 3)]
+    with pytest.raises(KeyError) as excinfo:
+        filtered_collection = return_filtered_collection(rules, COLLECTION)
+
+    assert 'contains' in str(excinfo.value)
+
+# return_sorted_collection tests
+
+
+def test_return_sorted_collection_by_ints():
+    sorted_collection = return_sorted_collection('id', COLLECTION)
+    assert (1, 2, 3, 4, 5, 6) == tuple((i['id'] for i in sorted_collection))
+
+
+def test_return_sorted_collection_by_strings():
+    sorted_collection = return_sorted_collection('name', COLLECTION)
+    assert (
+        'Betty', 'Don', 'Joan', 'Peggy', 'Pete', 'Roger'
+    ) == tuple((i['name'] for i in sorted_collection))
+
+
+def test_return_sorted_collection_if_key_is_none():
+    assert COLLECTION == return_sorted_collection(None, COLLECTION)


### PR DESCRIPTION
Created a class that gets back all table rows from the database using the API and prints them to CSV.  In theory, works for anything with an "iter" method, and in practice works out of the box for `buyers`, `suppliers`, `briefs`, and `brief_responses`.

Ash is asking for weekly printouts of (DOS-related) data, and so this is the first step.  
👉  [This is the data he's looking for](https://docs.google.com/spreadsheets/d/1DlkUYNSDgK1vjNB4LQgKP6AQJD9g89kOAw5MPwTVPqs/edit?ts=57e513ba#gid=0). 👈 

Things left to do in subsequent stories are:
- [Join logic](https://www.pivotaltracker.com/story/show/132760553): (ie, how many applications do we get per published brief)
- [Set up a regular jenkins thing](https://www.pivotaltracker.com/story/show/131737693) that prints out stuff once a week
