### PR TITLE
Abort script if an individual lot fails to send

### DIFF
--- a/scripts/send_dos_opportunities_email.py
+++ b/scripts/send_dos_opportunities_email.py
@@ -102,6 +102,5 @@ if __name__ == "__main__":
             lot_data=lot_data,
             number_of_days=number_of_days
         )
-
-    if not ok:
-        sys.exit(1)
+        if not ok:
+            sys.exit(1)


### PR DESCRIPTION
Before it was only aborting if the last lot failed which was incorrect. The script should fail as soon as it comes across an error otherwise failures to previous lots will go undetected.