### PR TITLE
Implement script to send emails for each DOS lot using Mailchimp client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 __pycache__
 output/
+venv

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -15,20 +15,23 @@ from dmscripts.helpers.logging_helpers import logging
 logger = logging_helpers.configure_logger({'dmapiclient': logging.INFO})
 
 
-lots = {
-    "digital-specialists": {
+lots = [
+    {
+        "lot_slug": "digital-specialists",
         "lot_name": "Digital specialists",
         "list_id": "096e52cebb"
     },
-    "digital-outcomes": {
+    {
+        "lot_slug": "digital-outcomes",
         "lot_name": "Digital outcomes",
         "list_id": "096e52cebb"
     },
-    "user-research-participants": {
+    {
+        "lot_slug": "user-research-participants",
         "lot_name": "User research participants",
         "list_id": "096e52cebb"
     }
-}
+]
 
 
 def create_campaign_data(lot_name, list_id):
@@ -101,10 +104,24 @@ def send_campaign(mailchimp_client, campaign_id):
     return False
 
 
-def main(mailchimp_username, mailchimp_api_key):
-    mailchimp_client = MailChimp(mailchimp_username, mailchimp_api_key)
+def get_mailchimp_client(mailchimp_username, mailchimp_api_key):
+    return MailChimp(mailchimp_username, mailchimp_api_key)
 
-    campaign_id = create_campaign(mailchimp_client)
-    if not campaign_id:
-        return False
+
+def main(mailchimp_username, mailchimp_api_key):
+    mailchimp_client = get_mailchimp_client(mailchimp_username, mailchimp_api_key)
+
+    for lot in lots:
+        campaign_data = create_campaign_data(lot["lot_name"], lot["list_id"])
+        campaign_id = create_campaign(mailchimp_client, campaign_data)
+        if not campaign_id:
+            return False
+
+        content_data = get_html_content()
+        if not set_campaign_content(mailchimp_client, campaign_id, content_data):
+            return False
+
+        if not send_campaign(mailchimp_client, campaign_id):
+            return False
+
     return True

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -1,7 +1,3 @@
-"""Spike script into mail chimp email sending.
-
-Test list ID is "096e52cebb" which can be used for local development
-"""
 from datetime import datetime, date, timedelta
 
 from requests.exceptions import RequestException
@@ -53,6 +49,7 @@ def get_campaign_data(lot_name, list_id):
 
 
 def get_html_content():
+    # function not yet implemented
     html_content = render_html("email_templates/dos_opportunities.html", data={})
     return {"html": html_content}
 

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -17,24 +17,6 @@ import dmapiclient
 
 logger = logging_helpers.configure_logger({'dmapiclient': logging.INFO})
 
-lots = [
-    {
-        "lot_slug": "digital-specialists",
-        "lot_name": "Digital specialists",
-        "list_id": "096e52cebb"
-    },
-    {
-        "lot_slug": "digital-outcomes",
-        "lot_name": "Digital outcomes",
-        "list_id": "096e52cebb"
-    },
-    {
-        "lot_slug": "user-research-participants",
-        "lot_name": "User research participants",
-        "list_id": "096e52cebb"
-    }
-]
-
 
 def get_live_briefs_between_two_dates(data_api_client, lot_slug, start_date, end_date):
     return [
@@ -118,26 +100,25 @@ def get_mailchimp_client(mailchimp_username, mailchimp_api_key):
     return MailChimp(mailchimp_username, mailchimp_api_key)
 
 
-def main(data_api_url, data_api_access_token, mailchimp_username, mailchimp_api_key, number_of_days):
+def main(data_api_url, data_api_access_token, mailchimp_username, mailchimp_api_key, lot_data, number_of_days):
     data_api_client = dmapiclient.DataAPIClient(data_api_url, data_api_access_token)
     mailchimp_client = get_mailchimp_client(mailchimp_username, mailchimp_api_key)
 
     start_date = date.today() - timedelta(days=number_of_days)
     end_date = date.today() - timedelta(days=1)
 
-    for lot in lots:
-        get_live_briefs_between_two_dates(data_api_client, lot["lot_slug"], start_date, end_date)
+    get_live_briefs_between_two_dates(data_api_client, lot_data["lot_slug"], start_date, end_date)
 
-        campaign_data = create_campaign_data(lot["lot_name"], lot["list_id"])
-        campaign_id = create_campaign(mailchimp_client, campaign_data)
-        if not campaign_id:
-            return False
+    campaign_data = create_campaign_data(lot_data["lot_name"], lot_data["list_id"])
+    campaign_id = create_campaign(mailchimp_client, campaign_data)
+    if not campaign_id:
+        return False
 
-        content_data = get_html_content()
-        if not set_campaign_content(mailchimp_client, campaign_id, content_data):
-            return False
+    content_data = get_html_content()
+    if not set_campaign_content(mailchimp_client, campaign_id, content_data):
+        return False
 
-        if not send_campaign(mailchimp_client, campaign_id):
-            return False
+    if not send_campaign(mailchimp_client, campaign_id):
+        return False
 
     return True

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -107,7 +107,12 @@ def main(data_api_url, data_api_access_token, mailchimp_username, mailchimp_api_
     start_date = date.today() - timedelta(days=number_of_days)
     end_date = date.today() - timedelta(days=1)
 
-    get_live_briefs_between_two_dates(data_api_client, lot_data["lot_slug"], start_date, end_date)
+    if not get_live_briefs_between_two_dates(data_api_client, lot_data["lot_slug"], start_date, end_date):
+        logger.info(
+            "No new briefs found for '{0}' lot".format(lot_data["lot_slug"]),
+            extra={"number_of_days": number_of_days}
+        )
+        return True
 
     campaign_data = create_campaign_data(lot_data["lot_name"], lot_data["list_id"])
     campaign_id = create_campaign(mailchimp_client, campaign_data)

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -1,0 +1,66 @@
+"""Spike script into mail chimp email sending."""
+from mailchimp3 import MailChimp
+
+from dmscripts.helpers.html_helpers import render_html
+
+SPECIALISTS_CAMPAIGN_DATA = {
+	"type": "regular",
+	"recipients": {
+		"list_id": "096e52cebb",  # test list containing one user (david mcdonald work email)
+	},
+	"settings": {
+		"subject_line": "New opportunities for Digital Specialists: Digital Outcomes and Specialists 2",
+		"title": "TEST! DOS Suppliers: Specialists [16 March]",
+		"from_name": "Digital Marketplace Team",
+		"reply_to": "do-not-reply@digitalmarketplace.service.gov.uk",
+		"use_conversation": False,
+		"authenticate": True,
+		"auto_footer": False,
+		"inline_css": False,
+		"auto_tweet": False,
+		"fb_comments": False
+	},
+	"tracking": {
+		"opens": True,
+		"html_clicks": True,
+		"text_clicks": False,
+		"goal_tracking": False,
+		"ecomm360": False
+	}
+}
+
+def get_html_content():
+	email_body = render_html('email_templates/dos_opportunities.html', data={})
+	return email_body
+
+def create_campaign(mailchimp_client):
+	try:
+		res = mailchimp_client.campaigns.create(data=SPECIALISTS_CAMPAIGN_DATA)
+		campaign_id = res['id']
+	except Exception as e:
+		print e
+
+	SPECIALISTS_CONTENT_DATA = {
+		"html": get_html_content()
+	}
+
+	try:
+		mailchimp_client.campaigns.content.update(campaign_id=campaign_id, data=SPECIALISTS_CONTENT_DATA)
+	except Exception as e:
+		print e
+
+	return campaign_id
+
+def send_campaign(mailchimp_client, campaign_id):
+	try:
+		return client.campaigns.actions.send(campaign_id=campaign_id)
+	except Exception as e:
+		print e
+
+def main(mailchimp_username, mailchimp_api_key):
+	mailchimp_client = MailChimp(mailchimp_username, mailchimp_api_key)
+
+	campaign_id = create_campaign(mailchimp_client)
+	if not campaign_id:
+		return False
+	return True

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -63,7 +63,7 @@ def create_campaign(mailchimp_client, campaign_data):
             "Mailchimp failed to create campaign for '{0}'".format(
                 campaign_data.get("settings").get("title")
             ),
-            extra={"error": e.message}
+            extra={"error": str(e)}
         )
     return False
 
@@ -74,7 +74,7 @@ def set_campaign_content(mailchimp_client, campaign_id, content_data):
     except RequestException as e:
         logger.error(
             "Mailchimp failed to set content for campaign id '{0}'".format(campaign_id),
-            extra={"error": e.message}
+            extra={"error": str(e)}
         )
     return False
 
@@ -86,7 +86,7 @@ def send_campaign(mailchimp_client, campaign_id):
     except RequestException as e:
         logger.error(
             "Mailchimp failed to send campaign id '{0}'".format(campaign_id),
-            extra={"error": e.message}
+            extra={"error": str(e)}
         )
     return False
 

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -1,66 +1,105 @@
-"""Spike script into mail chimp email sending."""
+"""Spike script into mail chimp email sending.
+
+Test list ID is "096e52cebb" which can be used for local development
+"""
+from datetime import datetime
+
 from mailchimp3 import MailChimp
 
-from dmscripts.helpers.html_helpers import render_html
+from requests.exceptions import RequestException
 
-SPECIALISTS_CAMPAIGN_DATA = {
-	"type": "regular",
-	"recipients": {
-		"list_id": "096e52cebb",  # test list containing one user (david mcdonald work email)
-	},
-	"settings": {
-		"subject_line": "New opportunities for Digital Specialists: Digital Outcomes and Specialists 2",
-		"title": "TEST! DOS Suppliers: Specialists [16 March]",
-		"from_name": "Digital Marketplace Team",
-		"reply_to": "do-not-reply@digitalmarketplace.service.gov.uk",
-		"use_conversation": False,
-		"authenticate": True,
-		"auto_footer": False,
-		"inline_css": False,
-		"auto_tweet": False,
-		"fb_comments": False
-	},
-	"tracking": {
-		"opens": True,
-		"html_clicks": True,
-		"text_clicks": False,
-		"goal_tracking": False,
-		"ecomm360": False
-	}
+from dmscripts.helpers.html_helpers import render_html
+from dmscripts.helpers import logging_helpers
+from dmscripts.helpers.logging_helpers import logging
+
+logger = logging_helpers.configure_logger({'dmapiclient': logging.INFO})
+
+
+lots = {
+    "digital-specialists": {
+        "lot_name": "Digital specialists",
+        "list_id": "096e52cebb"
+    },
+    "digital-outcomes": {
+        "lot_name": "Digital outcomes",
+        "list_id": "096e52cebb"
+    },
+    "user-research-participants": {
+        "lot_name": "User research participants",
+        "list_id": "096e52cebb"
+    }
 }
 
+
+def create_campaign_data(lot_name, list_id):
+    return {
+        "type": "regular",
+        "recipients": {
+            "list_id": list_id,
+        },
+        "settings": {
+            "subject_line": "New opportunities for {0}: Digital Outcomes and Specialists 2".format(lot_name),
+            "title": "DOS Suppliers: {0} [{1}]".format(lot_name, datetime.now().strftime("%d %B")),
+            "from_name": "Digital Marketplace Team",
+            "reply_to": "do-not-reply@digitalmarketplace.service.gov.uk",
+            "use_conversation": False,
+            "authenticate": True,
+            "auto_footer": False,
+            "inline_css": False,
+            "auto_tweet": False,
+            "fb_comments": False
+        },
+        "tracking": {
+            "opens": True,
+            "html_clicks": True,
+            "text_clicks": False,
+            "goal_tracking": False,
+            "ecomm360": False
+        }
+    }
+
+
 def get_html_content():
-	email_body = render_html('email_templates/dos_opportunities.html', data={})
-	return email_body
+    email_body = render_html("email_templates/dos_opportunities.html", data={})
+    return email_body
 
-def create_campaign(mailchimp_client):
-	try:
-		res = mailchimp_client.campaigns.create(data=SPECIALISTS_CAMPAIGN_DATA)
-		campaign_id = res['id']
-	except Exception as e:
-		print e
 
-	SPECIALISTS_CONTENT_DATA = {
-		"html": get_html_content()
-	}
+def create_campaign(mailchimp_client, campaign_data):
+    try:
+        campaign = mailchimp_client.campaigns.create(campaign_data)
+        return campaign['id']
+    except RequestException as e:
+        logger.error(
+            "Mailchimp failed to create campaign for '{0}'".format(
+                campaign_data.get("settings").get("title")
+            ),
+            extra={"error": e.message}
+        )
+    return False
 
-	try:
-		mailchimp_client.campaigns.content.update(campaign_id=campaign_id, data=SPECIALISTS_CONTENT_DATA)
-	except Exception as e:
-		print e
 
-	return campaign_id
+def set_campaign_content(mailchimp_client, campaign_id, content_data):
+    try:
+        return mailchimp_client.campaigns.content.update(campaign_id, content_data)
+    except RequestException as e:
+        logger.error(
+            "Mailchimp failed to set content for campaign id '{0}'".format(campaign_id),
+            extra={"error": e.message}
+        )
+    return False
+
 
 def send_campaign(mailchimp_client, campaign_id):
-	try:
-		return client.campaigns.actions.send(campaign_id=campaign_id)
-	except Exception as e:
-		print e
+    try:
+        return client.campaigns.actions.send(campaign_id=campaign_id)
+    except Exception as e:
+        print e
+
 
 def main(mailchimp_username, mailchimp_api_key):
-	mailchimp_client = MailChimp(mailchimp_username, mailchimp_api_key)
+    mailchimp_client = MailChimp(mailchimp_username, mailchimp_api_key)
 
-	campaign_id = create_campaign(mailchimp_client)
-	if not campaign_id:
-		return False
-	return True
+    campaign_id = create_campaign(mailchimp_client)
+    if not campaign_id:
+        return False
+    return True

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -26,7 +26,7 @@ def get_live_briefs_between_two_dates(data_api_client, lot_slug, start_date, end
     ]
 
 
-def create_campaign_data(lot_name, list_id):
+def get_campaign_data(lot_name, list_id):
     return {
         "type": "regular",
         "recipients": {
@@ -114,7 +114,7 @@ def main(data_api_url, data_api_access_token, mailchimp_username, mailchimp_api_
         )
         return True
 
-    campaign_data = create_campaign_data(lot_data["lot_name"], lot_data["list_id"])
+    campaign_data = get_campaign_data(lot_data["lot_name"], lot_data["list_id"])
     campaign_id = create_campaign(mailchimp_client, campaign_data)
     if not campaign_id:
         return False

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -103,12 +103,16 @@ def main(data_api_client, mailchimp_client, lot_data, number_of_days):
     start_date = date.today() - timedelta(days=number_of_days)
     end_date = date.today() - timedelta(days=1)
 
-    if not get_live_briefs_between_two_dates(data_api_client, lot_data["lot_slug"], start_date, end_date):
+    live_briefs = get_live_briefs_between_two_dates(data_api_client, lot_data["lot_slug"], start_date, end_date)
+    if not live_briefs:
         logger.info(
             "No new briefs found for '{0}' lot".format(lot_data["lot_slug"]),
             extra={"number_of_days": number_of_days}
         )
         return True
+    logger.info(
+        "{0} new briefs found for '{1}' lot".format(len(live_briefs), lot_data["lot_slug"])
+    )
 
     campaign_data = get_campaign_data(lot_data["lot_name"], lot_data["list_id"])
     logger.info(

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -101,6 +101,10 @@ def get_mailchimp_client(mailchimp_username, mailchimp_api_key):
 
 
 def main(data_api_url, data_api_access_token, mailchimp_username, mailchimp_api_key, lot_data, number_of_days):
+    logger.info(
+        "Begin process to send DOS notification emails for '{0}' lot".format(lot_data["lot_slug"]),
+        extra={"data_api_url": data_api_url, "lot_data": lot_data, "number_of_days": number_of_days}
+    )
     data_api_client = dmapiclient.DataAPIClient(data_api_url, data_api_access_token)
     mailchimp_client = get_mailchimp_client(mailchimp_username, mailchimp_api_key)
 
@@ -115,14 +119,23 @@ def main(data_api_url, data_api_access_token, mailchimp_username, mailchimp_api_
         return True
 
     campaign_data = get_campaign_data(lot_data["lot_name"], lot_data["list_id"])
+    logger.info(
+        "Creating campaign for '{0}' lot".format(lot_data["lot_slug"])
+    )
     campaign_id = create_campaign(mailchimp_client, campaign_data)
     if not campaign_id:
         return False
 
     content_data = get_html_content()
+    logger.info(
+        "Setting campaign data for '{0}' lot and '{1}' campaign id".format(lot_data["lot_slug"], campaign_id)
+    )
     if not set_campaign_content(mailchimp_client, campaign_id, content_data):
         return False
 
+    logger.info(
+        "Sending campaign for '{0}' lot and '{1}' campaign id".format(lot_data["lot_slug"], campaign_id)
+    )
     if not send_campaign(mailchimp_client, campaign_id):
         return False
 

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -91,9 +91,14 @@ def set_campaign_content(mailchimp_client, campaign_id, content_data):
 
 def send_campaign(mailchimp_client, campaign_id):
     try:
-        return client.campaigns.actions.send(campaign_id=campaign_id)
-    except Exception as e:
-        print e
+        mailchimp_client.campaigns.actions.send(campaign_id)
+        return True
+    except RequestException as e:
+        logger.error(
+            "Mailchimp failed to send campaign id '{0}'".format(campaign_id),
+            extra={"error": e.message}
+        )
+    return False
 
 
 def main(mailchimp_username, mailchimp_api_key):

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -96,17 +96,11 @@ def send_campaign(mailchimp_client, campaign_id):
     return False
 
 
-def get_mailchimp_client(mailchimp_username, mailchimp_api_key):
-    return MailChimp(mailchimp_username, mailchimp_api_key)
-
-
-def main(data_api_url, data_api_access_token, mailchimp_username, mailchimp_api_key, lot_data, number_of_days):
+def main(data_api_client, mailchimp_client, lot_data, number_of_days):
     logger.info(
         "Begin process to send DOS notification emails for '{0}' lot".format(lot_data["lot_slug"]),
-        extra={"data_api_url": data_api_url, "lot_data": lot_data, "number_of_days": number_of_days}
+        extra={"lot_data": lot_data, "number_of_days": number_of_days}
     )
-    data_api_client = dmapiclient.DataAPIClient(data_api_url, data_api_access_token)
-    mailchimp_client = get_mailchimp_client(mailchimp_username, mailchimp_api_key)
 
     start_date = date.today() - timedelta(days=number_of_days)
     end_date = date.today() - timedelta(days=1)

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -4,8 +4,6 @@ Test list ID is "096e52cebb" which can be used for local development
 """
 from datetime import datetime, date, timedelta
 
-from mailchimp3 import MailChimp
-
 from requests.exceptions import RequestException
 
 from dmscripts.helpers.html_helpers import render_html
@@ -55,8 +53,8 @@ def get_campaign_data(lot_name, list_id):
 
 
 def get_html_content():
-    email_body = render_html("email_templates/dos_opportunities.html", data={})
-    return email_body
+    html_content = render_html("email_templates/dos_opportunities.html", data={})
+    return {"html": html_content}
 
 
 def create_campaign(mailchimp_client, campaign_data):

--- a/email_templates/dos_opportunities.html
+++ b/email_templates/dos_opportunities.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+</head>
+<body>
+Dear supplier,
+<br /><br />
+There are new opportunities available...
+<br /><br />
+The Digital Marketplace team
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ jsonschema==2.5.1
 pandas==0.19.1
 xeger==0.3.1
 lorem==0.1.1
+mailchimp3==2.0.8

--- a/scripts/send_dos_opportunities_email.py
+++ b/scripts/send_dos_opportunities_email.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+"""Description to be added here
+
+Usage:
+    send_dos_opportunities_email.py --mailchimp-username=<mailchimp_username>
+                                             --mailchimp-api-key=<mailchimp_api_key>
+"""
+
+import sys
+
+from docopt import docopt
+
+sys.path.insert(0, '.')
+from dmscripts.send_dos_opportunities_email import main
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+    ok = main(
+        mailchimp_username=arguments['--mailchimp-username'],
+        mailchimp_api_key=arguments['--mailchimp-api-key']
+    )
+
+    if not ok:
+        sys.exit(1)

--- a/scripts/send_dos_opportunities_email.py
+++ b/scripts/send_dos_opportunities_email.py
@@ -3,16 +3,19 @@
 """Description to be added here
 
 Usage:
-    send_dos_opportunities_email.py --mailchimp-username=<mailchimp_username>
-                                             --mailchimp-api-key=<mailchimp_api_key>
+    send_dos_opportunities_email.py <stage> <api_token> <mailchimp_username> <mailchimp_api_key> <number_of_days>
 """
 
 import sys
 
 from docopt import docopt
+from mailchimp3 import MailChimp
+from dmapiclient import DataAPIClient
 
 sys.path.insert(0, '.')
+from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.send_dos_opportunities_email import main
+
 
 lots = [
     {
@@ -32,14 +35,21 @@ lots = [
     }
 ]
 
+
 if __name__ == "__main__":
     arguments = docopt(__doc__)
-    lots = ['ds', 'do', 'urp']
-    for lot in lots:
+
+    api_url = get_api_endpoint_from_stage(arguments['<stage>'])
+    data_api_client = DataAPIClient(api_url, arguments['<api_token>'])
+
+    mailchimp_client = MailChimp(arguments['<mailchimp_username>'], arguments['<mailchimp_api_key>'])
+
+    for lot_data in lots:
         ok = main(
-            mailchimp_username=arguments['--mailchimp-username'],
-            mailchimp_api_key=arguments['--mailchimp-api-key'],
-            lot=lot
+            data_api_client=data_api_client,
+            mailchimp_client=mailchimp_client,
+            lot_data=lot_data,
+            number_of_days=int(arguments['<number_of_days>'])
         )
 
     if not ok:

--- a/scripts/send_dos_opportunities_email.py
+++ b/scripts/send_dos_opportunities_email.py
@@ -16,11 +16,16 @@ Description:
         example2: if you run it on Wednesday and set number of days=3,
                     then it will include all briefs published on Sunday, Monday and Tuesday.
 
+    For testing purposes, you can override the list ID so you can send it to yourself only as
+    we have set up a testing list with ID "096e52cebb"
+
 Usage:
-    send_dos_opportunities_email.py <stage> <api_token> <mailchimp_username> <mailchimp_api_key> <number_of_days>
+    send_dos_opportunities_email.py
+        <stage> <api_token> <mailchimp_username> <mailchimp_api_key> <number_of_days> --list_id=<list_id>
 
 Example:
-    send_dos_opportunities_email.py preview b7g5r7e6gv876tv6 user@gds.gov.uk 7483crh87h34c3£@£ 3
+    send_dos_opportunities_email.py
+        preview b7g5r7e6gv876tv6 user@gds.gov.uk 7483crh87h34c3 3 --list_id=988972hse
 """
 
 import sys
@@ -38,23 +43,27 @@ lots = [
     {
         "lot_slug": "digital-specialists",
         "lot_name": "Digital specialists",
-        "list_id": "096e52cebb"
+        "list_id": "TO BE FILLED IN"
     },
     {
         "lot_slug": "digital-outcomes",
         "lot_name": "Digital outcomes",
-        "list_id": "096e52cebb"
+        "list_id": "TO BE FILLED IN"
     },
     {
         "lot_slug": "user-research-participants",
         "lot_name": "User research participants",
-        "list_id": "096e52cebb"
+        "list_id": "TO BE FILLED IN"
     }
 ]
 
 
 if __name__ == "__main__":
     arguments = docopt(__doc__)
+
+    if arguments.get("--list_id"):
+        for lot in lots:
+            lot.update({"list_id": arguments["--list_id"]})
 
     api_url = get_api_endpoint_from_stage(arguments['<stage>'])
     data_api_client = DataAPIClient(api_url, arguments['<api_token>'])

--- a/scripts/send_dos_opportunities_email.py
+++ b/scripts/send_dos_opportunities_email.py
@@ -14,13 +14,33 @@ from docopt import docopt
 sys.path.insert(0, '.')
 from dmscripts.send_dos_opportunities_email import main
 
+lots = [
+    {
+        "lot_slug": "digital-specialists",
+        "lot_name": "Digital specialists",
+        "list_id": "096e52cebb"
+    },
+    {
+        "lot_slug": "digital-outcomes",
+        "lot_name": "Digital outcomes",
+        "list_id": "096e52cebb"
+    },
+    {
+        "lot_slug": "user-research-participants",
+        "lot_name": "User research participants",
+        "list_id": "096e52cebb"
+    }
+]
 
 if __name__ == "__main__":
     arguments = docopt(__doc__)
-    ok = main(
-        mailchimp_username=arguments['--mailchimp-username'],
-        mailchimp_api_key=arguments['--mailchimp-api-key']
-    )
+    lots = ['ds', 'do', 'urp']
+    for lot in lots:
+        ok = main(
+            mailchimp_username=arguments['--mailchimp-username'],
+            mailchimp_api_key=arguments['--mailchimp-api-key'],
+            lot=lot
+        )
 
     if not ok:
         sys.exit(1)

--- a/scripts/send_dos_opportunities_email.py
+++ b/scripts/send_dos_opportunities_email.py
@@ -1,9 +1,26 @@
 #!/usr/bin/env python
 
-"""Description to be added here
+"""
+Description:
+    For every lot the script will:
+        - look for latest briefs for Digital Outcomes and Specialists
+        - if there are new briefs on that lot:
+            - it will create a Mailchimp campaign
+            - it will set the content of the campaign to be the briefs found
+            - it will send that campaign to the list_id as referenced in the `lots` variable
+        - if there are no new briefs on that lot no campaign is created or sent
+
+    Number of days tells the script for how many days before current date it should include in its search for briefs
+        example:  if you run this script on a Wednesday and set number of days=1,
+                    then it will only include briefs from Tuesday (preceding day).
+        example2: if you run it on Wednesday and set number of days=3,
+                    then it will include all briefs published on Sunday, Monday and Tuesday.
 
 Usage:
     send_dos_opportunities_email.py <stage> <api_token> <mailchimp_username> <mailchimp_api_key> <number_of_days>
+
+Example:
+    send_dos_opportunities_email.py preview b7g5r7e6gv876tv6 user@gds.gov.uk 7483crh87h34c3£@£ 3
 """
 
 import sys

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -1,0 +1,78 @@
+import pytest
+import mock
+from freezegun import freeze_time
+from requests.exceptions import RequestException
+
+import datetime
+
+from dmscripts.send_dos_opportunities_email import (
+    main,
+    create_campaign_data,
+    create_campaign,
+    set_campaign_content
+)
+
+
+def test_create_campaign_data():
+    lot_name = "Digital Outcomes"
+    list_id = "1111111"
+    expected_subject = "New opportunities for Digital Outcomes: Digital Outcomes and Specialists 2"
+
+    with freeze_time('2017-04-19 08:00:00'):
+        campaign_data = create_campaign_data(lot_name, list_id)
+        assert campaign_data["recipients"]["list_id"] == list_id
+        assert campaign_data["settings"]["subject_line"] == expected_subject
+        assert campaign_data["settings"]["title"] == "DOS Suppliers: Digital Outcomes [19 April]"
+        assert campaign_data["settings"]["from_name"] == "Digital Marketplace Team"
+        assert campaign_data["settings"]["reply_to"] == "do-not-reply@digitalmarketplace.service.gov.uk"
+
+
+@mock.patch('dmscripts.send_dos_opportunities_email.MailChimp')
+def test_create_campaign(mailchimp_client):
+    mailchimp_client.campaigns.create.return_value = {"id": "100"}
+
+    res = create_campaign(mailchimp_client, {"example": "data"})
+    assert res == "100"
+    mailchimp_client.campaigns.create.assert_called_once_with({"example": "data"})
+
+
+@mock.patch('dmscripts.send_dos_opportunities_email.logger', autospec=True)
+@mock.patch('dmscripts.send_dos_opportunities_email.MailChimp')
+def test_log_error_message_if_error_creating_campaign(mailchimp_client, logger):
+    mailchimp_client.campaigns.create.side_effect = RequestException("error message")
+    campaign_data = {
+        "example": "data",
+        "settings": {
+            "title": "campaign title"
+        }
+    }
+
+    assert create_campaign(mailchimp_client, campaign_data) is False
+    logger.error.assert_called_once_with(
+        "Mailchimp failed to create campaign for 'campaign title'", extra={"error": "error message"}
+    )
+
+
+@mock.patch('dmscripts.send_dos_opportunities_email.MailChimp')
+def test_set_campaign_content(mailchimp_client):
+    campaign_id = "1"
+    html_content = {"html": "<p>One or two words</p>"}
+    mailchimp_client.campaigns.content.update.return_value = html_content
+
+    res = set_campaign_content(mailchimp_client, campaign_id, html_content)
+    assert res == html_content
+    mailchimp_client.campaigns.content.update.assert_called_once_with(campaign_id, html_content)
+
+
+@mock.patch('dmscripts.send_dos_opportunities_email.logger', autospec=True)
+@mock.patch('dmscripts.send_dos_opportunities_email.MailChimp')
+def test_log_error_message_if_error_setting_campaign_content(mailchimp_client, logger):
+    mailchimp_client.campaigns.content.update.side_effect = RequestException("error message")
+    content_data = {
+        "html": "some html"
+    }
+
+    assert set_campaign_content(mailchimp_client, 1, content_data) is False
+    logger.error.assert_called_once_with(
+        "Mailchimp failed to set content for campaign id '1'", extra={"error": "error message"}
+    )

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -145,18 +145,17 @@ def test_log_error_message_if_error_sending_campaign(mailchimp_client, logger):
 @mock.patch('dmscripts.send_dos_opportunities_email.send_campaign')
 @mock.patch('dmscripts.send_dos_opportunities_email.set_campaign_content')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
-@mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_campaign_data')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
 def test_main_creates_campaign_sets_content_and_sends_campaign(
-    create_campaign, get_campaign_data, get_mailchimp_client, get_live_briefs_between_two_dates,
+    create_campaign, get_campaign_data, get_live_briefs_between_two_dates,
     set_campaign_content, send_campaign, get_html_content
 ):
     get_campaign_data.return_value = {"created": "campaign"}
     get_html_content.return_value = {"first": "content"}
     create_campaign.return_value = "1"
 
-    main("data_api_url", "data_api_access_token", "username", "API KEY", LOT_DATA, 1)
+    main(mock.MagicMock(), mock.MagicMock(), LOT_DATA, 1)
 
     # Creates campaign
     get_campaign_data.assert_called_once_with("Digital specialists", "096e52cebb")
@@ -173,7 +172,7 @@ def test_main_creates_campaign_sets_content_and_sends_campaign(
 @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 def test_main_gets_live_briefs_for_one_day(get_live_briefs_between_two_dates):
     with freeze_time('2017-04-19 08:00:00'):
-        main("data_api_url", "data_api_access_token", "username", "API KEY", LOT_DATA, 1)
+        main(mock.MagicMock(), mock.MagicMock(), LOT_DATA, 1)
         get_live_briefs_between_two_dates.assert_called_once_with(
             mock.ANY, "digital-specialists", date(2017, 4, 18), date(2017, 4, 18)
         )
@@ -182,7 +181,7 @@ def test_main_gets_live_briefs_for_one_day(get_live_briefs_between_two_dates):
 @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 def test_main_gets_live_briefs_for_three_days(get_live_briefs_between_two_dates):
     with freeze_time('2017-04-10 08:00:00'):
-        main("data_api_url", "data_api_access_token", "username", "API KEY", LOT_DATA, 3)
+        main(mock.MagicMock(), mock.MagicMock(), LOT_DATA, 3)
         get_live_briefs_between_two_dates.assert_called_once_with(
             mock.ANY, "digital-specialists", date(2017, 4, 7), date(2017, 4, 9)
         )
@@ -197,12 +196,12 @@ def test_if_no_briefs_then_no_campaign_created_nor_sent(
     get_live_briefs_between_two_dates, create_campaign, set_campaign_content, send_campaign, logger
 ):
     get_live_briefs_between_two_dates.return_value = []
-    result = main("data_api_url", "data_api_access_token", "username", "API KEY", LOT_DATA, 3)
+    result = main(mock.MagicMock(), mock.MagicMock(), LOT_DATA, 3)
     assert result is True
     create_campaign.assert_not_called()
     set_campaign_content.assert_not_called()
     send_campaign.assert_not_called()
 
-    logger.info.assert_called_once_with(
+    logger.info.assert_called_with(
         "No new briefs found for 'digital-specialists' lot", extra={"number_of_days": 3}
     )

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -7,7 +7,7 @@ from datetime import datetime, date
 
 from dmscripts.send_dos_opportunities_email import (
     main,
-    create_campaign_data,
+    get_campaign_data,
     create_campaign,
     set_campaign_content,
     send_campaign,
@@ -58,13 +58,13 @@ def test_get_live_briefs_between_two_dates():
     ]
 
 
-def test_create_campaign_data():
+def test_get_campaign_data():
     lot_name = "Digital Outcomes"
     list_id = "1111111"
     expected_subject = "New opportunities for Digital Outcomes: Digital Outcomes and Specialists 2"
 
     with freeze_time('2017-04-19 08:00:00'):
-        campaign_data = create_campaign_data(lot_name, list_id)
+        campaign_data = get_campaign_data(lot_name, list_id)
         assert campaign_data["recipients"]["list_id"] == list_id
         assert campaign_data["settings"]["subject_line"] == expected_subject
         assert campaign_data["settings"]["title"] == "DOS Suppliers: Digital Outcomes [19 April]"
@@ -143,15 +143,15 @@ def test_log_error_message_if_error_sending_campaign(mailchimp_client, logger):
 
 @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
-@mock.patch('dmscripts.send_dos_opportunities_email.create_campaign_data')
+@mock.patch('dmscripts.send_dos_opportunities_email.get_campaign_data')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
 def test_main_creates_campaigns(
-    create_campaign, create_campaign_data, get_mailchimp_client, get_live_briefs_between_two_dates
+    create_campaign, get_campaign_data, get_mailchimp_client, get_live_briefs_between_two_dates
 ):
-    create_campaign_data.return_value = {"created": "campaign"}
+    get_campaign_data.return_value = {"created": "campaign"}
 
     main("data_api_url", "data_api_access_token", "username", "API KEY", LOT_DATA, 1)
-    create_campaign_data.assert_called_once_with("Digital specialists", "096e52cebb")
+    get_campaign_data.assert_called_once_with("Digital specialists", "096e52cebb")
     create_campaign.assert_called_once_with(mock.ANY, {"created": "campaign"})
 
 

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -3,15 +3,53 @@ import mock
 from freezegun import freeze_time
 from requests.exceptions import RequestException
 
-import datetime
+from datetime import datetime, date
 
 from dmscripts.send_dos_opportunities_email import (
     main,
     create_campaign_data,
     create_campaign,
     set_campaign_content,
-    send_campaign
+    send_campaign,
+    get_live_briefs_between_two_dates
 )
+
+
+def test_get_live_briefs_between_two_dates():
+    data_api_client = mock.Mock()
+    brief_iter_values = [
+        {"publishedAt": "2017-03-24T09:52:17.669156Z"},
+        {"publishedAt": "2017-03-23T23:59:59.669156Z"},
+        {"publishedAt": "2017-03-23T09:52:17.669156Z"},
+        {"publishedAt": "2017-03-23T00:00:00.000000Z"},
+        {"publishedAt": "2017-03-22T09:52:17.669156Z"},
+        {"publishedAt": "2017-03-21T09:52:17.669156Z"},
+        {"publishedAt": "2017-03-20T09:52:17.669156Z"},
+        {"publishedAt": "2017-03-19T09:52:17.669156Z"},
+        {"publishedAt": "2017-03-18T09:52:17.669156Z"},
+        {"publishedAt": "2017-02-17T09:52:17.669156Z"}
+    ]
+
+    data_api_client.find_briefs_iter.return_value = iter(brief_iter_values)
+    briefs = get_live_briefs_between_two_dates(
+        data_api_client, "digital-specialists", date(2017, 3, 23), date(2017, 3, 23)
+    )
+    data_api_client.find_briefs_iter.assert_called_once_with(status="live", lot="digital-specialists")
+    assert briefs == [
+        {"publishedAt": "2017-03-23T23:59:59.669156Z"},
+        {"publishedAt": "2017-03-23T09:52:17.669156Z"},
+        {"publishedAt": "2017-03-23T00:00:00.000000Z"}
+    ]
+
+    data_api_client.find_briefs_iter.return_value = iter(brief_iter_values)
+    briefs = get_live_briefs_between_two_dates(
+        data_api_client, "digital-specialists", date(2017, 3, 18), date(2017, 3, 20)
+    )
+    assert briefs == [
+        {"publishedAt": "2017-03-20T09:52:17.669156Z"},
+        {"publishedAt": "2017-03-19T09:52:17.669156Z"},
+        {"publishedAt": "2017-03-18T09:52:17.669156Z"}
+    ]
 
 
 def test_create_campaign_data():
@@ -96,14 +134,16 @@ def test_log_error_message_if_error_sending_campaign(mailchimp_client, logger):
         "Mailchimp failed to send campaign id '1'", extra={"error": "error sending"}
     )
 
-
+@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign_data')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
-def test_main_creates_campaigns_for_each_lot(create_campaign, create_campaign_data, get_mailchimp_client):
+def test_main_creates_campaigns_for_each_lot(
+    create_campaign, create_campaign_data, get_mailchimp_client, get_live_briefs_between_two_dates
+):
     create_campaign_data.side_effect = [{"first": "campaign"}, {"second": "campaign"}, {"third": "campaign"}]
 
-    main("username", "API KEY")
+    main("data_api_url", "data_api_access_token", "username", "API KEY", 1)
 
     create_campaign_data.assert_any_call("Digital specialists", "096e52cebb")
     create_campaign.assert_any_call(mock.ANY, {"first": "campaign"})
@@ -114,15 +154,17 @@ def test_main_creates_campaigns_for_each_lot(create_campaign, create_campaign_da
     create_campaign_data.assert_any_call("User research participants", "096e52cebb")
     create_campaign.assert_any_call(mock.ANY, {"third": "campaign"})
 
-
+@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_html_content')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
 @mock.patch('dmscripts.send_dos_opportunities_email.set_campaign_content')
-def test_main_sets_content_for_each_lot(set_campaign_content, get_mailchimp_client, get_html_content, create_campaign):
+def test_main_sets_content_for_each_lot(
+    set_campaign_content, get_mailchimp_client, get_html_content, create_campaign, get_live_briefs_between_two_dates
+):
     get_html_content.side_effect = [{"first": "content"}, {"second": "content"}, {"third": "content"}]
     create_campaign.side_effect = ["1", "2", "3"]
-    main("username", "API KEY")
+    main("data_api_url", "data_api_access_token", "username", "API KEY", 1)
 
     get_html_content.assert_any_call()
     set_campaign_content.assert_any_call(mock.ANY, "1", {"first": "content"})
@@ -134,12 +176,32 @@ def test_main_sets_content_for_each_lot(set_campaign_content, get_mailchimp_clie
     set_campaign_content.assert_any_call(mock.ANY, "3", {"third": "content"})
 
 
+@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
 @mock.patch('dmscripts.send_dos_opportunities_email.send_campaign')
-def test_main_sends_campaign_for_each_lot(send_campaign, get_mailchimp_client, create_campaign):
+def test_main_sends_campaign_for_each_lot(
+    send_campaign, get_mailchimp_client, create_campaign, get_live_briefs_between_two_dates
+):
     create_campaign.side_effect = ["1", "2", "3"]
-    main("username", "API KEY")
+    main("data_api_url", "data_api_access_token", "username", "API KEY", 1)
     send_campaign.assert_any_call(mock.ANY, "1")
     send_campaign.assert_any_call(mock.ANY, "2")
     send_campaign.assert_any_call(mock.ANY, "3")
+
+@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
+def test_main_gets_live_briefs_for_one_day(get_live_briefs_between_two_dates):
+    with freeze_time('2017-04-19 08:00:00'):
+        main("data_api_url", "data_api_access_token", "username", "API KEY", 1)
+        get_live_briefs_between_two_dates.assert_any_call(
+            mock.ANY, "digital-specialists", date(2017, 4, 18), date(2017, 4, 18)
+        )
+
+
+@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
+def test_main_gets_live_briefs_for_three_days(get_live_briefs_between_two_dates):
+    with freeze_time('2017-04-10 08:00:00'):
+        main("data_api_url", "data_api_access_token", "username", "API KEY", 3)
+        get_live_briefs_between_two_dates.assert_any_call(
+            mock.ANY, "digital-specialists", date(2017, 4, 7), date(2017, 4, 9)
+        )

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -141,46 +141,32 @@ def test_log_error_message_if_error_sending_campaign(mailchimp_client, logger):
     )
 
 
+@mock.patch('dmscripts.send_dos_opportunities_email.get_html_content')
+@mock.patch('dmscripts.send_dos_opportunities_email.send_campaign')
+@mock.patch('dmscripts.send_dos_opportunities_email.set_campaign_content')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_campaign_data')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
-def test_main_creates_campaigns(
-    create_campaign, get_campaign_data, get_mailchimp_client, get_live_briefs_between_two_dates
+def test_main_creates_campaign_sets_content_and_sends_campaign(
+    create_campaign, get_campaign_data, get_mailchimp_client, get_live_briefs_between_two_dates,
+    set_campaign_content, send_campaign, get_html_content
 ):
     get_campaign_data.return_value = {"created": "campaign"}
-
-    main("data_api_url", "data_api_access_token", "username", "API KEY", LOT_DATA, 1)
-    get_campaign_data.assert_called_once_with("Digital specialists", "096e52cebb")
-    create_campaign.assert_called_once_with(mock.ANY, {"created": "campaign"})
-
-
-@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
-@mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
-@mock.patch('dmscripts.send_dos_opportunities_email.get_html_content')
-@mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
-@mock.patch('dmscripts.send_dos_opportunities_email.set_campaign_content')
-def test_main_sets_content(
-    set_campaign_content, get_mailchimp_client, get_html_content, create_campaign, get_live_briefs_between_two_dates
-):
     get_html_content.return_value = {"first": "content"}
     create_campaign.return_value = "1"
 
     main("data_api_url", "data_api_access_token", "username", "API KEY", LOT_DATA, 1)
+
+    # Creates campaign
+    get_campaign_data.assert_called_once_with("Digital specialists", "096e52cebb")
+    create_campaign.assert_called_once_with(mock.ANY, {"created": "campaign"})
+
+    # Sets campaign content
     get_html_content.assert_called_once_with()
     set_campaign_content.assert_called_once_with(mock.ANY, "1", {"first": "content"})
 
-
-@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
-@mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
-@mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
-@mock.patch('dmscripts.send_dos_opportunities_email.send_campaign')
-def test_main_sends_campaign(
-    send_campaign, get_mailchimp_client, create_campaign, get_live_briefs_between_two_dates
-):
-    create_campaign.return_value = "1"
-
-    main("data_api_url", "data_api_access_token", "username", "API KEY", LOT_DATA, 1)
+    # Sends campaign
     send_campaign.assert_called_once_with(mock.ANY, "1")
 
 

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -134,74 +134,90 @@ def test_log_error_message_if_error_sending_campaign(mailchimp_client, logger):
         "Mailchimp failed to send campaign id '1'", extra={"error": "error sending"}
     )
 
+
 @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign_data')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
-def test_main_creates_campaigns_for_each_lot(
+def test_main_creates_campaigns(
     create_campaign, create_campaign_data, get_mailchimp_client, get_live_briefs_between_two_dates
 ):
-    create_campaign_data.side_effect = [{"first": "campaign"}, {"second": "campaign"}, {"third": "campaign"}]
+    lot_data = {
+        "lot_slug": "digital-specialists",
+        "lot_name": "Digital specialists",
+        "list_id": "096e52cebb"
+    }
+    create_campaign_data.return_value = {"created": "campaign"}
 
-    main("data_api_url", "data_api_access_token", "username", "API KEY", 1)
+    main("data_api_url", "data_api_access_token", "username", "API KEY", lot_data, 1)
+    create_campaign_data.assert_called_once_with("Digital specialists", "096e52cebb")
+    create_campaign.assert_called_once_with(mock.ANY, {"created": "campaign"})
 
-    create_campaign_data.assert_any_call("Digital specialists", "096e52cebb")
-    create_campaign.assert_any_call(mock.ANY, {"first": "campaign"})
-
-    create_campaign_data.assert_any_call("Digital outcomes", "096e52cebb")
-    create_campaign.assert_any_call(mock.ANY, {"second": "campaign"})
-
-    create_campaign_data.assert_any_call("User research participants", "096e52cebb")
-    create_campaign.assert_any_call(mock.ANY, {"third": "campaign"})
 
 @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_html_content')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
 @mock.patch('dmscripts.send_dos_opportunities_email.set_campaign_content')
-def test_main_sets_content_for_each_lot(
+def test_main_sets_content(
     set_campaign_content, get_mailchimp_client, get_html_content, create_campaign, get_live_briefs_between_two_dates
 ):
-    get_html_content.side_effect = [{"first": "content"}, {"second": "content"}, {"third": "content"}]
-    create_campaign.side_effect = ["1", "2", "3"]
-    main("data_api_url", "data_api_access_token", "username", "API KEY", 1)
+    lot_data = {
+        "lot_slug": "digital-specialists",
+        "lot_name": "Digital specialists",
+        "list_id": "096e52cebb"
+    }
+    get_html_content.return_value = {"first": "content"}
+    create_campaign.return_value = "1"
 
-    get_html_content.assert_any_call()
-    set_campaign_content.assert_any_call(mock.ANY, "1", {"first": "content"})
-
-    get_html_content.assert_any_call()
-    set_campaign_content.assert_any_call(mock.ANY, "2", {"second": "content"})
-
-    get_html_content.assert_any_call()
-    set_campaign_content.assert_any_call(mock.ANY, "3", {"third": "content"})
+    main("data_api_url", "data_api_access_token", "username", "API KEY", lot_data, 1)
+    get_html_content.assert_called_once_with()
+    set_campaign_content.assert_called_once_with(mock.ANY, "1", {"first": "content"})
 
 
 @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 @mock.patch('dmscripts.send_dos_opportunities_email.create_campaign')
 @mock.patch('dmscripts.send_dos_opportunities_email.get_mailchimp_client')
 @mock.patch('dmscripts.send_dos_opportunities_email.send_campaign')
-def test_main_sends_campaign_for_each_lot(
+def test_main_sends_campaign(
     send_campaign, get_mailchimp_client, create_campaign, get_live_briefs_between_two_dates
 ):
-    create_campaign.side_effect = ["1", "2", "3"]
-    main("data_api_url", "data_api_access_token", "username", "API KEY", 1)
-    send_campaign.assert_any_call(mock.ANY, "1")
-    send_campaign.assert_any_call(mock.ANY, "2")
-    send_campaign.assert_any_call(mock.ANY, "3")
+    lot_data = {
+        "lot_slug": "digital-specialists",
+        "lot_name": "Digital specialists",
+        "list_id": "096e52cebb"
+    }
+    create_campaign.return_value = "1"
+
+    main("data_api_url", "data_api_access_token", "username", "API KEY", lot_data, 1)
+    send_campaign.assert_called_once_with(mock.ANY, "1")
+
 
 @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 def test_main_gets_live_briefs_for_one_day(get_live_briefs_between_two_dates):
+    lot_data = {
+        "lot_slug": "digital-specialists",
+        "lot_name": "Digital specialists",
+        "list_id": "096e52cebb"
+    }
+
     with freeze_time('2017-04-19 08:00:00'):
-        main("data_api_url", "data_api_access_token", "username", "API KEY", 1)
-        get_live_briefs_between_two_dates.assert_any_call(
+        main("data_api_url", "data_api_access_token", "username", "API KEY", lot_data, 1)
+        get_live_briefs_between_two_dates.assert_called_once_with(
             mock.ANY, "digital-specialists", date(2017, 4, 18), date(2017, 4, 18)
         )
 
 
 @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates')
 def test_main_gets_live_briefs_for_three_days(get_live_briefs_between_two_dates):
+    lot_data = {
+        "lot_slug": "digital-specialists",
+        "lot_name": "Digital specialists",
+        "list_id": "096e52cebb"
+    }
+
     with freeze_time('2017-04-10 08:00:00'):
-        main("data_api_url", "data_api_access_token", "username", "API KEY", 3)
-        get_live_briefs_between_two_dates.assert_any_call(
+        main("data_api_url", "data_api_access_token", "username", "API KEY", lot_data, 3)
+        get_live_briefs_between_two_dates.assert_called_once_with(
             mock.ANY, "digital-specialists", date(2017, 4, 7), date(2017, 4, 9)
         )

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -72,8 +72,8 @@ def test_get_campaign_data():
         assert campaign_data["settings"]["reply_to"] == "do-not-reply@digitalmarketplace.service.gov.uk"
 
 
-@mock.patch('dmscripts.send_dos_opportunities_email.MailChimp')
-def test_create_campaign(mailchimp_client):
+def test_create_campaign():
+    mailchimp_client = mock.MagicMock()
     mailchimp_client.campaigns.create.return_value = {"id": "100"}
 
     res = create_campaign(mailchimp_client, {"example": "data"})
@@ -82,8 +82,8 @@ def test_create_campaign(mailchimp_client):
 
 
 @mock.patch('dmscripts.send_dos_opportunities_email.logger', autospec=True)
-@mock.patch('dmscripts.send_dos_opportunities_email.MailChimp')
-def test_log_error_message_if_error_creating_campaign(mailchimp_client, logger):
+def test_log_error_message_if_error_creating_campaign(logger):
+    mailchimp_client = mock.MagicMock()
     mailchimp_client.campaigns.create.side_effect = RequestException("error message")
     campaign_data = {
         "example": "data",
@@ -98,10 +98,10 @@ def test_log_error_message_if_error_creating_campaign(mailchimp_client, logger):
     )
 
 
-@mock.patch('dmscripts.send_dos_opportunities_email.MailChimp')
-def test_set_campaign_content(mailchimp_client):
+def test_set_campaign_content():
     campaign_id = "1"
     html_content = {"html": "<p>One or two words</p>"}
+    mailchimp_client = mock.MagicMock()
     mailchimp_client.campaigns.content.update.return_value = html_content
 
     res = set_campaign_content(mailchimp_client, campaign_id, html_content)
@@ -110,8 +110,8 @@ def test_set_campaign_content(mailchimp_client):
 
 
 @mock.patch('dmscripts.send_dos_opportunities_email.logger', autospec=True)
-@mock.patch('dmscripts.send_dos_opportunities_email.MailChimp')
-def test_log_error_message_if_error_setting_campaign_content(mailchimp_client, logger):
+def test_log_error_message_if_error_setting_campaign_content(logger):
+    mailchimp_client = mock.MagicMock()
     mailchimp_client.campaigns.content.update.side_effect = RequestException("error message")
     content_data = {
         "html": "some html"
@@ -123,17 +123,17 @@ def test_log_error_message_if_error_setting_campaign_content(mailchimp_client, l
     )
 
 
-@mock.patch('dmscripts.send_dos_opportunities_email.MailChimp')
-def test_send_campaign(mailchimp_client):
+def test_send_campaign():
     campaign_id = "1"
+    mailchimp_client = mock.MagicMock()
     res = send_campaign(mailchimp_client, campaign_id)
     assert res is True
     mailchimp_client.campaigns.actions.send.assert_called_once_with(campaign_id)
 
 
 @mock.patch('dmscripts.send_dos_opportunities_email.logger', autospec=True)
-@mock.patch('dmscripts.send_dos_opportunities_email.MailChimp')
-def test_log_error_message_if_error_sending_campaign(mailchimp_client, logger):
+def test_log_error_message_if_error_sending_campaign(logger):
+    mailchimp_client = mock.MagicMock()
     mailchimp_client.campaigns.actions.send.side_effect = RequestException("error sending")
     assert send_campaign(mailchimp_client, "1") is False
     logger.error.assert_called_once_with(


### PR DESCRIPTION
Trello card: https://trello.com/c/RDQcaDGo/252-write-and-implement-the-script-to-send-the-emails-for-each-lot

The script sends emails with new briefs to suppliers.
The script will be run by a jenkins job every weekday.
The script will look for briefs published on a previous day or three previous days, depending on instructions from the jenkins job. E.g. if email is sent on Monday, the script will search for briefs published on Fri, Sat, Sun. If the email is sent between Tue-Fri, the script will look for briefs published on a previous day to sending.

For the moment, we haven't touched he content of the email and it's setup with some dummy text. There is a separate story to implement this:
https://trello.com/c/rajSbay6/251-create-the-email-template-for-supplier-notifications