### PR TITLE
Script to generate counterpart G-Cloud 8 PDFs

### DIFF
--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -5,6 +5,7 @@ else:
     import csv
 
 from multiprocessing.pool import ThreadPool
+from dmutils.formats import dateformat
 
 
 LOTS = {
@@ -62,10 +63,15 @@ def add_framework_info(client, framework_slug):
         supplier_framework = client.get_supplier_framework_info(record['supplier_id'], framework_slug)
         supplier_framework = supplier_framework['frameworkInterest']
         supplier_framework['declaration'] = supplier_framework['declaration'] or {}
+        supplier_framework['countersignedPath'] = supplier_framework['countersignedPath'] or ''
+        supplier_framework['countersignedAt'] = dateformat(supplier_framework['countersignedAt']) or ''
 
         return dict(record,
                     declaration=supplier_framework['declaration'],
-                    onFramework=supplier_framework['onFramework'])
+                    onFramework=supplier_framework['onFramework'],
+                    countersignedPath=supplier_framework['countersignedPath'],
+                    countersignedAt=supplier_framework['countersignedAt'],
+                    )
 
     return inner
 
@@ -93,6 +99,8 @@ def get_csv_rows(records, framework_slug):
         "supplier_id",
         "supplier_name",
         "on_framework",
+        "countersigned_at",
+        "countersigned_path",
         ] + LOTS[framework_slug] + DECLARATION_FIELDS[framework_slug]
 
     return headers, rows
@@ -103,6 +111,8 @@ def create_row(record, framework_slug):
         'supplier_id': record['supplier']['id'],
         'supplier_name': record['supplier']['name'],
         'on_framework': record['onFramework'],
+        'countersigned_at': record['countersignedAt'],
+        'countersigned_path': record['countersignedPath'],
     }
     row.update({(lot, record['counts'][lot]) for lot in LOTS[framework_slug]})
     row.update(((field, record['declaration'].get(field, "")) for field in DECLARATION_FIELDS[framework_slug]))

--- a/dmscripts/generate_agreement_signature_pages.py
+++ b/dmscripts/generate_agreement_signature_pages.py
@@ -5,6 +5,9 @@ import re
 import subprocess
 
 from .html import render_html
+from . import logging
+
+logger = logging.configure_logger({'dmapiclient.base': logging.WARNING})
 
 
 def save_page(html, supplier_id, output_dir):
@@ -32,8 +35,8 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework, templat
     template_css_path = os.path.join(template_dir, '{}-signature-page.css'.format(framework))
     countersignature_img_path = os.path.join(template_dir, '{}-countersignature.png'.format(framework))
     for data in rows:
