### PR TITLE
[#141943157]mark_definite_framework_results: make declaration "status" handling "special case"

### DIFF
--- a/dmscripts/mark_definite_framework_results.py
+++ b/dmscripts/mark_definite_framework_results.py
@@ -99,12 +99,13 @@ def mark_definite_framework_results(
             logger=logger
         )
 
-        if service_counter["passed"] and _passes_validation(
-                supplier_framework["declaration"],
-                declaration_definite_pass_schema,
-                logger,
-                schema_name="declaration_definite_pass_schema",
-                tablevel=1,
+        if supplier_framework["declaration"].get("status") == "complete" and service_counter["passed"] and \
+                _passes_validation(
+                    supplier_framework["declaration"],
+                    declaration_definite_pass_schema,
+                    logger,
+                    schema_name="declaration_definite_pass_schema",
+                    tablevel=1,
                 ):
             logger.info("\tResult: PASS")
             if not dry_run:
@@ -112,12 +113,13 @@ def mark_definite_framework_results(
                     client.set_framework_result(supplier_id, framework_slug, True, updated_by)
                 else:
                     logger.debug("\tUnchanged result - not re-setting")
-        elif (not service_counter["passed"]) or (declaration_baseline_schema and not _passes_validation(
-                supplier_framework["declaration"],
-                declaration_baseline_schema,
-                logger,
-                schema_name="declaration_baseline_schema",
-                tablevel=1,
+        elif supplier_framework["declaration"].get("status") != "complete" or (not service_counter["passed"]) or \
+                (declaration_baseline_schema and not _passes_validation(
+                    supplier_framework["declaration"],
+                    declaration_baseline_schema,
+                    logger,
+                    schema_name="declaration_baseline_schema",
+                    tablevel=1,
                 )):
             logger.info("\tResult: FAIL")
             if not dry_run:

--- a/schemas/digital-outcomes-and-services-2.declaration.json
+++ b/schemas/digital-outcomes-and-services-2.declaration.json
@@ -28,7 +28,6 @@
             "$schema": "http://json-schema.org/draft-04/schema#",
             "type": "object",
             "properties": {
-                "status": {"enum": ["complete"]},
                 "termsOfParticipation": {"enum": [true]},
                 "termsAndConditions": {"enum": [true]},
                 "10WorkingDays": {"enum": [true]},
@@ -70,8 +69,7 @@
                 "publishContracts": {"enum": [true]},
                 "safeguardOfficialInformation": {"enum": [true]},
                 "safeguardPersonalData": {"enum": [true]}
-            },
-            "required": ["status"]
+            }
         }
     }
 }

--- a/tests/test_mark_definite_framework_results.py
+++ b/tests/test_mark_definite_framework_results.py
@@ -28,7 +28,6 @@ _declaration_definite_pass_schema = lambda: {
             "$schema": "http://json-schema.org/draft-04/schema#",
             "type": "object",
             "properties": {
-                "status": {"enum": ["complete"]},
                 "shouldBeFalseStrict": {"enum": [False]},
                 "shouldBeTrueStrict": {"enum": [True]},
                 "shouldMatchPatternStrict": {
@@ -441,6 +440,7 @@ def test_no_prev_results_no_baseline_schema(
     expected_sf_actions = {
         3456: False,
         4321: True,
+        4567: False,
         5432: False,
         6543: True,
         8765: True,
@@ -493,6 +493,7 @@ def test_no_prev_results_neither_optional_schema(
     expected_sf_actions = {
         3456: True,
         4321: True,
+        4567: False,
         5432: False,
         6543: True,
         8765: True,


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/141943157

It was going to be ugly to get the frameworks to automagically generate
an assessment schema that also included the `status` criteria, and what's
more we already do "special case" handling of the service "status" field.
also change included dos2 schema, no longer including `status`, to match
this.