### PR TITLE
[#134342643]export_framework_applicant_details dos2 followup

### DIFF
--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -129,17 +129,23 @@ def get_csv_rows(records, framework_slug):
     return headers, rows_iter
 
 
+def _pass_fail_from_record(record):
+    if record["onFramework"] is False:
+        return "fail"
+    else:
+        return (
+            "pass" if record["onFramework"] else "discretionary"
+        ) + (
+            "" if record["counts"] else "_with_failed_services"
+        )
+
+
 def create_row(framework_slug, record):
     return dict(chain(
         (
             ("supplier_id", record["supplier"]["id"]),
             ("supplier_name", record["supplier"]["name"]),
-            (
-                "pass_fail",
-                "pass" if record["onFramework"] and record["counts"] else (
-                    "pass_with_failed_services" if record["onFramework"] else "fail"
-                )
-            ),
+            ("pass_fail", _pass_fail_from_record(record)),
             ("countersigned_at", record["countersignedAt"]),
             ("countersigned_path", record["countersignedPath"]),
         ),

--- a/tests/test_export_framework_applicant_details.py
+++ b/tests/test_export_framework_applicant_details.py
@@ -81,3 +81,7 @@ def test_add_submitted_draft_counts(mock_data_client):
         {'supplier': {'id': 1}},
     )
     assert record['counts'] == {'iaas': 1, 'paas': 1, 'saas': 3}
+
+#
+# TODO these tests are not comprehensive enough - fix that. Notably they fail to check the final output of the script
+#

--- a/tests/test_export_framework_applicant_details.py
+++ b/tests/test_export_framework_applicant_details.py
@@ -80,7 +80,7 @@ def test_add_submitted_draft_counts(mock_data_client):
         'g-cloud-8',
         {'supplier': {'id': 1}},
     )
-    assert record['counts'] == {'iaas': 1, 'paas': 1, 'saas': 3}
+    assert record['counts'] == {("iaas", "failed"): 1, ("paas", "submitted"): 1, ("saas", "submitted"): 3}
 
 #
 # TODO these tests are not comprehensive enough - fix that. Notably they fail to check the final output of the script

--- a/tests/test_export_framework_applicant_details.py
+++ b/tests/test_export_framework_applicant_details.py
@@ -80,4 +80,4 @@ def test_add_submitted_draft_counts(mock_data_client):
         'g-cloud-8',
         {'supplier': {'id': 1}},
     )
-    assert record['counts'] == {'paas': 1, 'saas': 3}
+    assert record['counts'] == {'iaas': 1, 'paas': 1, 'saas': 3}

--- a/tests/test_mark_definite_framework_results.py
+++ b/tests/test_mark_definite_framework_results.py
@@ -36,7 +36,7 @@ _declaration_definite_pass_schema = lambda: {
                 "shouldBeTrueStrict": {"enum": [True]},
                 "shouldMatchPatternStrict": {
                     "type": "string",
-                    "pattern": "^H.? *E.? *L.? *Y.? *S?",
+                    "pattern": "^H\\.? *E\\.? *L\\.? *Y\\.? *S?",
                 },
             },
         },


### PR DESCRIPTION
This fixes the logic related to story https://www.pivotaltracker.com/story/show/134342643 in two main ways:
 - Includes `failed` services in the service counts
 - Switches the `on_framework` column to the more general `pass_fail` which can take on the values `pass`, `fail`, `discretionary`, `pass_with_failed_services`, `discretionary_with_failed_services`.

Other than that it's a tidyup reducing unnecessary dict copying and adding a note that this script is under-tested. I feel I should move on to other items in the backlog rather than spending days writing tests for this (case in point note the fairly major behaviour changes in this PR that only required one tiny test change).