### PR TITLE
[#127983495]upload_counterpart_agreement notifications

### DIFF
--- a/dmscripts/upload_counterpart_agreements.py
+++ b/dmscripts/upload_counterpart_agreements.py
@@ -34,7 +34,7 @@ def upload_counterpart_file(
     supplier_name = supplier_framework['declaration']['nameOfOrganisation']
     download_filename = generate_download_filename(supplier_id, COUNTERPART_FILENAME, supplier_name)
 
-    notify_emails = dm_notify_client and frozenset(chain(
+    email_addresses_to_notify = dm_notify_client and frozenset(chain(
         (supplier_framework["declaration"]["primaryContactEmail"],),
         (
             user["emailAddress"]
@@ -71,7 +71,7 @@ def upload_counterpart_file(
                 upload_path, supplier_framework['agreementId'])
             )
 
-        for notify_email in (notify_emails or ()):
+        for notify_email in (email_addresses_to_notify or ()):
             if not dry_run:
                 dm_notify_client.send_email(notify_email, notify_template_id, {
                     "framework_slug": framework["slug"],

--- a/dmscripts/upload_counterpart_agreements.py
+++ b/dmscripts/upload_counterpart_agreements.py
@@ -5,8 +5,8 @@ from boto.exception import S3ResponseError
 from dmapiclient import APIError
 from dmutils.documents import generate_timestamped_document_upload_path, generate_download_filename, \
     COUNTERPART_FILENAME
-from dmutils.email.exceptions import EmailError
 from dmutils.email.helpers import hash_string
+from dmutils.email.exceptions import EmailError
 
 from dmscripts.bulk_upload_documents import get_supplier_id_from_framework_file_path
 from dmscripts.helpers import logging_helpers
@@ -21,6 +21,7 @@ def upload_counterpart_file(
         data_api_client,
         dm_notify_client=None,
         notify_template_id=None,
+        notify_fail_early=True,
         logger=None,
         ):
     if bool(dm_notify_client) != bool(notify_template_id):
@@ -71,25 +72,36 @@ def upload_counterpart_file(
                 upload_path, supplier_framework['agreementId'])
             )
 
+        failed_send_email_calls = 0
         for notify_email in (email_addresses_to_notify or ()):
-            if not dry_run:
-                dm_notify_client.send_email(notify_email, notify_template_id, {
-                    "framework_slug": framework["slug"],
-                    "framework_name": framework["name"],
-                    "supplier_name": supplier_name,
-                }, allow_resend=True)
-            else:
-                logger.info("[Dry-run] Send notify email to %s", hash_string(notify_email))
+            try:
+                if not dry_run:
+                    dm_notify_client.send_email(notify_email, notify_template_id, {
+                        "framework_slug": framework["slug"],
+                        "framework_name": framework["name"],
+                        "supplier_name": supplier_name,
+                    }, allow_resend=True)
+                else:
+                    logger.info("[Dry-run] Send notify email to %s", hash_string(notify_email))
+            except EmailError as e:
+                if notify_fail_early:
+                    raise
+                else:
+                    failed_send_email_calls += 1
+    # just catching these exceptions for logging then reraising
     except (OSError, IOError) as e:
         logger.error("Error reading file '{}': {}".format(file_path, e.message))
+        raise
     except S3ResponseError as e:
         logger.error("Error uploading '{}' to '{}': {}".format(file_path, upload_path, e.message))
-    except EmailError as e:
-        # dm_notify_client should have already logged the error
-        pass
+        raise
     except APIError as e:
         logger.error("API error setting upload path '{}' on agreement ID {}: {}".format(
             upload_path,
             supplier_framework['agreementId'],
             e.message)
         )
+        raise
+
+    if failed_send_email_calls:
+        raise EmailError("{} notify send_emails calls failed".format(failed_send_email_calls))

--- a/dmscripts/upload_counterpart_agreements.py
+++ b/dmscripts/upload_counterpart_agreements.py
@@ -1,4 +1,5 @@
 import getpass
+from itertools import chain
 
 from boto.exception import S3ResponseError
 from dmapiclient import APIError
@@ -9,18 +10,38 @@ from dmscripts.bulk_upload_documents import get_supplier_id_from_framework_file_
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
 
-logger = logging_helpers.configure_logger({'dmapiclient.base': logging.WARNING})
 
+def upload_counterpart_file(
+        bucket,
+        framework,
+        file_path,
+        dry_run,
+        data_api_client,
+        dm_notify_client=None,
+        notify_template_id=None,
+        logger=None,
+        ):
+    if bool(dm_notify_client) != bool(notify_template_id):
+        raise TypeError("Either specify both dm_notify_client and notify_template_id or neither")
 
-def upload_counterpart_file(bucket, framework_slug, file_path, dry_run, client):
+    logger = logger or logging_helpers.getLogger()
+
     supplier_id = get_supplier_id_from_framework_file_path(file_path)
-    supplier_framework = client.get_supplier_framework_info(supplier_id, framework_slug)
+    supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework["slug"])
     supplier_framework = supplier_framework['frameworkInterest']
     supplier_name = supplier_framework['declaration']['nameOfOrganisation']
     download_filename = generate_download_filename(supplier_id, COUNTERPART_FILENAME, supplier_name)
 
+    notify_emails = dm_notify_client and frozenset(chain(
+        (supplier_framework["declaration"]["primaryContactEmail"],),
+        (
+            user["emailAddress"]
+            for user in data_api_client.find_users_iter(supplier_id=int(supplier_id)) if user["active"]
+        ),
+    ))
+
     upload_path = generate_timestamped_document_upload_path(
-        framework_slug,
+        framework["slug"],
         supplier_id,
         "agreements",
         COUNTERPART_FILENAME
@@ -34,7 +55,7 @@ def upload_counterpart_file(bucket, framework_slug, file_path, dry_run, client):
                 logger.info("UPLOADED: '{}' to '{}'".format(file_path, upload_path))
 
             # Save filepath to framework agreement
-            client.update_framework_agreement(
+            data_api_client.update_framework_agreement(
                 supplier_framework['agreementId'],
                 {"countersignedAgreementPath": upload_path},
                 'upload-counterpart-agreements script run by {}'.format(getpass.getuser())
@@ -47,6 +68,16 @@ def upload_counterpart_file(bucket, framework_slug, file_path, dry_run, client):
             logger.info("[Dry-run] countersignedAgreementPath='{}' for agreement ID {}".format(
                 upload_path, supplier_framework['agreementId'])
             )
+
+        for notify_email in (notify_emails or ()):
+            if not dry_run:
+                dm_notify_client.send_email(notify_email, notify_template_id, {
+                    "framework_slug": framework["slug"],
+                    "framework_name": framework["name"],
+                    "supplier_name": supplier_name,
+                }, allow_resend=True)
+            else:
+                logger.info("[Dry-run] Send notify email to %s", notify_email)
     except (OSError, IOError) as e:
         logger.error("Error reading file '{}': {}".format(file_path, e.message))
     except S3ResponseError as e:

--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -22,8 +22,15 @@ This will:
 
    * set the "countersigned agreement path" in the current FrameworkAgreement referenced by the SupplierFramework
 
-Usage:
-   scripts/upload-counterpart-agreemets.py <stage> <api_token> <documents_directory> <framework_slug> [--dry-run]
+   * if <notify_key> and <notify_template_id> are provided, will send a notification email to all the supplier's active
+     users (and their primaryContactEmail for that framework)
+
+Usage: scripts/upload-counterpart-agreemets.py <stage> <api_token> <documents_directory> <framework_slug> [options]
+
+Options:
+    --dry-run                                   # Don't actually do anything
+    --notify-key=<notify_key>                   # GOV.UK Notify service key
+    --notify-template-id=<notify_template_id>   # GOV.UK Notify template id for notification email
 
 """
 
@@ -33,20 +40,31 @@ sys.path.insert(0, '.')
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.bulk_upload_documents import get_bucket_name, get_all_files_of_type
 from dmscripts.upload_counterpart_agreements import upload_counterpart_file
+from dmscripts.helpers import logging_helpers
+from dmscripts.helpers.logging_helpers import logging
+
 from docopt import docopt
 from dmapiclient import DataAPIClient
 
 from dmutils.s3 import S3
+from dmutils.email.dm_notify import DMNotifyClient
+
+
+logger = logging_helpers.configure_logger({'dmapiclient.base': logging.WARNING})
 
 
 if __name__ == '__main__':
     arguments = docopt(__doc__)
 
+    if bool(arguments.get("--notify-key")) != bool(arguments.get("--notify-template-id")):
+        raise ValueError("Either specify both --notify-key and --notify-template-id or neither")
+
     stage = arguments['<stage>']
-    client = DataAPIClient(get_api_endpoint_from_stage(stage), arguments['<api_token>'])
-    framework_slug = arguments['<framework_slug>']
+    data_api_client = DataAPIClient(get_api_endpoint_from_stage(stage), arguments['<api_token>'])
+    framework = data_api_client.get_framework(arguments['<framework_slug>'])["frameworks"]
     document_directory = arguments['<documents_directory>']
     dry_run = arguments['--dry-run']
+    dm_notify_client = arguments.get("--notify-key") and DMNotifyClient(arguments["--notify-key"], logger=logger)
 
     if dry_run:
         bucket = None
@@ -54,4 +72,13 @@ if __name__ == '__main__':
         bucket = S3(get_bucket_name(stage, "agreements"))
 
     for file_path in get_all_files_of_type(document_directory, "pdf"):
-        upload_counterpart_file(bucket, framework_slug, file_path, dry_run, client)
+        upload_counterpart_file(
+            bucket,
+            framework,
+            file_path,
+            dry_run,
+            data_api_client,
+            dm_notify_client=dm_notify_client,
+            notify_template_id=arguments.get("--notify-template-id"),
+            logger=logger,
+        )

--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -50,7 +50,10 @@ from dmutils.s3 import S3
 from dmutils.email.dm_notify import DMNotifyClient
 
 
-logger = logging_helpers.configure_logger({'dmapiclient.base': logging.WARNING})
+logger = logging_helpers.configure_logger({
+    'dmapiclient.base': logging.WARNING,
+    'notifications_python_client.base': logging.WARNING,
+})
 
 
 if __name__ == '__main__':

--- a/tests/test_upload_counterpart_agreements.py
+++ b/tests/test_upload_counterpart_agreements.py
@@ -10,8 +10,9 @@ else:
     import builtins
 
 
+@pytest.mark.parametrize("notify_fail_early", (False, True,))  # should make no difference
 @mock.patch('dmscripts.upload_counterpart_agreements.getpass.getuser')
-def test_upload_counterpart_file_uploads_and_calls_api_if_not_dry_run(getuser):
+def test_upload_counterpart_file_uploads_and_calls_api_if_not_dry_run(getuser, notify_fail_early):
     getuser.return_value = 'test user'
     bucket = mock.Mock()
     data_api_client = mock.Mock()
@@ -35,6 +36,7 @@ def test_upload_counterpart_file_uploads_and_calls_api_if_not_dry_run(getuser):
                 'pdfs/123456-file.pdf',
                 False,
                 data_api_client,
+                notify_fail_early=notify_fail_early,
             )
 
             bucket.save.assert_called_once_with(
@@ -55,7 +57,8 @@ def test_upload_counterpart_file_uploads_and_calls_api_if_not_dry_run(getuser):
             )
 
 
-def test_upload_counterpart_file_does_not_perform_actions_if_dry_run():
+@pytest.mark.parametrize("notify_fail_early", (False, True,))  # should make no difference
+def test_upload_counterpart_file_does_not_perform_actions_if_dry_run(notify_fail_early):
     bucket = mock.Mock()
     data_api_client = mock.Mock()
     data_api_client.get_supplier_framework_info.return_value = {
@@ -96,6 +99,7 @@ def test_upload_counterpart_file_does_not_perform_actions_if_dry_run():
             data_api_client,
             dm_notify_client=dm_notify_client,
             notify_template_id="dead-beef-baad-f00d",
+            notify_fail_early=notify_fail_early,
         )
 
         assert bucket.save.called is False
@@ -171,7 +175,12 @@ def test_upload_counterpart_file_does_not_perform_actions_if_dry_run():
         ),
     ),
 ))
-def test_upload_counterpart_file_sends_correct_emails(find_users_iterable, expected_send_email_emails):
+@pytest.mark.parametrize("notify_fail_early", (False, True,))  # should make no difference
+def test_upload_counterpart_file_sends_correct_emails(
+        notify_fail_early,
+        find_users_iterable,
+        expected_send_email_emails,
+        ):
     bucket = mock.Mock()
     data_api_client = mock.Mock()
     data_api_client.get_supplier_framework_info.return_value = {
@@ -198,6 +207,7 @@ def test_upload_counterpart_file_sends_correct_emails(find_users_iterable, expec
             data_api_client,
             dm_notify_client=dm_notify_client,
             notify_template_id="dead-beef-baad-f00d",
+            notify_fail_early=notify_fail_early,
         )
 
         assert bucket.save.called is True

--- a/tests/test_upload_counterpart_agreements.py
+++ b/tests/test_upload_counterpart_agreements.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 from sys import version_info
 from freezegun import freeze_time
 from dmscripts.upload_counterpart_agreements import upload_counterpart_file
@@ -13,17 +14,28 @@ else:
 def test_upload_counterpart_file_uploads_and_calls_api_if_not_dry_run(getuser):
     getuser.return_value = 'test user'
     bucket = mock.Mock()
-    client = mock.Mock()
-    client.get_supplier_framework_info.return_value = {
+    data_api_client = mock.Mock()
+    data_api_client.get_supplier_framework_info.return_value = {
         "frameworkInterest": {
             "agreementId": 23,
-            "declaration": {"nameOfOrganisation": "The supplier who signed"}
+            "declaration": {
+                "nameOfOrganisation": "The supplier who signed",
+            },
         }
     }
 
     with freeze_time('2016-11-12 13:14:15'):
         with mock.patch.object(builtins, 'open', mock.mock_open(read_data='foo')):
-            upload_counterpart_file(bucket, 'g-cloud-8', 'pdfs/123456-file.pdf', False, client)
+            upload_counterpart_file(
+                bucket,
+                {
+                    "name": "Gee Cloud Eight",
+                    "slug": "g-cloud-8",
+                },
+                'pdfs/123456-file.pdf',
+                False,
+                data_api_client,
+            )
 
             bucket.save.assert_called_once_with(
                 "g-cloud-8/agreements/123456/123456-agreement-countersignature-2016-11-12-131415.pdf",
@@ -33,27 +45,174 @@ def test_upload_counterpart_file_uploads_and_calls_api_if_not_dry_run(getuser):
                 download_filename='The_supplier_who_signed-123456-agreement-countersignature.pdf'
             )
 
-            client.update_framework_agreement.assert_called_once_with(
+            data_api_client.update_framework_agreement.assert_called_once_with(
                 23,
-                {'countersignedAgreementPath':
+                {
+                    'countersignedAgreementPath':
                     'g-cloud-8/agreements/123456/123456-agreement-countersignature-2016-11-12-131415.pdf'
-                 },
+                },
                 'upload-counterpart-agreements script run by test user'
             )
 
 
-def test_upload_counterpart_file_does_not_upload_or_call_api_if_dry_run():
+def test_upload_counterpart_file_does_not_perform_actions_if_dry_run():
     bucket = mock.Mock()
-    client = mock.Mock()
-    client.get_supplier_framework_info.return_value = {
+    data_api_client = mock.Mock()
+    data_api_client.get_supplier_framework_info.return_value = {
         "frameworkInterest": {
             "agreementId": 23,
-            "declaration": {"nameOfOrganisation": "The supplier who signed"}
-        }
+            "declaration": {
+                "nameOfOrganisation": "The supplier who signed",
+                "primaryContactEmail": "supplier.primary@example.com",
+            },
+        },
     }
+    data_api_client.find_users_iter.side_effect = lambda *args, **kwargs: iter((
+        {
+            "id": 111322,
+            "emailAddress": "user.111322@example.com",
+            "supplierId": 123456,
+            "active": True,
+        },
+        {
+            "id": 111321,
+            "emailAddress": "user.111321@example.com",
+            "supplierId": 123456,
+            "active": True,
+        },
+    ))
+    dm_notify_client = mock.Mock()
+    dm_notify_client.send_email.side_effect = AssertionError("This shouldn't be called")
 
     with mock.patch.object(builtins, 'open', mock.mock_open(read_data='foo')):
-        upload_counterpart_file(bucket, 'g-cloud-8', 'pdfs/123456-file.pdf', True, client)
+        upload_counterpart_file(
+            bucket,
+            {
+                "name": "Dos Two",
+                "slug": "digital-outcomes-and-specialists-2",
+            },
+            'pdfs/123456-file.pdf',
+            True,
+            data_api_client,
+            dm_notify_client=dm_notify_client,
+            notify_template_id="dead-beef-baad-f00d",
+        )
 
-        bucket.save.assert_not_called()
-        client.update_framework_agreement.assert_not_called()
+        assert bucket.save.called is False
+        assert data_api_client.update_framework_agreement.called is False
+        data_api_client.find_users_iter.assert_called_with(supplier_id=123456)
+
+
+@pytest.mark.parametrize("find_users_iterable,expected_send_email_emails", (
+    (
+        (
+            {
+                "id": 111322,
+                "emailAddress": "user.111322@example.com",
+                "supplierId": 123456,
+                "active": True,
+            },
+            {
+                "id": 111321,
+                "emailAddress": "user.111321@example.com",
+                "supplierId": 123456,
+                "active": True,
+            },
+            {
+                "id": 111320,
+                "emailAddress": "user.111320@example.com",
+                "supplierId": 123456,
+                "active": False,
+            },
+            {
+                "id": 111323,
+                "emailAddress": "supplier.primary@example.com",
+                "supplierId": 123456,
+                "active": True,
+            },
+        ),
+        (
+            "supplier.primary@example.com",
+            "user.111321@example.com",
+            "user.111322@example.com",
+        ),
+    ),
+    (
+        (
+            {
+                "id": 111329,
+                "emailAddress": "user.111329@example.com",
+                "supplierId": 123456,
+                "active": True,
+            },
+            {
+                "id": 111320,
+                "emailAddress": "user.111320@example.com",
+                "supplierId": 123456,
+                "active": False,
+            },
+        ),
+        (
+            "supplier.primary@example.com",
+            "user.111329@example.com",
+        ),
+    ),
+    (
+        (
+            {
+                "id": 222765,
+                "emailAddress": "user.222765@example.com",
+                "supplierId": 123456,
+                "active": False,
+            },
+        ),
+        (
+            "supplier.primary@example.com",
+        ),
+    ),
+))
+def test_upload_counterpart_file_sends_correct_emails(find_users_iterable, expected_send_email_emails):
+    bucket = mock.Mock()
+    data_api_client = mock.Mock()
+    data_api_client.get_supplier_framework_info.return_value = {
+        "frameworkInterest": {
+            "agreementId": 23,
+            "declaration": {
+                "nameOfOrganisation": "The supplier who signed",
+                "primaryContactEmail": "supplier.primary@example.com",
+            },
+        },
+    }
+    data_api_client.find_users_iter.side_effect = lambda *args, **kwargs: iter(find_users_iterable)
+    dm_notify_client = mock.Mock()
+
+    with mock.patch.object(builtins, 'open', mock.mock_open(read_data='foo')):
+        upload_counterpart_file(
+            bucket,
+            {
+                "name": "Dos Two",
+                "slug": "digital-outcomes-and-specialists-2",
+            },
+            'pdfs/123456-file.pdf',
+            False,
+            data_api_client,
+            dm_notify_client=dm_notify_client,
+            notify_template_id="dead-beef-baad-f00d",
+        )
+
+        assert bucket.save.called is True
+        assert data_api_client.update_framework_agreement.called is True
+        data_api_client.find_users_iter.assert_called_with(supplier_id=123456)
+
+        expected_personalisation = {
+            "framework_slug": "digital-outcomes-and-specialists-2",
+            "framework_name": "Dos Two",
+            "supplier_name": "The supplier who signed",
+        }
+
+        assert sorted(dm_notify_client.send_email.call_args_list) == sorted(
+            (
+                (email, "dead-beef-baad-f00d", expected_personalisation),
+                {"allow_resend": True},
+            ) for email in expected_send_email_emails
+        )


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/127983495

One thing I'm considering is whether it's the right thing to swallow `EmailError` and continue to the next supplier - if we're not able to send an email we maybe don't want to blaze ahead and upload a bunch of files if there's a likelihood that *all* the emails are going to fail and we've just lost the chance to send the users emails...?