### PR TITLE
Add paas environments for staging and preview

### DIFF
--- a/dmscripts/helpers/env_helpers.py
+++ b/dmscripts/helpers/env_helpers.py
@@ -7,10 +7,12 @@ def get_api_endpoint_from_stage(stage, app='api'):
 
     """
 
-    stage_prefixes = {
-        'preview': 'preview-{}.development'.format(app),
-        'staging': 'staging-{}'.format(app),
-        'production': app
+    stage_domains = {
+        'preview_paas': 'https://{}.preview.marketplace.team'.format(app),
+        'staging_paas': 'https://{}.staging.marketplace.team'.format(app),
+        'production': 'https://{}.digitalmarketplace.service.gov.uk'.format(app),
+        'preview': 'https://preview-{}.development.digitalmarketplace.service.gov.uk'.format(app),
+        'staging': 'https://staging-{}.digitalmarketplace.service.gov.uk'.format(app),
     }
 
     dev_ports = {
@@ -21,9 +23,7 @@ def get_api_endpoint_from_stage(stage, app='api'):
     if stage in ['local', 'dev', 'development']:
         return 'http://localhost:{}'.format(dev_ports[app])
 
-    return "https://{}.digitalmarketplace.service.gov.uk".format(
-        stage_prefixes[stage]
-    )
+    return stage_domains[stage]
 
 
 def get_assets_endpoint_from_stage(stage):


### PR DESCRIPTION
Allows using `preview_paas` and `staging_paas` as environments name
when running scripts that are using API endpoint env helpers.

The environment names are temporary to avoid switching all existing
Jenkins jobs at once. `_paas` environments should be renamed to
preview and staging after the switch and the old ones can be removed.