### PR TITLE
Update agreement-generation scripts to use details from API

### DIFF
--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -23,9 +23,9 @@ def render_html_for_successful_suppliers(rows, framework_kwargs, template_dir, o
     template_path = os.path.join(template_dir, 'framework-agreement-signature-page.html')
     template_css_path = os.path.join(template_dir, 'framework-agreement-signature-page.css')
     for data in rows:
-        data.update(framework_kwargs)
         if data['pass_fail'] == 'fail':
             continue
+        data.update(framework_kwargs)
         data['awardedLots'] = filter(lambda lot: int(data[lot]) > 0, framework_kwargs['lotOrder'])
         html = render_html(template_path, data)
         save_page(html, data['supplier_id'], output_dir, "signature-page")
@@ -37,7 +37,6 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework_kwargs, 
     template_css_path = os.path.join(template_dir, 'framework-agreement-signature-page.css')
     countersignature_img_path = os.path.join(template_dir, 'framework-agreement-countersignature.png')
     for data in rows:
-        data.update(framework_kwargs)
         if data['pass_fail'] == 'fail' or data['countersigned_path'] or not data['countersigned_at']:
             logger.info("SKIPPING {}: pass_fail={} countersigned_at={} countersigned_path={}".format(
                 data['supplier_id'],
@@ -46,6 +45,7 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework_kwargs, 
                 data['countersigned_path'])
             )
             continue
+        data.update(framework_kwargs)
         data['awardedLots'] = filter(lambda lot: int(data[lot]) > 0, framework_kwargs['lotOrder'])
         html = render_html(template_path, data)
         save_page(html, data['supplier_id'], output_dir, "agreement-countersignature")

--- a/scripts/bulk-upload-ccs-documents.py
+++ b/scripts/bulk-upload-ccs-documents.py
@@ -1,6 +1,11 @@
 """
 !!! NOTE: THIS IS AN OLD SCRIPT AND PROBABLY NOT THE ONE YOU WANT !!!
 
+PREREQUISITE: You'll need AWS credentials set up for the environment that you're uploading to:
+              Save your aws_access_key_id and aws_secret_access_key in ~/.aws/credentials
+              If you have more than one set of credentials in there then be sure to set your AWS_PROFILE environment
+              variable to reference the right credentials before running the script.
+
 For uploading result letters and framework agreements you should prefer bulk-upload-documents.py because it sets a
 nice supplier-friendly filename at the same time.
 

--- a/scripts/bulk-upload-documents.py
+++ b/scripts/bulk-upload-documents.py
@@ -3,6 +3,12 @@
 !!! NOTE: This script is the preferred way to upload framework agreement signature pages and "fail" letters.
 !!! You can't upload countersigned/counterpart pages with this script because the DB also needs to be updated for those.
 
+PREREQUISITE: You'll need AWS credentials set up for the environment that you're uploading to:
+              Save your aws_access_key_id and aws_secret_access_key in ~/.aws/credentials
+              If you have more than one set of credentials in there then be sure to set your AWS_PROFILE environment
+              variable to reference the right credentials before running the script.
+
+
 This script requires a tab-separated file matching supplier ids to supplier names; the first column must be the
 supplier ID and the second column is the supplier name, e.g.:
 

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -12,23 +12,27 @@ in the API response for the given framework.
 
 The 'frameworkAgreementDetails' JSON object from the API should look something like this:
 {
-    "frameworkName": "Digital Outcomes and Specialists 2",
+    "contractNoticeNumber": "2016/S 217-395765",
     "frameworkAgreementVersion": "RM1043iv",
-    "frameworkRefDate": "16-01-2017",
-    "frameworkStartDate": "30/01/2017",
     "frameworkEndDate": "29/01/2018",
     "frameworkExtensionLength": "12 months",
+    "frameworkRefDate": "16-01-2017",
+    "frameworkStartDate": "30/01/2017",
     "frameworkURL": "https://www.gov.uk/government/publications/digital-outcomes-and-specialists-2-framework-agreement",
-    "pageNumber": "3",
-    "pageTotal": "45",
-    "contractNoticeNumber": "2016/S 217-395765",
-    "lotOrder": ["digital-outcomes", "digital-specialists", "user-research-studios", "user-research-participants"],
     "lotDescriptions": {
-        "digital-outcomes": "Lot 1: digital outcomes",
-        "digital-specialists": "Lot 2: digital specialists",
-        "user-research-studios": "Lot 3: user research studios",
-        "user-research-participants": "Lot 4: user research participants"
-    }
+      "digital-outcomes": "Lot 1: digital outcomes",
+      "digital-specialists": "Lot 2: digital specialists",
+      "user-research-participants": "Lot 4: user research participants",
+      "user-research-studios": "Lot 3: user research studios"
+    },
+    "lotOrder": [
+      "digital-outcomes",
+      "digital-specialists",
+      "user-research-studios",
+      "user-research-participants"
+    ],
+    "pageTotal": 45,
+    "signaturePageNumber": 3
 }
 
 Usage:
@@ -58,7 +62,9 @@ if __name__ == '__main__':
 
     framework_slug = args['<framework_slug>']
     client = DataAPIClient(get_api_endpoint_from_stage(args['<stage>']), args['<api_token>'])
-    framework_kwargs = client.get_framework(framework_slug)['frameworks']['frameworkAgreementDetails']
+    framework = client.get_framework(framework_slug)['frameworks']
+    framework_kwargs = framework['frameworkAgreementDetails']
+    framework_kwargs['frameworkName'] = framework['name']
 
     supplier_id_file = args['<supplier_id_file>']
     if supplier_id_file:

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -7,10 +7,10 @@ Generate framework agreement counterpart signature pages from supplier "about yo
 who successfully applied to a framework and whose signed agreements have been approved by CCS.
 
 This script supersedes the old "generate-g8-counterpart-signature-pages.py" which uses framework-specific templates.
-Instead, this script requires a dict of framework-specific information, that is read as JSON from a file supplied
-as the "framework_json" command-line argument.
+Instead, this script requires a dict of framework-specific information, that is read from 'frameworkAgreementDetails'
+in the API response for the given framework.
 
-The supplied JSON file should look something like this:
+The 'frameworkAgreementDetails' JSON object from the API should look something like this:
 {
     "frameworkName": "Digital Outcomes and Specialists 2",
     "frameworkAgreementVersion": "RM1043iv",
@@ -33,10 +33,9 @@ The supplied JSON file should look something like this:
 
 Usage:
     scripts/generate-framework-agreement-counterpart-signature-pages.py <stage> <api_token> <framework_slug>
-    <framework_json> <template_folder> <output_folder> [<supplier_id_file>]
+    <template_folder> <output_folder> [<supplier_id_file>]
 
 """
-import json
 import os
 import shutil
 import sys
@@ -58,8 +57,8 @@ if __name__ == '__main__':
     args = docopt(__doc__)
 
     framework_slug = args['<framework_slug>']
-    framework_kwargs = declaration_definite_pass_schema = json.load(open(args["<framework_json>"], "r"))
     client = DataAPIClient(get_api_endpoint_from_stage(args['<stage>']), args['<api_token>'])
+    framework_kwargs = client.get_framework(framework_slug)['frameworks']['frameworkAgreementDetails']
 
     supplier_id_file = args['<supplier_id_file>']
     if supplier_id_file:

--- a/scripts/generate-framework-agreement-signature-pages.py
+++ b/scripts/generate-framework-agreement-signature-pages.py
@@ -7,10 +7,10 @@ Generate framework agreement signature pages from supplier "about you" informati
 who successfully applied to a framework.
 
 This script supersedes the old "generate-agreement-signature-pages.py" which uses framework-specific templates.
-Instead, this script requires a dict of framework-specific information, that is read as JSON from a file supplied
-as the "framework_json" command-line argument.
+Instead, this script requires a dict of framework-specific information, that is read from 'frameworkAgreementDetails'
+in the API response for the given framework.
 
-The supplied JSON file should look something like this:
+The 'frameworkAgreementDetails' JSON object from the API should look something like this:
 {
     "frameworkName": "Digital Outcomes and Specialists 2",
     "frameworkAgreementVersion": "RM1043iv",
@@ -32,11 +32,10 @@ The supplied JSON file should look something like this:
 }
 
 Usage:
-    scripts/generate-framework-agreement-signature-pages.py <stage> <api_token> <framework_slug> <framework_json>
-    <template_folder> <output_folder> [<supplier_id_file>]
+    scripts/generate-framework-agreement-signature-pages.py <stage> <api_token> <framework_slug> <template_folder>
+    <output_folder> [<supplier_id_file>]
 
 """
-import json
 import os
 import shutil
 import sys
@@ -57,8 +56,8 @@ if __name__ == '__main__':
     args = docopt(__doc__)
 
     framework_slug = args['<framework_slug>']
-    framework_kwargs = declaration_definite_pass_schema = json.load(open(args["<framework_json>"], "r"))
     client = DataAPIClient(get_api_endpoint_from_stage(args['<stage>']), args['<api_token>'])
+    framework_kwargs = client.get_framework(framework_slug)['frameworks']['frameworkAgreementDetails']
 
     supplier_id_file = args['<supplier_id_file>']
     if supplier_id_file:

--- a/scripts/generate-framework-agreement-signature-pages.py
+++ b/scripts/generate-framework-agreement-signature-pages.py
@@ -12,23 +12,27 @@ in the API response for the given framework.
 
 The 'frameworkAgreementDetails' JSON object from the API should look something like this:
 {
-    "frameworkName": "Digital Outcomes and Specialists 2",
+    "contractNoticeNumber": "2016/S 217-395765",
     "frameworkAgreementVersion": "RM1043iv",
-    "frameworkRefDate": "16-01-2017",
-    "frameworkStartDate": "30/01/2017",
     "frameworkEndDate": "29/01/2018",
     "frameworkExtensionLength": "12 months",
+    "frameworkRefDate": "16-01-2017",
+    "frameworkStartDate": "30/01/2017",
     "frameworkURL": "https://www.gov.uk/government/publications/digital-outcomes-and-specialists-2-framework-agreement",
-    "pageNumber": "3",
-    "pageTotal": "45",
-    "contractNoticeNumber": "2016/S 217-395765",
-    "lotOrder": ["digital-outcomes", "digital-specialists", "user-research-studios", "user-research-participants"],
     "lotDescriptions": {
-        "digital-outcomes": "Lot 1: digital outcomes",
-        "digital-specialists": "Lot 2: digital specialists",
-        "user-research-studios": "Lot 3: user research studios",
-        "user-research-participants": "Lot 4: user research participants"
-    }
+      "digital-outcomes": "Lot 1: digital outcomes",
+      "digital-specialists": "Lot 2: digital specialists",
+      "user-research-participants": "Lot 4: user research participants",
+      "user-research-studios": "Lot 3: user research studios"
+    },
+    "lotOrder": [
+      "digital-outcomes",
+      "digital-specialists",
+      "user-research-studios",
+      "user-research-participants"
+    ],
+    "pageTotal": 45,
+    "signaturePageNumber": 3
 }
 
 Usage:
@@ -57,7 +61,9 @@ if __name__ == '__main__':
 
     framework_slug = args['<framework_slug>']
     client = DataAPIClient(get_api_endpoint_from_stage(args['<stage>']), args['<api_token>'])
-    framework_kwargs = client.get_framework(framework_slug)['frameworks']['frameworkAgreementDetails']
+    framework = client.get_framework(framework_slug)['frameworks']
+    framework_kwargs = framework['frameworkAgreementDetails']
+    framework_kwargs['frameworkName'] = framework['name']
 
     supplier_id_file = args['<supplier_id_file>']
     if supplier_id_file:

--- a/scripts/make-g-cloud-live.py
+++ b/scripts/make-g-cloud-live.py
@@ -1,4 +1,8 @@
 """
+PREREQUISITE: For document migration to work you'll need AWS credentials set up for the relevant environment:
+              Save your aws_access_key_id and aws_secret_access_key in ~/.aws/credentials
+              If you have more than one set of credentials in there then be sure to set your AWS_PROFILE environment
+              variable to reference the right credentials before running the script.
 
 For a G-Cloud style framework (with uploaded documents to migrate) this will:
  1. Find all suppliers awarded onto the framework

--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -1,4 +1,9 @@
 """
+PREREQUISITE: You'll need AWS credentials set up for the environment that you're uploading to:
+              Save your aws_access_key_id and aws_secret_access_key in ~/.aws/credentials
+              If you have more than one set of credentials in there then be sure to set your AWS_PROFILE environment
+              variable to reference the right credentials before running the script.
+
 This will:
  * scan a directory for pdf files (they should be in the format <supplier_id>-some-ignored-words.pdf but this isn't
    enforced)


### PR DESCRIPTION
Previously we needed to pass in a JSON file but now this JSON will come from the frameworkAgreementDetails an the API response for the framework.