### PR TITLE
NO-TICKET_add_venv3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ exclude = ./venv,./venv3
 max-line-length = 120
 
 [pytest]
-norecursedirs= venv*
+norecursedirs= venv venv3


### PR DESCRIPTION
####This should pass once the intermittent test failure fix is merged  https://github.com/alphagov/digitalmarketplace-scripts/pull/73

As per https://github.com/alphagov/digitalmarketplace-api/blob/master/setup.cfg#L2
* Add venv3* to pytest `norecursedirs` 