### PR TITLE
Add script to send stats to Performance Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ The `scripts` folder in this repository contains scripts that interact with the 
   Checks all free-text fields in submitted G-Cloud draft services for "bad words" and generates a CSV report of any bad
   words found.
 
+* `send-stats-to-performance-platform.py`
+
+  Fetches application statistics for a framework from the API and pushes them to the Performance Platform.
+
 * `set-search-alias.py`
 
   Used to set a new alias to an existing Elasticsearch index, via the Search API.

--- a/dmscripts/send_stats_to_performance_platform.py
+++ b/dmscripts/send_stats_to_performance_platform.py
@@ -1,5 +1,3 @@
-import json
-
 import backoff
 import base64
 import requests

--- a/dmscripts/send_stats_to_performance_platform.py
+++ b/dmscripts/send_stats_to_performance_platform.py
@@ -1,0 +1,163 @@
+import json
+
+import backoff
+import base64
+import requests
+
+from datetime import datetime, timedelta
+import dmapiclient
+
+from dmscripts.helpers import logging_helpers
+from dmscripts.helpers.logging_helpers import logging
+
+HOURLY_TIME_FORMAT = '%Y-%m-%dT%H:00:00+00:00'  # On the hour exactly
+DAILY_TIME_FORMAT = '%Y-%m-%dT00:00:00+00:00'  # Midnight
+PERFORMANCE_PLATFORM_URLS = {
+    "day": {
+        "stage": "https://www.performance.service.gov.uk/data/gcloud/applications-by-stage",
+        "lot": "https://www.performance.service.gov.uk/data/gcloud/applications-by-lot",
+    },
+    "hour": {
+        "stage": "https://www.performance.service.gov.uk/data/gcloud/applications-by-stage-realtime",
+        "lot": "https://www.performance.service.gov.uk/data/gcloud/applications-by-lot-realtime",
+    },
+}
+
+logger = logging_helpers.configure_logger({'dmapiclient': logging.WARNING})
+
+
+def _format_statistics(stats, category, groupings):
+    return _label_and_count(stats[category], groupings)
+
+
+def _label_and_count(stats, groupings):
+    data = {
+        label: _sum_counts(stats, filters)
+        for label, filters in groupings.items()
+    }
+    return data
+
+
+def _sum_counts(stats, filter_by=None, sum_by='count'):
+    return sum(
+        statistic[sum_by] for statistic in stats
+        if not filter_by or all(
+            _find(statistic.get(key), value)
+            for key, value in filter_by.items()
+        )
+    )
+
+
+def _find(statistic, filter_value):
+    if isinstance(filter_value, list):
+        return statistic in filter_value
+    else:
+        return statistic == filter_value
+
+
+def _generate_id(timestamp, period, data_type, data_item):
+    # Instructions from Performance Platform:
+    # _id should be a unique url-friendly, base64-encoded, UTF8 encoded concatenation identifier, formed from:
+    # _timestamp, service (= gcloud), period (= day or hour), dataType (= applications-by-stage/lot), stage/lot
+    id_bytes = b'{}-gcloud-{}-{}-{}'.format(timestamp, period, data_type, data_item)
+    return base64.b64encode(id_bytes).encode('utf-8')
+
+
+def send_data(data, url, pp_bearer):
+    # Equivalent to
+    # curl -X POST -d '<payload>' -H 'Content-type: application/json' -H 'Authorization: Bearer <bearer-token>' <url>
+    logger.info(u"Sending data to Performance Platform dataset '{url}':\n{data}", extra={'url': url, 'data': data})
+    res = requests.post(url, json=data, headers={'Authorization': 'Bearer {}'.format(pp_bearer)})
+    if res.status_code != 200:
+        logger.error(
+            u"Failed to send data: {code}: {cause}",
+            extra={'code': res.status_code, 'cause': res.json().get('message', res.text)}
+        )
+    return res.status_code
+
+
+def applications_by_stage(stats):
+    return _format_statistics(
+        stats,
+        'interested_suppliers',
+        {
+            'interested': {
+                'declaration_status': [None, 'started'],
+                'has_completed_services': False
+            },
+            'made-declaration': {
+                'declaration_status': 'complete',
+                'has_completed_services': False
+            },
+            'completed-services': {
+                'declaration_status': [None, 'started'],
+                'has_completed_services': True
+            },
+            'eligible': {
+                'declaration_status': 'complete',
+                'has_completed_services': True
+            }
+        }
+    )
+
+
+def services_by_lot(stats, framework):
+    return _format_statistics(
+        stats,
+        'services',
+        {
+            lot['slug']: {
+                'lot': lot['slug'],
+                'status': 'submitted',
+            } for lot in framework['lots']
+        }
+    )
+
+
+def send_by_stage_stats(stats, timestamp_string, period, pp_bearer):
+    data_type = "applications-by-stage"
+    processed_stats = applications_by_stage(stats)
+    data = [{
+        "_id": _generate_id(timestamp_string, period, data_type, stage),
+        "_timestamp": timestamp_string,
+        "service": "gcloud",
+        "stage": stage,
+        "count": processed_stats.get(stage, 0),
+        "dataType": data_type,
+        "period": period
+    } for stage in processed_stats]
+
+    return send_data(data, PERFORMANCE_PLATFORM_URLS[period]['stage'], pp_bearer)
+
+
+def send_by_lot_stats(stats, timestamp_string, period, framework, pp_bearer):
+    data_type = "applications-by-lot"
+    processed_stats = services_by_lot(stats, framework)
+    data = [{
+        "_id": _generate_id(timestamp_string, period, data_type, lot),
+        "_timestamp": timestamp_string,
+        "service": "gcloud",
+        "lot": lot,
+        "count": processed_stats.get(lot, 0),
+        "dataType": data_type,
+        "period": period
+    } for lot in processed_stats]
+
+    return send_data(data, PERFORMANCE_PLATFORM_URLS[period]['lot'], pp_bearer)
+
+
+@backoff.on_exception(backoff.expo, dmapiclient.HTTPError, max_tries=5)
+def send_framework_stats(data_api_client, framework_slug, period, pp_bearer):
+    stats = data_api_client.get_framework_stats(framework_slug)
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
+    now = datetime.utcnow()
+    # _timestamp is the *start* of the period to which the data relates but the "reading" here is at the *end*
+    # of the period, so need to subtract the period from the current time
+    timestamp_string = (
+        (now - timedelta(days=1)).strftime(DAILY_TIME_FORMAT)
+        if period == 'day' else
+        (now - timedelta(hours=1)).strftime(HOURLY_TIME_FORMAT)
+    )
+    res1 = send_by_stage_stats(stats, timestamp_string, period, pp_bearer)
+    res2 = send_by_lot_stats(stats, timestamp_string, period, framework, pp_bearer)
+    return res1 == res2 == 200

