### PR TITLE
Dates should be formatted nicely in countersigned agreements

### DIFF
--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -4,6 +4,8 @@ import shutil
 import re
 import subprocess
 
+from datetime import datetime
+
 from dmscripts.helpers.html_helpers import render_html
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
@@ -47,6 +49,9 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework_kwargs, 
             continue
         data.update(framework_kwargs)
         data['awardedLots'] = filter(lambda lot: int(data[lot]) > 0, framework_kwargs['lotOrder'])
+        data['countersigned_at'] = datetime.strptime(
+            data['countersigned_at'], '%Y-%m-%dT%H:%M:%S.%fZ'
+        ).strftime('%d %B %Y')
         html = render_html(template_path, data)
         save_page(html, data['supplier_id'], output_dir, "agreement-countersignature")
     shutil.copyfile(template_css_path, os.path.join(output_dir, 'framework-agreement-signature-page.css'))

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -29,13 +29,14 @@ def render_html_for_successful_suppliers(rows, framework_kwargs, template_dir, o
             continue
         data.update(framework_kwargs)
         data['awardedLots'] = filter(lambda lot: int(data[lot]) > 0, framework_kwargs['lotOrder'])
+        data['include_countersignature'] = False
         html = render_html(template_path, data)
         save_page(html, data['supplier_id'], output_dir, "signature-page")
     shutil.copyfile(template_css_path, os.path.join(output_dir, 'framework-agreement-signature-page.css'))
 
 
 def render_html_for_suppliers_awaiting_countersignature(rows, framework_kwargs, template_dir, output_dir):
-    template_path = os.path.join(template_dir, 'framework-agreement-counterpart-signature-page.html')
+    template_path = os.path.join(template_dir, 'framework-agreement-signature-page.html')
     template_css_path = os.path.join(template_dir, 'framework-agreement-signature-page.css')
     countersignature_img_path = os.path.join(template_dir, 'framework-agreement-countersignature.png')
     for data in rows:
@@ -52,6 +53,7 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework_kwargs, 
         data['countersigned_at'] = datetime.strptime(
             data['countersigned_at'], '%Y-%m-%dT%H:%M:%S.%fZ'
         ).strftime('%d %B %Y')
+        data['include_countersignature'] = True
         html = render_html(template_path, data)
         save_page(html, data['supplier_id'], output_dir, "agreement-countersignature")
     shutil.copyfile(template_css_path, os.path.join(output_dir, 'framework-agreement-signature-page.css'))


### PR DESCRIPTION
Previously the generated PDFs had an ugly looking date format.  This makes it nicer.

The `'%d %B %Y'` format gives e.g. "29 March 2017"

Handy strptime reference here: https://docs.python.org/2/library/datetime.html#datetime.datetime.strptime

** EDIT **
Now also passes in `include_countersignature` param to template kwargs, so the template knows whether or not to include the countersignature.

~~(Corresponding update to agreements repo coming v. soon)~~
Corresponding update to agreements repo here: 
 - [ ] https://github.gds/gds/digitalmarketplace-agreements/pull/18