-        if data['on_framework'] is False or not data['countersigned_at'] or data['countersigned_path']:
-            print("SKIPPING {}: on_f={} at={} path={}".format(
+        if data['on_framework'] is False or data['countersigned_path'] or not data['countersigned_at']:
+            logger.info("SKIPPING {}: on_fwk={} countersigned_at={} countersigned_path={}".format(
                 data['supplier_id'],
                 data['on_framework'],
                 data['countersigned_at'],
@@ -58,4 +61,4 @@ def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
         pdf_path = '{}'.format(re.sub(html_dir, pdf_dir, pdf_path))
         exit_code = subprocess.call(['wkhtmltopdf', 'file://{}'.format(html_path), pdf_path])
         if exit_code > 0:
-            print("ERROR: {} on {}".format(exit_code, html_page))
+            logger.error("ERROR {} on {}".format(exit_code, html_page))

--- a/dmscripts/generate_agreement_signature_pages.py
+++ b/dmscripts/generate_agreement_signature_pages.py
@@ -27,6 +27,26 @@ def render_html_for_successful_suppliers(rows, framework, template_dir, output_d
     shutil.copyfile(template_css_path, os.path.join(output_dir, '{}-signature-page.css'.format(framework)))
 
 
+def render_html_for_suppliers_awaiting_countersignature(rows, framework, template_dir, output_dir):
+    template_path = os.path.join(template_dir, '{}-counterpart-signature-page.html'.format(framework))
+    template_css_path = os.path.join(template_dir, '{}-signature-page.css'.format(framework))
+    countersignature_img_path = os.path.join(template_dir, '{}-countersignature.png'.format(framework))
+    for data in rows:
+        if data['on_framework'] is False or not data['countersigned_at'] or data['countersigned_path']:
+            print("SKIPPING {}: on_f={} at={} path={}".format(
+                data['supplier_id'],
+                data['on_framework'],
+                data['countersigned_at'],
+                data['countersigned_path'])
+            )
+            continue
+        data['appliedLots'] = filter(lambda lot: int(data[lot]) > 0, ['saas', 'paas', 'iaas', 'scs'])
+        html = render_html(template_path, data)
+        save_page(html, data['supplier_id'], output_dir)
+    shutil.copyfile(template_css_path, os.path.join(output_dir, '{}-signature-page.css'.format(framework)))
+    shutil.copyfile(countersignature_img_path, os.path.join(output_dir, '{}-countersignature.png'.format(framework)))
+
+
 def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
     html_dir = os.path.abspath(html_dir)
     pdf_dir = os.path.abspath(pdf_dir)

--- a/scripts/generate-agreement-signature-pages.py
+++ b/scripts/generate-agreement-signature-pages.py
@@ -17,6 +17,7 @@ Example:
 import sys
 import os
 import shutil
+import tempfile
 
 sys.path.insert(0, '.')
 
@@ -37,9 +38,7 @@ if __name__ == '__main__':
     TEMPLATE_FOLDER = arguments['<template_folder>']
     OUTPUT_FOLDER = arguments['<output_folder>']
 
-    html_dir = os.path.join(OUTPUT_FOLDER, 'html')
-
-    os.makedirs(html_dir)
+    html_dir = tempfile.mkdtemp()
 
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), API_TOKEN)
 

--- a/scripts/generate-agreement-signature-pages.py
+++ b/scripts/generate-agreement-signature-pages.py
@@ -11,7 +11,7 @@ Usage:
     scripts/generate-agreement-signature-pages.py <stage> <api_token> <framework_slug> <template_folder> <output_folder>
 
 Example:
-    generate-agreement-signature-pages.py dev myToken g-cloud-8 ../digitalmarketplace-agreements/documents/g-cloud
+    generate-agreement-signature-pages.py dev myToken g-cloud-8 ../digitalmarketplace-agreements/documents/g-cloud pdfs
 
 """
 import sys

--- a/scripts/generate-agreement-signature-pages.py
+++ b/scripts/generate-agreement-signature-pages.py
@@ -26,7 +26,6 @@ from dmscripts.export_framework_applicant_details import find_suppliers_with_det
 from dmscripts.generate_agreement_signature_pages import render_html_for_successful_suppliers, \
     render_pdf_for_each_html_page
 from dmapiclient import DataAPIClient
-from dmscripts import logging
 
 
 if __name__ == '__main__':
@@ -38,13 +37,9 @@ if __name__ == '__main__':
     TEMPLATE_FOLDER = arguments['<template_folder>']
     OUTPUT_FOLDER = arguments['<output_folder>']
 
-    repo_root = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), '..'))
     html_dir = os.path.join(OUTPUT_FOLDER, 'html')
 
     os.makedirs(html_dir)
-
-    logger = logging.configure_logger()
 
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), API_TOKEN)
 

--- a/scripts/generate-counterpart-signature-pages.py
+++ b/scripts/generate-counterpart-signature-pages.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""Generate framework agreement counterpart signature pages from supplier "about you" information for suppliers
+who applied to a framework.
+
+Currently will only work for framework_slug=g-cloud-8.
+
+To add support for future frameworks we will will need to add to the LOTS and DECLARATION_FIELDS in
+dmscripts/export_framework_applicant_details.py
+
+Usage:
+    scripts/generate-counterpart-signature-pages.py <stage> <api_token> <framework_slug> <template_folder> <out_folder>
+
+Example:
+    generate-counterpart-signature-pages.py dev myToken g-cloud-8 ../digitalmarketplace-agreements/documents/g-cloud pdf
+
+"""
+import sys
+import os
+import shutil
+
+sys.path.insert(0, '.')
+
+from docopt import docopt
+from dmscripts.env import get_api_endpoint_from_stage
+from dmscripts.export_framework_applicant_details import find_suppliers_with_details
+from dmscripts.generate_agreement_signature_pages import render_html_for_suppliers_awaiting_countersignature, \
+    render_pdf_for_each_html_page
+from dmapiclient import DataAPIClient
+from dmscripts import logging
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    STAGE = arguments['<stage>']
+    API_TOKEN = arguments['<api_token>']
+    FRAMEWORK = arguments['<framework_slug>']
+    TEMPLATE_FOLDER = arguments['<template_folder>']
+    OUTPUT_FOLDER = arguments['<out_folder>']
+
+    repo_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..'))
+    html_dir = os.path.join(OUTPUT_FOLDER, 'html')
+
+    os.makedirs(html_dir)
+
+    logger = logging.configure_logger()
+
+    client = DataAPIClient(get_api_endpoint_from_stage(STAGE), API_TOKEN)
+
+    headers, rows = find_suppliers_with_details(client, FRAMEWORK)
+
+    render_html_for_suppliers_awaiting_countersignature(rows, FRAMEWORK, TEMPLATE_FOLDER, html_dir)
+
+    html_pages = os.listdir(html_dir)
+    html_pages.remove('{}-signature-page.css'.format(FRAMEWORK))
+    html_pages.remove('{}-countersignature.png'.format(FRAMEWORK))
+    render_pdf_for_each_html_page(html_pages, html_dir, OUTPUT_FOLDER)
+    shutil.rmtree(html_dir)

--- a/scripts/generate-counterpart-signature-pages.py
+++ b/scripts/generate-counterpart-signature-pages.py
@@ -17,6 +17,7 @@ Example:
 import sys
 import os
 import shutil
+import tempfile
 
 sys.path.insert(0, '.')
 
@@ -26,7 +27,6 @@ from dmscripts.export_framework_applicant_details import find_suppliers_with_det
 from dmscripts.generate_agreement_signature_pages import render_html_for_suppliers_awaiting_countersignature, \
     render_pdf_for_each_html_page
 from dmapiclient import DataAPIClient
-from dmscripts import logging
 
 
 if __name__ == '__main__':
@@ -38,13 +38,7 @@ if __name__ == '__main__':
     TEMPLATE_FOLDER = arguments['<template_folder>']
     OUTPUT_FOLDER = arguments['<out_folder>']
 
-    repo_root = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), '..'))
-    html_dir = os.path.join(OUTPUT_FOLDER, 'html')
-
-    os.makedirs(html_dir)
-
-    logger = logging.configure_logger()
+    html_dir = tempfile.mkdtemp()
 
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), API_TOKEN)
 

