### PR TITLE
Bugfix logging import

### DIFF
--- a/dmscripts/json_schema_service_faker.py
+++ b/dmscripts/json_schema_service_faker.py
@@ -1,13 +1,13 @@
 import copy
 import json
-import logging
 import lorem
 import random
 import re
 import xeger
+from dmscripts.helpers import logging_helpers
 from jsonschema import validate, ValidationError
 
-logger = logging.configure_logger()
+logger = logging_helpers.configure_logger()
 
 
 class JsonSchemaDataFaker(object):


### PR DESCRIPTION
Before: Script fails to run with `AttributeError: 'module' object has no attribute 'configure_logger'`

After: Script runs OK.