### PR TITLE
Improve make-g-cloud-live script

### DIFF
--- a/scripts/make-g-cloud-live.py
+++ b/scripts/make-g-cloud-live.py
@@ -85,7 +85,7 @@ def document_copier(draft_bucket, documents_bucket, dry_run):
             documents_bucket.bucket_name, live_document_path)
 
         if dry_run:
-            print(u"    > not copying {}".format(message_suffix))
+            print(u"    > dry run: skipped copying {}".format(message_suffix))
         else:
             key = documents_bucket.bucket.copy_key(live_document_path,
                                                    src_bucket_name=draft_bucket.bucket_name,
@@ -101,7 +101,7 @@ def make_draft_service_live(client, copy_document, draft_service, framework_slug
     print(u"  > Migrating draft {} - {}".format(draft_service['id'], draft_service['serviceName']))
     if dry_run:
         service_id = random.randint(1000, 10000)
-        print(u"    > generating random test service ID: {}".format(service_id))
+        print(u"    > dry run: generating random test service ID: {}".format(service_id))
     else:
         services = client.publish_draft_service(draft_service['id'], 'make-g-cloud-live script')
         service_id = services['services']['id']
@@ -121,7 +121,7 @@ def make_draft_service_live(client, copy_document, draft_service, framework_slug
             document_updates[document_key] = get_live_asset_url(live_document_path)
 
     if dry_run:
-        print(u"    > not updating document URLs {}".format(document_updates))
+        print(u"    > dry run: skipped updating document URLs {}".format(document_updates))
     else:
         client.update_service(service_id, document_updates, 'Moving documents to live bucket')
         print("    > document URLs updated")


### PR DESCRIPTION
When running on Jenkins we saw over 300 services fail to publish but no useful error messages were shown.  On a subsequent run of the script locally all the failed serviced published just fine.

This adds:
 * Per-service backoff so that 5 attempts will be made to publish a service that fails as the result of an API or S3 error
 * Better reporting at the end of the run, showing number of published and failed services
 * Exit with a non-zero status code if there were failures, so Jenkins knows to mark the build red