--- a/dmscripts/send_stats_to_performance_platform.py
+++ b/dmscripts/send_stats_to_performance_platform.py
@@ -59,8 +59,8 @@ def _generate_id(timestamp, period, data_type, data_item):
     # Instructions from Performance Platform:
     # _id should be a unique url-friendly, base64-encoded, UTF8 encoded concatenation identifier, formed from:
     # _timestamp, service (= gcloud), period (= day or hour), dataType (= applications-by-stage/lot), stage/lot
-    id_bytes = b'{}-gcloud-{}-{}-{}'.format(timestamp, period, data_type, data_item)
-    return base64.b64encode(id_bytes).encode('utf-8')
+    id_bytes = '{}-gcloud-{}-{}-{}'.format(timestamp, period, data_type, data_item).encode('utf-8')
+    return base64.b64encode(id_bytes)
 
 
 def send_data(data, url, pp_bearer):

--- a/dmscripts/send_stats_to_performance_platform.py
+++ b/dmscripts/send_stats_to_performance_platform.py
@@ -27,6 +27,22 @@ logger = logging_helpers.configure_logger({'dmapiclient': logging.WARNING})
 
 
 def _format_statistics(stats, category, groupings):
+    """Filter statistics according to specified groupings
+
+    :param stats: Framework statistics as returned by our API
+    :param category: Top-level key from the statistics that we want to filter, e.g. 'interested_suppliers'
+    :param groupings: Rules about how data should be grouped, with new keys specified along with a set of conditions
+                      that must be met for data to be included under that key.
+                      Lists will match with any values that are in the list, and exact values are matched exactly.
+                      e.g.
+                       'interested': {
+                            'declaration_status': [None, 'started'],
+                            'has_completed_services': False
+                        }
+                      Will result in a key 'interested' in the return value that has a count of 'interested_suppliers'
+                      with a declaration status in [None or 'started'] and 'has_completed_services' == False
+    :return: A dictionary of statistics formatted according to the specified groupings
+    """
     return _label_and_count(stats[category], groupings)
 
 

--- a/scripts/send-stats-to-performance-platform.py
+++ b/scripts/send-stats-to-performance-platform.py
@@ -1,0 +1,29 @@
+"""
+Script to fetch application statistics for a framework from the API and push them to the Performance Platform.
+
+Usage:
+    scripts/send-stats-to-performance-platform.py <framework_slug> <stage> <api_token> <pp_bearer> (--day | --hour)
+"""
+import sys
+sys.path.insert(0, '.')
+
+from docopt import docopt
+
+from dmapiclient import DataAPIClient
+
+from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
+from dmscripts.send_stats_to_performance_platform import send_framework_stats
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    STAGE = arguments['<stage>']
+    FRAMEWORK_SLUG = arguments['<framework_slug>']
+    PERIOD = 'day' if arguments['--day'] else 'hour'
+
+    api_url = get_api_endpoint_from_stage(STAGE)
+    client = DataAPIClient(api_url, arguments['<api_token>'])
+
+    ok = send_framework_stats(client, FRAMEWORK_SLUG, PERIOD, arguments['<pp_bearer>'])
+    if not ok:
+        sys.exit(1)

