### PR TITLE
Notify suppliers when framework closes

### DIFF
--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -111,3 +111,37 @@ class SuccessfulSupplierContextForNotify(SupplierFrameworkData):
         }
         personalisation.update(lot_dict)
         return {user['email address']: personalisation}
+
+
+class AppliedToFrameworkSupplierContextForNotify(SupplierFrameworkData):
+    """Get the personalisation/ context for 'You application result - if successful email'"""
+
+    def __init__(self, client, target_framework_slug, successful_notification_date):
+        """Get the target framework to operate on and list the lots.
+
+        :param client: Instantiated api client
+        :param target_framework_slug: Framework to fetch data for
+        """
+        super(AppliedToFrameworkSupplierContextForNotify, self).__init__(client, target_framework_slug)
+
+        self.successful_notification_date = successful_notification_date
+        self.framework = client.get_framework(self.target_framework_slug)['frameworks']
+
+    def get_users_peronalisations(self):
+        """Return {email_address: {personalisations}} for all users who expressed interest in the framework
+        """
+        output = {}
+        for supplier_framework in self.data:
+            for user in supplier_framework['users']:
+                output.update(self.get_user_personalisation(user))
+        return output
+
+    def get_user_personalisation(self, user):
+        """Get dict of all info required by template given a user and framework."""
+        personalisation = {
+            'successful_notification_date': self.successful_notification_date,
+            'framework_name': self.framework['name'],
+            'framework_slug': self.framework['slug'],
+            'applied': user['application_status'] == 'application'
+        }
+        return {user['email address']: personalisation}

--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -58,7 +58,7 @@ class SuccessfulSupplierContextForNotify(SupplierFrameworkData):
         self.framework = client.get_framework(self.target_framework_slug)['frameworks']
         self.framework_lots = [i['name'] for i in self.framework['lots']]
 
-    def get_users_peronalisations(self):
+    def get_users_personalisations(self):
         """Return {email_address: {personalisations}} for users eligible for the
         'Your application result - if successful' email
         """
@@ -127,7 +127,7 @@ class AppliedToFrameworkSupplierContextForNotify(SupplierFrameworkData):
         self.successful_notification_date = successful_notification_date
         self.framework = client.get_framework(self.target_framework_slug)['frameworks']
 
-    def get_users_peronalisations(self):
+    def get_users_personalisations(self):
         """Return {email_address: {personalisations}} for all users who expressed interest in the framework
         """
         output = {}

--- a/scripts/notify-successful-suppliers-for-framework.py
+++ b/scripts/notify-successful-suppliers-for-framework.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
 
     context_helper = SuccessfulSupplierContextForNotify(api_client, FRAMEWORK_SLUG)
     context_helper.populate_data()
-    context_data = context_helper.get_users_peronalisations()
+    context_data = context_helper.get_users_personalisations()
 
     for user_email, personalisation in context_data.items():
         logger.info(user_email)

--- a/scripts/notify-suppliers-whether-application-made-for-framework.py
+++ b/scripts/notify-suppliers-whether-application-made-for-framework.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
 
     context_helper = AppliedToFrameworkSupplierContextForNotify(api_client, FRAMEWORK_SLUG, NOTIFICATION_DATE)
     context_helper.populate_data()
-    context_data = context_helper.get_users_peronalisations()
+    context_data = context_helper.get_users_personalisations()
     error_count = 0
     for user_email, personalisation in context_data.items():
         logger.info(user_email)

--- a/scripts/notify-suppliers-whether-application-made-for-framework.py
+++ b/scripts/notify-suppliers-whether-application-made-for-framework.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Email all suppliers who registered interest in applying to a framework about whether or not they made an application.
+Uses the Notify API to send emails.
+
+Usage:
+    scripts/notify-suppliers-whether-application-made-for-framework.py <stage> <api_token> <framework_slug>
+        <govuk_notify_api_key> <successful_notification_date> [--dry-run]
+
+Example:
+    scripts/notify-suppliers-whether-application-made-for-framework.py preview myToken g-cloud-9
+        my-awesome-key "29th March 2017" --dry-run
+
+Options:
+    -h, --help  Show this screen
+"""
+import sys
+
+sys.path.insert(0, '.')
+from docopt import docopt
+
+from dmapiclient import DataAPIClient
+from dmutils.email.dm_notify import DMNotifyClient
+from dmutils.email.exceptions import EmailError
+from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
+from dmscripts.helpers import logging_helpers
+from dmscripts.helpers.logging_helpers import logging
+from dmscripts.helpers.supplier_data_helpers import AppliedToFrameworkSupplierContextForNotify
+
+logger = logging_helpers.configure_logger({"dmapiclient": logging.INFO})
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    STAGE = arguments['<stage>']
+    API_TOKEN = arguments['<api_token>']
+    FRAMEWORK_SLUG = arguments['<framework_slug>']
+    GOVUK_NOTIFY_API_KEY = arguments['<govuk_notify_api_key>']
+    NOTIFICATION_DATE = arguments['<successful_notification_date>']
+    DRY_RUN = arguments['--dry-run']
+
+    mail_client = DMNotifyClient(GOVUK_NOTIFY_API_KEY, logger=logger)
+    api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(STAGE), auth_token=API_TOKEN)
+
+    context_helper = AppliedToFrameworkSupplierContextForNotify(api_client, FRAMEWORK_SLUG, NOTIFICATION_DATE)
+    context_helper.populate_data()
+    context_data = context_helper.get_users_peronalisations()
+    error_count = 0
+    for user_email, personalisation in context_data.items():
+        logger.info(user_email)
+        template_id = ('de02a7e3-80f6-4391-818c-48326e1f4688'
+                       if personalisation['applied']
+                       else '87a126b4-7909-4b63-b981-d3c3d6a558ff')
+        if DRY_RUN:
+            logger.info("[Dry Run] Sending email {} to {}".format(template_id, user_email))
+        else:
+            try:
+                mail_client.send_email(user_email, template_id, personalisation, allow_resend=False)
+            except EmailError as e:
+                logger.error(u'Error sending email to {}: {}'.format(user_email, e))
+                error_count += 1
+
+    sys.exit(error_count)


### PR DESCRIPTION
Script for this story: https://www.pivotaltracker.com/story/show/141695173

It reuses the pattern from the existing `notify-successful-suppliers` script.  This one needs a slightly less complicated set of personalisation data so the new `AppliedToFrameworkSupplierContextForNotify` is pretty simple.  I discussed with Paul whether it should instead use the `modeltrawler` pattern but we decided that wasn't a good way to go right now (time constraints as much as anything else, but this also isn't quite the typical use-case for modeltrawler).

I hard-coded the Notify template IDs in the script as (1) these shouldn't change from framework to framework and (2) it feels less error-prone than people having to pass multiple template IDs as command line params.

The fetch of user data here is relying on the currently-broken `export_users` method on the API.  This is a shame - it wasn't broken when I wrote this - but hopefully we'll find some way to fix it before tomorrow rather than having to move all the logic for "applied/didn't apply" out to this script.