--- a/tests/test_export_framework_applicant_details.py
+++ b/tests/test_export_framework_applicant_details.py
@@ -43,8 +43,22 @@ def test_add_supplier_info(mock_data_client):
 
 def test_add_framework_info(mock_data_client):
     mock_data_client.get_supplier_framework_info.side_effect = [
-        {'frameworkInterest': {'declaration': {'status': 'complete'}, 'onFramework': True}},
-        {'frameworkInterest': {'declaration': {'status': 'complete'}, 'onFramework': False}},
+        {
+            'frameworkInterest': {
+                'declaration': {'status': 'complete'},
+                'onFramework': True,
+                'countersignedPath': None,
+                'countersignedAt': None
+            }
+        },
+        {
+            'frameworkInterest': {
+                'declaration': {'status': 'complete'},
+                'onFramework': False,
+                'countersignedPath': None,
+                'countersignedAt': None
+            }
+        },
     ]
 
     framework_info_adder = export_framework_applicant_details.add_framework_info(mock_data_client, 'g-cloud-8')
@@ -57,8 +71,10 @@ def test_add_framework_info(mock_data_client):
         call(1, 'g-cloud-8'), call(2, 'g-cloud-8')
     ])
     assert records == [
-        {'supplier_id': 1, 'declaration': {'status': 'complete'}, 'onFramework': True},
-        {'supplier_id': 2, 'declaration': {'status': 'complete'}, 'onFramework': False},
+        {'supplier_id': 1, 'onFramework': True, 'declaration': {'status': 'complete'},
+         'countersignedPath': '', 'countersignedAt': ''},
+        {'supplier_id': 2, 'onFramework': False, 'declaration': {'status': 'complete'},
+         'countersignedPath': '', 'countersignedAt': ''}
     ]
 
 


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/story/show/128842655

I started off trying to parameterise the `generate-agreement-sinature-pages` script, but it turns out that there are enough differences with generating the counterpart pages that it makes more sense to me as a separate (but very similar) thing.

The main differences are different conditions on when a file should be generated, an extra file that needs to be copied and later removed, (i.e. the signature file), and file names.

It could probably have been parameterised and just one script, but that would have involved an explosion of command line arguments and/or a bunch of conditional steps in generate_agreement_signatre_pages.py` that wouldn't be very pretty.