--- a/tests/test_send_stats_to_performance_platform.py
+++ b/tests/test_send_stats_to_performance_platform.py
@@ -158,45 +158,53 @@ def test_services_by_lot():
 @mock.patch('dmscripts.send_stats_to_performance_platform.send_data')
 def test_send_by_stage_stats_per_day_calls_send_data_with_correct_data(send_data):
     send_by_stage_stats(STATS_JSON, '2017-03-29T00:00:00+00:00', 'day', 'pp-bearer-token')
+    expected_sent_data_items = [
+        {'count': 184,
+         '_timestamp': '2017-03-29T00:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-stage',
+         'period': 'day',
+         # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-interested'
+         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1pbnRlcmVzdGVk',
+         'stage': 'interested'
+        },
+        {'count': 97,
+         '_timestamp': '2017-03-29T00:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-stage',
+         'period': 'day',
+         # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-made-declaration'
+         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1tYWRlLWRlY2xhcmF0aW9u',  # noqa
+         'stage': 'made-declaration'
+         },
+        {'count': 79,
+         '_timestamp': '2017-03-29T00:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-stage',
+         'period': 'day',
+         # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-completed-services'
+         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1jb21wbGV0ZWQtc2VydmljZXM=',  # noqa
+         'stage': 'completed-services'
+         },
+        {'count': 89,
+         '_timestamp': '2017-03-29T00:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-stage',
+         'period': 'day',
+         # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-eligible'
+         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1lbGlnaWJsZQ==',
+         'stage': 'eligible'
+         }
+    ]
+    # Python 2 and Python 3 can generate the data in varying order, so test items independent of order in the list
+    sent_data = send_data.call_args[0][0]
+    assert len(sent_data) == 4
+    for item in sent_data:
+        assert item in expected_sent_data_items
+        expected_sent_data_items.remove(item)  # Each item should appear once in the call args so remove once found
+
     send_data.assert_called_with(
-        [
-            {'count': 184,
-             '_timestamp': '2017-03-29T00:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-stage',
-             'period': 'day',
-             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-interested'
-             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1pbnRlcmVzdGVk',
-             'stage': 'interested'
-            },
-            {'count': 97,
-             '_timestamp': '2017-03-29T00:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-stage',
-             'period': 'day',
-             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-made-declaration'
-             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1tYWRlLWRlY2xhcmF0aW9u',  # noqa
-             'stage': 'made-declaration'
-             },
-            {'count': 79,
-             '_timestamp': '2017-03-29T00:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-stage',
-             'period': 'day',
-             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-completed-services'
-             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1jb21wbGV0ZWQtc2VydmljZXM=',  # noqa
-             'stage': 'completed-services'
-             },
-            {'count': 89,
-             '_timestamp': '2017-03-29T00:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-stage',
-             'period': 'day',
-             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-eligible'
-             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1lbGlnaWJsZQ==',
-             'stage': 'eligible'
-             }
-        ],
+        mock.ANY,  # Data sent has already been tested above
         'https://www.performance.service.gov.uk/data/gcloud/applications-by-stage',
         'pp-bearer-token'
     )
