### PR TITLE
Return error if errors generating PDFs and unobfuscate dry-run emails

### DIFF
--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -56,6 +56,7 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework_kwargs, 
 def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
     html_dir = os.path.abspath(html_dir)
     pdf_dir = os.path.abspath(pdf_dir)
+    ok = True
     if not os.path.exists(pdf_dir):
         os.mkdir(pdf_dir)
     for index, html_page in enumerate(html_pages):
@@ -65,3 +66,5 @@ def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
         exit_code = subprocess.call(['wkhtmltopdf', 'file://{}'.format(html_path), pdf_path])
         if exit_code > 0:
             logger.error("ERROR {} on {}".format(exit_code, html_page))
+            ok = False
+    return ok

--- a/dmscripts/upload_counterpart_agreements.py
+++ b/dmscripts/upload_counterpart_agreements.py
@@ -5,12 +5,10 @@ from boto.exception import S3ResponseError
 from dmapiclient import APIError
 from dmutils.documents import generate_timestamped_document_upload_path, generate_download_filename, \
     COUNTERPART_FILENAME
-from dmutils.email.helpers import hash_string
 from dmutils.email.exceptions import EmailError
 
 from dmscripts.bulk_upload_documents import get_supplier_id_from_framework_file_path
 from dmscripts.helpers import logging_helpers
-from dmscripts.helpers.logging_helpers import logging
 
 
 def upload_counterpart_file(
@@ -82,7 +80,7 @@ def upload_counterpart_file(
                         "supplier_name": supplier_name,
                     }, allow_resend=True)
                 else:
-                    logger.info("[Dry-run] Send notify email to %s", hash_string(notify_email))
+                    logger.info("[Dry-run] Send notify email to %s", notify_email)
             except EmailError as e:
                 if notify_fail_early:
                     raise

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -80,5 +80,7 @@ if __name__ == '__main__':
     html_pages = os.listdir(html_dir)
     html_pages.remove('framework-agreement-signature-page.css')
     html_pages.remove('framework-agreement-countersignature.png')
-    render_pdf_for_each_html_page(html_pages, html_dir, args['<output_folder>'])
+    ok = render_pdf_for_each_html_page(html_pages, html_dir, args['<output_folder>'])
     shutil.rmtree(html_dir)
+    if not ok:
+        sys.exit(1)

--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -25,7 +25,7 @@ This will:
    * if <notify_key> and <notify_template_id> are provided, will send a notification email to all the supplier's active
      users (and their primaryContactEmail for that framework)
 
-Usage: scripts/upload-counterpart-agreemets.py <stage> <api_token> <documents_directory> <framework_slug> [options]
+Usage: scripts/upload-counterpart-agreements.py <stage> <api_token> <documents_directory> <framework_slug> [options]
 
 Options:
     --dry-run                                   # Don't actually do anything


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/story/show/128842967

We need the Jenkins job to know if the PDF generation step hasn't worked as expected, so the script needs to return an error code.

Its also useful in dry-run mode to see what on earth the script would have done, so I'm unobfuscating email addresses in dry-run output.