### PR TITLE
mark-definite-framework-results: reformat description in docstring for docopt's sake

### DIFF
--- a/scripts/mark-definite-framework-results.py
+++ b/scripts/mark-definite-framework-results.py
@@ -16,8 +16,8 @@ with the supplier_framework and mark those that fail the draft_service_schema as
 supplier_frameworks with no remaining non-failed draft services are considered a definite fail in all cases.
 
 The default behaviour is to skip supplier_frameworks which already have a non-null onFramework set and draft services
-whose status is already "failed", though this can be controlled with the --reassess-passed-sf, --reassess-failed-sf and
---reassess-failed-draft-services, the latter of which will mark "failed" services back as "submitted" if it proves
+whose status is already "failed", though this can be controlled with the --reassess-passed-sf, --reassess-failed-sf
+and --reassess-failed-draft-services, the latter of which will mark "failed" services back as "submitted" if it proves
 not to fail this time around (or if no draft_service_schema is supplied).
 
 Usage: mark-definite-framework-results.py [options] <stage> <api_token> <framework_slug>


### PR DESCRIPTION
docopt was interpreting a description line (mid-paragraph) beginning
with `--reassess-failed-draft-services` as a declaration of that option, and
so, it being declared twice, it was refusing to allow it to be used, claiming
`--reassess-failed-draft-services is not a unique prefix:...`