@@ -205,45 +213,53 @@ def test_send_by_stage_stats_per_day_calls_send_data_with_correct_data(send_data
 @mock.patch('dmscripts.send_stats_to_performance_platform.send_data')
 def test_send_by_stage_stats_per_hour_calls_send_data_with_correct_data(send_data):
     send_by_stage_stats(STATS_JSON, '2017-03-29T12:00:00+00:00', 'hour', 'pp-bearer-token')
+    expected_sent_data_items = [
+        {'count': 184,
+         '_timestamp': '2017-03-29T12:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-stage',
+         'period': 'hour',
+         # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-interested'
+         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtaW50ZXJlc3RlZA==',
+         'stage': 'interested'
+         },
+        {'count': 97,
+         '_timestamp': '2017-03-29T12:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-stage',
+         'period': 'hour',
+         # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-made-declaration'
+         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtbWFkZS1kZWNsYXJhdGlvbg==',  # noqa
+         'stage': 'made-declaration'
+         },
+        {'count': 79,
+         '_timestamp': '2017-03-29T12:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-stage',
+         'period': 'hour',
+         # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-completed-services'
+         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtY29tcGxldGVkLXNlcnZpY2Vz',  # noqa
+         'stage': 'completed-services'
+         },
+        {'count': 89,
+         '_timestamp': '2017-03-29T12:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-stage',
+         'period': 'hour',
+         # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-eligible'
+         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtZWxpZ2libGU=',
+         'stage': 'eligible'
+         }
+    ]
+    # Python 2 and Python 3 can generate the data in varying order, so test items independent of order in the list
+    sent_data = send_data.call_args[0][0]
+    assert len(sent_data) == 4
+    for item in sent_data:
+        assert item in expected_sent_data_items
+        expected_sent_data_items.remove(item)  # Each item should appear once in the call args so remove once found
+
     send_data.assert_called_with(
-        [
-            {'count': 184,
-             '_timestamp': '2017-03-29T12:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-stage',
-             'period': 'hour',
-             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-interested'
-             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtaW50ZXJlc3RlZA==',
-             'stage': 'interested'
-             },
-            {'count': 97,
-             '_timestamp': '2017-03-29T12:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-stage',
-             'period': 'hour',
-             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-made-declaration'
-             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtbWFkZS1kZWNsYXJhdGlvbg==',  # noqa
-             'stage': 'made-declaration'
-             },
-            {'count': 79,
-             '_timestamp': '2017-03-29T12:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-stage',
-             'period': 'hour',
-             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-completed-services'
-             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtY29tcGxldGVkLXNlcnZpY2Vz',  # noqa
-             'stage': 'completed-services'
-             },
-            {'count': 89,
-             '_timestamp': '2017-03-29T12:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-stage',
-             'period': 'hour',
-             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-eligible'
-             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtZWxpZ2libGU=',
-             'stage': 'eligible'
-             }
-        ],
+        mock.ANY,  # Data sent has already been tested above
         'https://www.performance.service.gov.uk/data/gcloud/applications-by-stage-realtime',
         'pp-bearer-token'
     )
@@ -252,36 +268,45 @@ def test_send_by_stage_stats_per_hour_calls_send_data_with_correct_data(send_dat
 @mock.patch('dmscripts.send_stats_to_performance_platform.send_data')
 def test_send_by_lot_stats_per_day_calls_send_data_with_correct_data(send_data):
     send_by_lot_stats(STATS_JSON, '2017-03-29T00:00:00+00:00', 'day', FRAMEWORK_JSON['frameworks'], 'pp-bearer-token')
+    expected_sent_data_items = [
+        {'count': 84,
+         '_timestamp': '2017-03-29T00:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-lot',
+         'period': 'day',
+         'lot': 'cloud-hosting',
+         # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-hosting'
+         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtaG9zdGluZw=='
+         },
+        {'count': 102,
+         '_timestamp': '2017-03-29T00:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-lot',
+         'period': 'day',
+         'lot': 'cloud-support',
+         # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-support'
+         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtc3VwcG9ydA=='
+         },
+        {'count': 94,
+         '_timestamp': '2017-03-29T00:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-lot',
+         'period': 'day',
+         'lot': 'cloud-software',
+         # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-software'
+         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtc29mdHdhcmU='
+         }
+    ]
+
+    # Python 2 and Python 3 can generate the data in varying order, so test items independent of order in the list
+    sent_data = send_data.call_args[0][0]
+    assert len(sent_data) == 3
+    for item in sent_data:
+        assert item in expected_sent_data_items
+        expected_sent_data_items.remove(item)  # Each item should appear once in the call args so remove once found
+
     send_data.assert_called_with(
-        [
-            {'count': 84,
-             '_timestamp': '2017-03-29T00:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-lot',
-             'period': 'day',
-             'lot': 'cloud-hosting',
-             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-hosting'
-             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtaG9zdGluZw=='
-             },
-            {'count': 102,
-             '_timestamp': '2017-03-29T00:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-lot',
-             'period': 'day',
-             'lot': 'cloud-support',
-             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-support'
-             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtc3VwcG9ydA=='
-             },
-            {'count': 94,
-             '_timestamp': '2017-03-29T00:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-lot',
-             'period': 'day',
-             'lot': 'cloud-software',
-             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-software'
-             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtc29mdHdhcmU='
-             }
-        ],
+        mock.ANY,  # Data sent has already been tested above
         'https://www.performance.service.gov.uk/data/gcloud/applications-by-lot',
         'pp-bearer-token'
     )
@@ -290,36 +315,45 @@ def test_send_by_lot_stats_per_day_calls_send_data_with_correct_data(send_data):
 @mock.patch('dmscripts.send_stats_to_performance_platform.send_data')
 def test_send_by_lot_stats_per_hour_calls_send_data_with_correct_data(send_data):
     send_by_lot_stats(STATS_JSON, '2017-03-29T12:00:00+00:00', 'hour', FRAMEWORK_JSON['frameworks'], 'pp-bearer-token')
+    expected_sent_data_items = [
+        {'count': 84,
+         '_timestamp': '2017-03-29T12:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-lot',
+         'period': 'hour',
+         'lot': 'cloud-hosting',
+         # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-hosting'
+         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLWhvc3Rpbmc='
+         },
+        {'count': 102,
+         '_timestamp': '2017-03-29T12:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-lot',
+         'period': 'hour',
+         'lot': 'cloud-support',
+         # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-support'
+         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLXN1cHBvcnQ='
+         },
+        {'count': 94,
+         '_timestamp': '2017-03-29T12:00:00+00:00',
+         'service': 'gcloud',
+         'dataType': 'applications-by-lot',
+         'period': 'hour',
+         'lot': 'cloud-software',
+         # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-software'
+         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLXNvZnR3YXJl'
+         }
+    ]
+
+    # Python 2 and Python 3 can generate the data in varying order, so test items independent of order in the list
+    sent_data = send_data.call_args[0][0]
+    assert len(sent_data) == 3
+    for item in sent_data:
+        assert item in expected_sent_data_items
+        expected_sent_data_items.remove(item)  # Each item should appear once in the call args so remove once found
+
     send_data.assert_called_with(
-        [
-            {'count': 84,
-             '_timestamp': '2017-03-29T12:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-lot',
-             'period': 'hour',
-             'lot': 'cloud-hosting',
-             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-hosting'
-             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLWhvc3Rpbmc='
-             },
-            {'count': 102,
-             '_timestamp': '2017-03-29T12:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-lot',
-             'period': 'hour',
-             'lot': 'cloud-support',
-             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-support'
-             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLXN1cHBvcnQ='
-             },
-            {'count': 94,
-             '_timestamp': '2017-03-29T12:00:00+00:00',
-             'service': 'gcloud',
-             'dataType': 'applications-by-lot',
-             'period': 'hour',
-             'lot': 'cloud-software',
-             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-software'
-             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLXNvZnR3YXJl'
-             }
-        ],
+        mock.ANY,  # Data sent has already been tested above
         'https://www.performance.service.gov.uk/data/gcloud/applications-by-lot-realtime',
         'pp-bearer-token'
     )

--- a/tests/test_send_stats_to_performance_platform.py
+++ b/tests/test_send_stats_to_performance_platform.py
@@ -1,0 +1,325 @@
+import json
+
+import mock
+
+from dmscripts.send_stats_to_performance_platform import applications_by_stage, services_by_lot, send_by_stage_stats, \
+    send_by_lot_stats
+
+FRAMEWORK_JSON = json.loads('''
+{
+    "frameworks": {
+        "lots": [
+            {"slug": "cloud-hosting"},
+            {"slug": "cloud-software"},
+            {"slug": "cloud-support"}
+        ]
+    }
+}
+''')
+
+STATS_JSON = json.loads('''
+{
+   "services": [
+      {
+         "count": 13,
+         "status": "not-submitted",
+         "declaration_made": false,
+         "lot": "cloud-hosting"
+      },
+      {
+         "count": 17,
+         "status": "not-submitted",
+         "declaration_made": true,
+         "lot": "cloud-hosting"
+      },
+      {
+         "count": 19,
+         "status": "not-submitted",
+         "declaration_made": false,
+         "lot": "cloud-software"
+      },
+      {
+         "count": 23,
+         "status": "not-submitted",
+         "declaration_made": true,
+         "lot": "cloud-software"
+      },
+      {
+         "count": 29,
+         "status": "not-submitted",
+         "declaration_made": false,
+         "lot": "cloud-support"
+      },
+      {
+         "count": 31,
+         "status": "not-submitted",
+         "declaration_made": true,
+         "lot": "cloud-support"
+      },
+      {
+         "count": 37,
+         "status": "submitted",
+         "declaration_made": true,
+         "lot": "cloud-hosting"
+      },
+      {
+         "count": 41,
+         "status": "submitted",
+         "declaration_made": true,
+         "lot": "cloud-software"
+      },
+      {
+         "count": 43,
+         "status": "submitted",
+         "declaration_made": true,
+         "lot": "cloud-support"
+      },
+            {
+         "count": 47,
+         "status": "submitted",
+         "declaration_made": false,
+         "lot": "cloud-hosting"
+      },
+      {
+         "count": 53,
+         "status": "submitted",
+         "declaration_made": false,
+         "lot": "cloud-software"
+      },
+      {
+         "count": 59,
+         "status": "submitted",
+         "declaration_made": false,
+         "lot": "cloud-support"
+      }
+   ],
+   "interested_suppliers": [
+      {
+         "count": 101,
+         "declaration_status": null,
+         "has_completed_services": false
+      },
+      {
+         "count": 97,
+         "declaration_status": "complete",
+         "has_completed_services": false
+      },
+      {
+         "count": 89,
+         "declaration_status": "complete",
+         "has_completed_services": true
+      },
+      {
+         "count": 83,
+         "declaration_status": "started",
+         "has_completed_services": false
+      },
+      {
+         "count": 79,
+         "declaration_status": "started",
+         "has_completed_services": true
+      }
+   ],
+   "supplier_users": [
+      {
+         "count": 7654,
+         "recent_login": false
+      },
+      {
+         "count": 4567,
+         "recent_login": null
+      },
+      {
+         "count": 2345,
+         "recent_login": true
+      }
+   ]
+}
+''')
+
+
+def test_applications_by_stage():
+    assert applications_by_stage(STATS_JSON) == {
+        'completed-services': 79,  # 79 - incomplete declaration plus completed services
+        'eligible': 89,            # 89 - complete declaration plus completed services
+        'interested': 184,         # 101 + 83 - incomplete declaration and no services
+        'made-declaration': 97     # 97 - complete declaration and no services
+    }
+
+
+def test_services_by_lot():
+    assert services_by_lot(STATS_JSON, FRAMEWORK_JSON['frameworks']) == {
+        'cloud-hosting': 84,   # 37 + 47 submitted with or without complete declaration
+        'cloud-software': 94,  # 41 + 53 submitted with or without complete declaration
+        'cloud-support': 102    # 43 + 59 submitted with or without complete declaration
+    }
+
+
+@mock.patch('dmscripts.send_stats_to_performance_platform.send_data')
+def test_send_by_stage_stats_per_day_calls_send_data_with_correct_data(send_data):
+    send_by_stage_stats(STATS_JSON, '2017-03-29T00:00:00+00:00', 'day', 'pp-bearer-token')
+    send_data.assert_called_with(
+        [
+            {'count': 184,
+             '_timestamp': '2017-03-29T00:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-stage',
+             'period': 'day',
+             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-interested'
+             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1pbnRlcmVzdGVk',
+             'stage': 'interested'
+            },
+            {'count': 97,
+             '_timestamp': '2017-03-29T00:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-stage',
+             'period': 'day',
+             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-made-declaration'
+             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1tYWRlLWRlY2xhcmF0aW9u',  # noqa
+             'stage': 'made-declaration'
+             },
+            {'count': 79,
+             '_timestamp': '2017-03-29T00:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-stage',
+             'period': 'day',
+             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-completed-services'
+             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1jb21wbGV0ZWQtc2VydmljZXM=',  # noqa
+             'stage': 'completed-services'
+             },
+            {'count': 89,
+             '_timestamp': '2017-03-29T00:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-stage',
+             'period': 'day',
+             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-eligible'
+             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1lbGlnaWJsZQ==',
+             'stage': 'eligible'
+             }
+        ],
+        'https://www.performance.service.gov.uk/data/gcloud/applications-by-stage',
+        'pp-bearer-token'
+    )
+
+
+@mock.patch('dmscripts.send_stats_to_performance_platform.send_data')
+def test_send_by_stage_stats_per_hour_calls_send_data_with_correct_data(send_data):
+    send_by_stage_stats(STATS_JSON, '2017-03-29T12:00:00+00:00', 'hour', 'pp-bearer-token')
+    send_data.assert_called_with(
+        [
+            {'count': 184,
+             '_timestamp': '2017-03-29T12:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-stage',
+             'period': 'hour',
+             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-interested'
+             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtaW50ZXJlc3RlZA==',
+             'stage': 'interested'
+             },
+            {'count': 97,
+             '_timestamp': '2017-03-29T12:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-stage',
+             'period': 'hour',
+             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-made-declaration'
+             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtbWFkZS1kZWNsYXJhdGlvbg==',  # noqa
+             'stage': 'made-declaration'
+             },
+            {'count': 79,
+             '_timestamp': '2017-03-29T12:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-stage',
+             'period': 'hour',
+             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-completed-services'
+             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtY29tcGxldGVkLXNlcnZpY2Vz',  # noqa
+             'stage': 'completed-services'
+             },
+            {'count': 89,
+             '_timestamp': '2017-03-29T12:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-stage',
+             'period': 'hour',
+             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-eligible'
+             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtZWxpZ2libGU=',
+             'stage': 'eligible'
+             }
+        ],
+        'https://www.performance.service.gov.uk/data/gcloud/applications-by-stage-realtime',
+        'pp-bearer-token'
+    )
+
+
+@mock.patch('dmscripts.send_stats_to_performance_platform.send_data')
+def test_send_by_lot_stats_per_day_calls_send_data_with_correct_data(send_data):
+    send_by_lot_stats(STATS_JSON, '2017-03-29T00:00:00+00:00', 'day', FRAMEWORK_JSON['frameworks'], 'pp-bearer-token')
+    send_data.assert_called_with(
+        [
+            {'count': 84,
+             '_timestamp': '2017-03-29T00:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-lot',
+             'period': 'day',
+             'lot': 'cloud-hosting',
+             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-hosting'
+             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtaG9zdGluZw=='
+             },
+            {'count': 102,
+             '_timestamp': '2017-03-29T00:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-lot',
+             'period': 'day',
+             'lot': 'cloud-support',
+             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-support'
+             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtc3VwcG9ydA=='
+             },
+            {'count': 94,
+             '_timestamp': '2017-03-29T00:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-lot',
+             'period': 'day',
+             'lot': 'cloud-software',
+             # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-software'
+             '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtc29mdHdhcmU='
+             }
+        ],
+        'https://www.performance.service.gov.uk/data/gcloud/applications-by-lot',
+        'pp-bearer-token'
+    )
+
+
+@mock.patch('dmscripts.send_stats_to_performance_platform.send_data')
+def test_send_by_lot_stats_per_hour_calls_send_data_with_correct_data(send_data):
+    send_by_lot_stats(STATS_JSON, '2017-03-29T12:00:00+00:00', 'hour', FRAMEWORK_JSON['frameworks'], 'pp-bearer-token')
+    send_data.assert_called_with(
+        [
+            {'count': 84,
+             '_timestamp': '2017-03-29T12:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-lot',
+             'period': 'hour',
+             'lot': 'cloud-hosting',
+             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-hosting'
+             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLWhvc3Rpbmc='
+             },
+            {'count': 102,
+             '_timestamp': '2017-03-29T12:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-lot',
+             'period': 'hour',
+             'lot': 'cloud-support',
+             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-support'
+             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLXN1cHBvcnQ='
+             },
+            {'count': 94,
+             '_timestamp': '2017-03-29T12:00:00+00:00',
+             'service': 'gcloud',
+             'dataType': 'applications-by-lot',
+             'period': 'hour',
+             'lot': 'cloud-software',
+             # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-software'
+             '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLXNvZnR3YXJl'
+             }
+        ],
+        'https://www.performance.service.gov.uk/data/gcloud/applications-by-lot-realtime',
+        'pp-bearer-token'
+    )

--- a/tests/test_send_stats_to_performance_platform.py
+++ b/tests/test_send_stats_to_performance_platform.py
@@ -165,7 +165,7 @@ def test_send_by_stage_stats_per_day_calls_send_data_with_correct_data(send_data
          'dataType': 'applications-by-stage',
          'period': 'day',
          # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-interested'
-         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1pbnRlcmVzdGVk',
+         '_id': b'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1pbnRlcmVzdGVk',
          'stage': 'interested'
         },
         {'count': 97,
@@ -174,7 +174,7 @@ def test_send_by_stage_stats_per_day_calls_send_data_with_correct_data(send_data
          'dataType': 'applications-by-stage',
          'period': 'day',
          # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-made-declaration'
-         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1tYWRlLWRlY2xhcmF0aW9u',  # noqa
+         '_id': b'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1tYWRlLWRlY2xhcmF0aW9u',  # noqa
          'stage': 'made-declaration'
          },
         {'count': 79,
@@ -183,7 +183,7 @@ def test_send_by_stage_stats_per_day_calls_send_data_with_correct_data(send_data
          'dataType': 'applications-by-stage',
          'period': 'day',
          # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-completed-services'
-         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1jb21wbGV0ZWQtc2VydmljZXM=',  # noqa
+         '_id': b'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1jb21wbGV0ZWQtc2VydmljZXM=',  # noqa
          'stage': 'completed-services'
          },
         {'count': 89,
@@ -192,7 +192,7 @@ def test_send_by_stage_stats_per_day_calls_send_data_with_correct_data(send_data
          'dataType': 'applications-by-stage',
          'period': 'day',
          # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-stage-eligible'
-         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1lbGlnaWJsZQ==',
+         '_id': b'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1zdGFnZS1lbGlnaWJsZQ==',
          'stage': 'eligible'
          }
     ]
@@ -220,7 +220,7 @@ def test_send_by_stage_stats_per_hour_calls_send_data_with_correct_data(send_dat
          'dataType': 'applications-by-stage',
          'period': 'hour',
          # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-interested'
-         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtaW50ZXJlc3RlZA==',
+         '_id': b'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtaW50ZXJlc3RlZA==',
          'stage': 'interested'
          },
         {'count': 97,
@@ -229,7 +229,7 @@ def test_send_by_stage_stats_per_hour_calls_send_data_with_correct_data(send_dat
          'dataType': 'applications-by-stage',
          'period': 'hour',
          # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-made-declaration'
-         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtbWFkZS1kZWNsYXJhdGlvbg==',  # noqa
+         '_id': b'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtbWFkZS1kZWNsYXJhdGlvbg==',  # noqa
          'stage': 'made-declaration'
          },
         {'count': 79,
@@ -238,7 +238,7 @@ def test_send_by_stage_stats_per_hour_calls_send_data_with_correct_data(send_dat
          'dataType': 'applications-by-stage',
          'period': 'hour',
          # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-completed-services'
-         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtY29tcGxldGVkLXNlcnZpY2Vz',  # noqa
+         '_id': b'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtY29tcGxldGVkLXNlcnZpY2Vz',  # noqa
          'stage': 'completed-services'
          },
         {'count': 89,
@@ -247,7 +247,7 @@ def test_send_by_stage_stats_per_hour_calls_send_data_with_correct_data(send_dat
          'dataType': 'applications-by-stage',
          'period': 'hour',
          # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-stage-eligible'
-         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtZWxpZ2libGU=',
+         '_id': b'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktc3RhZ2UtZWxpZ2libGU=',
          'stage': 'eligible'
          }
     ]
@@ -276,7 +276,7 @@ def test_send_by_lot_stats_per_day_calls_send_data_with_correct_data(send_data):
          'period': 'day',
          'lot': 'cloud-hosting',
          # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-hosting'
-         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtaG9zdGluZw=='
+         '_id': b'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtaG9zdGluZw=='
          },
         {'count': 102,
          '_timestamp': '2017-03-29T00:00:00+00:00',
@@ -285,7 +285,7 @@ def test_send_by_lot_stats_per_day_calls_send_data_with_correct_data(send_data):
          'period': 'day',
          'lot': 'cloud-support',
          # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-support'
-         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtc3VwcG9ydA=='
+         '_id': b'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtc3VwcG9ydA=='
          },
         {'count': 94,
          '_timestamp': '2017-03-29T00:00:00+00:00',
@@ -294,7 +294,7 @@ def test_send_by_lot_stats_per_day_calls_send_data_with_correct_data(send_data):
          'period': 'day',
          'lot': 'cloud-software',
          # Base 64 encoding of '2017-03-29T00:00:00+00:00-gcloud-day-applications-by-lot-cloud-software'
-         '_id': 'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtc29mdHdhcmU='
+         '_id': b'MjAxNy0wMy0yOVQwMDowMDowMCswMDowMC1nY2xvdWQtZGF5LWFwcGxpY2F0aW9ucy1ieS1sb3QtY2xvdWQtc29mdHdhcmU='
          }
     ]
 
@@ -323,7 +323,7 @@ def test_send_by_lot_stats_per_hour_calls_send_data_with_correct_data(send_data)
          'period': 'hour',
          'lot': 'cloud-hosting',
          # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-hosting'
-         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLWhvc3Rpbmc='
+         '_id': b'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLWhvc3Rpbmc='
          },
         {'count': 102,
          '_timestamp': '2017-03-29T12:00:00+00:00',
@@ -332,7 +332,7 @@ def test_send_by_lot_stats_per_hour_calls_send_data_with_correct_data(send_data)
          'period': 'hour',
          'lot': 'cloud-support',
          # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-support'
-         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLXN1cHBvcnQ='
+         '_id': b'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLXN1cHBvcnQ='
          },
         {'count': 94,
          '_timestamp': '2017-03-29T12:00:00+00:00',
@@ -341,7 +341,7 @@ def test_send_by_lot_stats_per_hour_calls_send_data_with_correct_data(send_data)
          'period': 'hour',
          'lot': 'cloud-software',
          # Base 64 encoding of '2017-03-29T12:00:00+00:00-gcloud-hour-applications-by-lot-cloud-software'
-         '_id': 'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLXNvZnR3YXJl'
+         '_id': b'MjAxNy0wMy0yOVQxMjowMDowMCswMDowMC1nY2xvdWQtaG91ci1hcHBsaWNhdGlvbnMtYnktbG90LWNsb3VkLXNvZnR3YXJl'
          }
     ]
 


### PR DESCRIPTION
This new script hits our API statistics endpoint and reformats the data into the form required by our performance platform datasets before posting it to the relevant place.

The stats reformatting methods (`_format_statistics`, `_label_and_count`, `_sum_counts`, `_find`) are based on those used in the admin app, but there are enough differences here that I don't think it's worth extracting these methods into shared utils right now.

I guess in future if the performance platform works out for us then the admin app stats views will become obsolete and be removed anyway.
