### PR TITLE
Add `frameworkSlug` and `specialistRole` to final csv

### DIFF
--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -186,6 +186,8 @@ CONFIGS = [
             'essentialRequirements-False',
             'essentialRequirements-True',
             'clarificationQuestions',
+            'frameworkSlug',
+            'specialistRole'
         ),
         'sort_by': ['id']
     }


### PR DESCRIPTION
For each brief, we know how many people applied to it, as well as how many people applied successfully/unsuccessfully.

Ash also wants to know how many people _could have_ applied to each brief, so we're putting some more stuff in the information about the applied-to briefs so that he can use a lookup table.