### PR TITLE
Add brief status to successful brief response CSV

### DIFF
--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -123,6 +123,7 @@ CONFIGS = [
             'supplierId',
             'supplierName',
             'submittedAt',
+            'status',
         ),
         'sort_by': ['briefId', 'submittedAt']
     },


### PR DESCRIPTION
Ash was getting confused that all successful brief_responses
were included in the `successful_brief_responses` CSV, including
responses for briefs that were later withdrawn (or drafts :/).

Thus he wants one extra column in the `successful_brief_responses`
CSV: the current status of the brief that was applied to.

He would like it to be the final column in the CSV.