### PR TITLE
Add users to mailchimp lists using the mailchimp API

### DIFF
--- a/dmscripts/upload_dos_opportunities_email_list.py
+++ b/dmscripts/upload_dos_opportunities_email_list.py
@@ -27,10 +27,16 @@ def main(data_api_client, mailchimp_client, lot_data, logger):
         "{} emails have been found for lot {}".format(len(emails), lot_data["lot_slug"])
     )
 
+    existing_mailchimp_emails = mailchimp_client.get_email_addresses_from_list(lot_data["list_id"])
     logger.info(
-        "Subscribing new emails to mailchimp list {}".format(lot_data["list_id"])
+        "{} existing emails found on list {}".format(len(existing_mailchimp_emails), lot_data["list_id"])
     )
-    if not mailchimp_client.subscribe_new_emails_to_list(lot_data["list_id"], emails):
+
+    new_emails = list(set(emails) - set(existing_mailchimp_emails))
+    logger.info(
+        "Subscribing {} new emails to mailchimp list {}".format(len(new_emails), lot_data["list_id"])
+    )
+    if not mailchimp_client.subscribe_new_emails_to_list(lot_data["list_id"], new_emails):
         return False
 
     return True

--- a/dmscripts/upload_dos_opportunities_email_list.py
+++ b/dmscripts/upload_dos_opportunities_email_list.py
@@ -10,11 +10,14 @@ def find_user_emails(supplier_users, services):
     return email_addresses
 
 
-def main(data_api_client, lot_data):
+def main(data_api_client, mailchimp_client, lot_data):
     data_helper = SupplierFrameworkData(data_api_client, lot_data["framework_slug"])
     supplier_users = data_helper.get_supplier_users()
 
-    framework_services = data_api_client.find_services_iter(framework=lot_data["framework_slug"], lot=lot_data["lot_slug"])
+    framework_services = data_api_client.find_services_iter(
+        framework=lot_data["framework_slug"], lot=lot_data["lot_slug"]
+    )
     emails = find_user_emails(supplier_users, framework_services)
     print emails
+    mailchimp_client.subscribe_new_emails_to_list(lot_data["list_id"], emails)
     return True

--- a/dmscripts/upload_dos_opportunities_email_list.py
+++ b/dmscripts/upload_dos_opportunities_email_list.py
@@ -10,10 +10,11 @@ def find_user_emails(supplier_users, services):
     return email_addresses
 
 
-def main(data_client, lot_data):
-    data_helper = SupplierFrameworkData(data_client, lot_data["framework_slug"])
+def main(data_api_client, lot_data):
+    data_helper = SupplierFrameworkData(data_api_client, lot_data["framework_slug"])
     supplier_users = data_helper.get_supplier_users()
 
-    framework_services = data_client.find_services_iter(lot_data["framework_slug"], lot_data["lot_slug"])
-    find_user_emails(supplier_users, framework_services)
+    framework_services = data_api_client.find_services_iter(lot_data["framework_slug"], lot_data["lot_slug"])
+    emails = find_user_emails(supplier_users, framework_services)
+    print emails
     return True

--- a/dmscripts/upload_dos_opportunities_email_list.py
+++ b/dmscripts/upload_dos_opportunities_email_list.py
@@ -30,5 +30,7 @@ def main(data_api_client, mailchimp_client, lot_data, logger):
     logger.info(
         "Subscribing new emails to mailchimp list {}".format(lot_data["list_id"])
     )
-    mailchimp_client.subscribe_new_emails_to_list(lot_data["list_id"], emails)
+    if not mailchimp_client.subscribe_new_emails_to_list(lot_data["list_id"], emails):
+        return False
+
     return True

--- a/dmscripts/upload_dos_opportunities_email_list.py
+++ b/dmscripts/upload_dos_opportunities_email_list.py
@@ -1,0 +1,19 @@
+from dmscripts.helpers.supplier_data_helpers import SupplierFrameworkData
+
+
+def find_user_emails(supplier_users, services):
+    """Return email addresses for any supplier who has a service in services."""
+    email_addresses = []
+    for service in services:
+        for user in supplier_users.get(service['supplierId'], []):
+            email_addresses.append(user['email address'])
+    return email_addresses
+
+
+def main(data_client, lot_data):
+    data_helper = SupplierFrameworkData(data_client, lot_data["framework_slug"])
+    supplier_users = data_helper.get_supplier_users()
+
+    framework_services = data_client.find_services_iter(lot_data["framework_slug"], lot_data["lot_slug"])
+    find_user_emails(supplier_users, framework_services)
+    return True

--- a/dmscripts/upload_dos_opportunities_email_list.py
+++ b/dmscripts/upload_dos_opportunities_email_list.py
@@ -10,14 +10,25 @@ def find_user_emails(supplier_users, services):
     return email_addresses
 
 
-def main(data_api_client, mailchimp_client, lot_data):
+def main(data_api_client, mailchimp_client, lot_data, logger):
+    logger.info(
+        "Begin mailchimp email list updating process for {} lot".format(lot_data["lot_slug"]),
+        extra={"lot_data": lot_data}
+    )
+
     data_helper = SupplierFrameworkData(data_api_client, lot_data["framework_slug"])
     supplier_users = data_helper.get_supplier_users()
-
     framework_services = data_api_client.find_services_iter(
         framework=lot_data["framework_slug"], lot=lot_data["lot_slug"]
     )
+
     emails = find_user_emails(supplier_users, framework_services)
-    print emails
+    logger.info(
+        "{} emails have been found for lot {}".format(len(emails), lot_data["lot_slug"])
+    )
+
+    logger.info(
+        "Subscribing new emails to mailchimp list {}".format(lot_data["list_id"])
+    )
     mailchimp_client.subscribe_new_emails_to_list(lot_data["list_id"], emails)
     return True

--- a/dmscripts/upload_dos_opportunities_email_list.py
+++ b/dmscripts/upload_dos_opportunities_email_list.py
@@ -10,6 +10,10 @@ def find_user_emails(supplier_users, services):
     return email_addresses
 
 
+def lowercase_list(x):
+    return [item.lower() for item in x]
+
+
 def main(data_api_client, mailchimp_client, lot_data, logger):
     logger.info(
         "Begin mailchimp email list updating process for {} lot".format(lot_data["lot_slug"]),
@@ -32,7 +36,9 @@ def main(data_api_client, mailchimp_client, lot_data, logger):
         "{} existing emails found on list {}".format(len(existing_mailchimp_emails), lot_data["list_id"])
     )
 
-    new_emails = list(set(emails) - set(existing_mailchimp_emails))
+    # lowercase required because mailchimp may capatalise emails addresses returned from the mailchimp API based on it's
+    # on how it stores both the lowercase hash but also the original (potentially capatilised) email address
+    new_emails = list(set(lowercase_list(emails)) - set(lowercase_list(existing_mailchimp_emails)))
     logger.info(
         "Subscribing {} new emails to mailchimp list {}".format(len(new_emails), lot_data["list_id"])
     )

--- a/dmscripts/upload_dos_opportunities_email_list.py
+++ b/dmscripts/upload_dos_opportunities_email_list.py
@@ -14,7 +14,7 @@ def main(data_api_client, lot_data):
     data_helper = SupplierFrameworkData(data_api_client, lot_data["framework_slug"])
     supplier_users = data_helper.get_supplier_users()
 
-    framework_services = data_api_client.find_services_iter(lot_data["framework_slug"], lot_data["lot_slug"])
+    framework_services = data_api_client.find_services_iter(framework=lot_data["framework_slug"], lot=lot_data["lot_slug"])
     emails = find_user_emails(supplier_users, framework_services)
     print emails
     return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
-git+https://github.com/alphagov/digitalmarketplace-utils.git@25.0.3#egg=digitalmarketplace-utils==25.0.3
+git+https://github.com/alphagov/digitalmarketplace-utils.git@26.1.0#egg=digitalmarketplace-utils==26.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.5.0#egg=digitalmarketplace-apiclient==7.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.0.0#egg=notifications-python-client==4.0.0

--- a/scripts/send_dos_opportunities_email.py
+++ b/scripts/send_dos_opportunities_email.py
@@ -47,6 +47,10 @@ from dmapiclient import DataAPIClient
 sys.path.insert(0, '.')
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.send_dos_opportunities_email import main
+from dmscripts.helpers import logging_helpers
+
+
+logger = logging_helpers.configure_logger()
 
 
 lots = [
@@ -80,6 +84,14 @@ if __name__ == "__main__":
             number_of_days = 3  # If Monday, then 3 days of briefs
         else:
             number_of_days = 1
+
+    # Override list for non-production environment
+    if arguments['<stage>'] != "production":
+        logger.info(
+            "The environment is not production. Emails will be sent to test list unless you set the list id manually."
+        )
+        for lot in lots:
+            lot.update({"list_id": "096e52cebb"})
 
     # Override list id
     if arguments.get("--list_id"):

--- a/scripts/send_dos_opportunities_email.py
+++ b/scripts/send_dos_opportunities_email.py
@@ -41,13 +41,13 @@ import sys
 from datetime import date
 
 from docopt import docopt
-from mailchimp3 import MailChimp
 from dmapiclient import DataAPIClient
 
 sys.path.insert(0, '.')
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.send_dos_opportunities_email import main
 from dmscripts.helpers import logging_helpers
+from dmutils.email.dm_mailchimp import DMMailChimpClient
 
 
 logger = logging_helpers.configure_logger()
@@ -105,12 +105,12 @@ if __name__ == "__main__":
     api_url = get_api_endpoint_from_stage(arguments['<stage>'])
     data_api_client = DataAPIClient(api_url, arguments['<api_token>'])
 
-    mailchimp_client = MailChimp(arguments['<mailchimp_username>'], arguments['<mailchimp_api_key>'])
+    dm_mailchimp_client = DMMailChimpClient(arguments['<mailchimp_username>'], arguments['<mailchimp_api_key>'], logger)
 
     for lot_data in lots:
         ok = main(
             data_api_client=data_api_client,
-            mailchimp_client=mailchimp_client,
+            mailchimp_client=dm_mailchimp_client,
             lot_data=lot_data,
             number_of_days=number_of_days
         )

--- a/scripts/upload_dos_opportunities_email_list.py
+++ b/scripts/upload_dos_opportunities_email_list.py
@@ -38,4 +38,4 @@ if __name__ == '__main__':
     data_api_client = DataAPIClient(api_url, arguments['<api_token>'])
 
     for lot_data in lots:
-    	main(data_api_client, lot_data)
+        main(data_api_client, lot_data)

--- a/scripts/upload_dos_opportunities_email_list.py
+++ b/scripts/upload_dos_opportunities_email_list.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""
+Description:
+    upload_dos_opportunities_email_list
+Usage:
+    upload_dos_opportunities_email_list.py <stage> <api_token>
+Example:
+    upload_dos_opportunities_email_list.py preview myToken
+
+"""
+from docopt import docopt
+from dmapiclient import DataAPIClient
+
+from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
+from dmscripts.upload_dos_opportunities_email_list import main
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    api_url = get_api_endpoint_from_stage(arguments['<stage>'])
+    data_api_client = DataAPIClient(api_url, arguments['<api_token>'])
+
+    main(data_api_client)

--- a/scripts/upload_dos_opportunities_email_list.py
+++ b/scripts/upload_dos_opportunities_email_list.py
@@ -5,10 +5,10 @@ Description:
     upload_dos_opportunities_email_list
 
 Usage:
-    upload_dos_opportunities_email_list.py <stage> <api_token>
+    upload_dos_opportunities_email_list.py <stage> <api_token> <mailchimp_username> <mailchimp_api_key>
 
 Example:
-    upload_dos_opportunities_email_list.py preview myToken
+    upload_dos_opportunities_email_list.py preview myToken user@gds.gov.uk 7483crh87h34c3
 
 """
 
@@ -16,10 +16,15 @@ import sys
 
 from docopt import docopt
 from dmapiclient import DataAPIClient
+from dmutils.email.dm_mailchimp import DMMailChimpClient
 
 sys.path.insert(0, '.')
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.upload_dos_opportunities_email_list import main
+from dmscripts.helpers import logging_helpers
+
+
+logger = logging_helpers.configure_logger()
 
 
 lots = [
@@ -36,6 +41,7 @@ if __name__ == '__main__':
 
     api_url = get_api_endpoint_from_stage(arguments['<stage>'])
     data_api_client = DataAPIClient(api_url, arguments['<api_token>'])
+    dm_mailchimp_client = DMMailChimpClient(arguments['<mailchimp_username>'], arguments['<mailchimp_api_key>'], logger)
 
     for lot_data in lots:
-        main(data_api_client, lot_data)
+        main(data_api_client, dm_mailchimp_client, lot_data)

--- a/scripts/upload_dos_opportunities_email_list.py
+++ b/scripts/upload_dos_opportunities_email_list.py
@@ -44,17 +44,17 @@ if __name__ == '__main__':
     lots = [
         {
             "lot_slug": "digital-specialists",
-            "list_id": "prod_list_id" if arguments['<stage>'] == "production" else "07c21f0451",
+            "list_id": "30ba9fdf39" if arguments['<stage>'] == "production" else "07c21f0451",
             "framework_slug": "digital-outcomes-and-specialists-2"
         },
         {
             "lot_slug": "digital-outcomes",
-            "list_id": "prod_list_id2" if arguments['<stage>'] == "production" else "f0077c516d",
+            "list_id": "97952fee38" if arguments['<stage>'] == "production" else "f0077c516d",
             "framework_slug": "digital-outcomes-and-specialists-2"
         },
         {
             "lot_slug": "user-research-participants",
-            "list_id": "prod_list_id3" if arguments['<stage>'] == "production" else "d35601203b",
+            "list_id": "e6b93a3bce" if arguments['<stage>'] == "production" else "d35601203b",
             "framework_slug": "digital-outcomes-and-specialists-2"
         }
     ]

--- a/scripts/upload_dos_opportunities_email_list.py
+++ b/scripts/upload_dos_opportunities_email_list.py
@@ -28,17 +28,26 @@ from dmscripts.helpers.logging_helpers import logging
 logger = logging_helpers.configure_logger({'dmapiclient': logging.INFO})
 
 
-lots = [
-    {
-        "lot_slug": "digital-specialists",
-        "list_id": "07c21f0451",
-        "framework_slug": "digital-outcomes-and-specialists-2"
-    }
-]
-
-
 if __name__ == '__main__':
     arguments = docopt(__doc__)
+
+    lots = [
+        {
+            "lot_slug": "digital-specialists",
+            "list_id": "prod_list_id" if arguments['<stage>'] == "production" else "07c21f0451",
+            "framework_slug": "digital-outcomes-and-specialists-2"
+        },
+        {
+            "lot_slug": "digital-outcomes",
+            "list_id": "prod_list_id2" if arguments['<stage>'] == "production" else "f0077c516d",
+            "framework_slug": "digital-outcomes-and-specialists-2"
+        },
+        {
+            "lot_slug": "user-research-participants",
+            "list_id": "prod_list_id3" if arguments['<stage>'] == "production" else "d35601203b",
+            "framework_slug": "digital-outcomes-and-specialists-2"
+        }
+    ]
 
     api_url = get_api_endpoint_from_stage(arguments['<stage>'])
     data_api_client = DataAPIClient(api_url, arguments['<api_token>'])

--- a/scripts/upload_dos_opportunities_email_list.py
+++ b/scripts/upload_dos_opportunities_email_list.py
@@ -2,7 +2,17 @@
 
 """
 Description:
-    upload_dos_opportunities_email_list
+    For every lot the script will:
+    - find a list of emails for all suppliers and their users from the API
+    - add new emails to mailchimp list if they're not there. If the user previously unsubscribed themselves
+    from the list, they will not be subscribed when the script runs.
+
+    Please be aware that sometimes there can be a delay (up to a few minutes) in adding new addresses
+    to a mailchimp user list after an API call has been made. Unfortunately we couldn't find mailchimp documentation
+    regarding this.
+
+    If in the command line you provide an environment other than production the script will run on test lists
+    that we have setup on mailchimp.
 
 Usage:
     upload_dos_opportunities_email_list.py <stage> <api_token> <mailchimp_username> <mailchimp_api_key>

--- a/scripts/upload_dos_opportunities_email_list.py
+++ b/scripts/upload_dos_opportunities_email_list.py
@@ -1,18 +1,34 @@
 #!/usr/bin/env python
+
 """
 Description:
     upload_dos_opportunities_email_list
+
 Usage:
     upload_dos_opportunities_email_list.py <stage> <api_token>
+
 Example:
     upload_dos_opportunities_email_list.py preview myToken
 
 """
+
+import sys
+
 from docopt import docopt
 from dmapiclient import DataAPIClient
 
+sys.path.insert(0, '.')
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.upload_dos_opportunities_email_list import main
+
+
+lots = [
+    {
+        "lot_slug": "digital-specialists",
+        "list_id": "07c21f0451",
+        "framework_slug": "digital-outcomes-and-specialists-2"
+    }
+]
 
 
 if __name__ == '__main__':
@@ -21,4 +37,5 @@ if __name__ == '__main__':
     api_url = get_api_endpoint_from_stage(arguments['<stage>'])
     data_api_client = DataAPIClient(api_url, arguments['<api_token>'])
 
-    main(data_api_client)
+    for lot_data in lots:
+    	main(data_api_client, lot_data)

--- a/scripts/upload_dos_opportunities_email_list.py
+++ b/scripts/upload_dos_opportunities_email_list.py
@@ -22,9 +22,10 @@ sys.path.insert(0, '.')
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.upload_dos_opportunities_email_list import main
 from dmscripts.helpers import logging_helpers
+from dmscripts.helpers.logging_helpers import logging
 
 
-logger = logging_helpers.configure_logger()
+logger = logging_helpers.configure_logger({'dmapiclient': logging.INFO})
 
 
 lots = [
@@ -44,4 +45,4 @@ if __name__ == '__main__':
     dm_mailchimp_client = DMMailChimpClient(arguments['<mailchimp_username>'], arguments['<mailchimp_api_key>'], logger)
 
     for lot_data in lots:
-        main(data_api_client, dm_mailchimp_client, lot_data)
+        main(data_api_client, dm_mailchimp_client, lot_data, logger)

--- a/tests/test_upload_dos_opportunities_email_list.py
+++ b/tests/test_upload_dos_opportunities_email_list.py
@@ -1,0 +1,48 @@
+import mock
+
+from dmapiclient import DataAPIClient
+from dmscripts.upload_dos_opportunities_email_list import find_user_emails, main, SupplierFrameworkData
+
+
+def test_find_user_emails():
+    supplier_users = {
+        100: [{'supplier_id': 100, 'email address': 'email1@email.com'}],
+        102: [
+            {'supplier_id': 102, 'email address': 'email2@email.com'},
+            {'supplier_id': 102, 'email address': 'email3@email.com'}
+        ],
+        103: [{'supplier_id': 103, 'email address': 'email4@email.com'}],
+    }
+
+    services = [
+        {'supplierId': 102},
+        {'supplierId': 103}
+    ]
+    assert find_user_emails(supplier_users, services) == ['email2@email.com', 'email3@email.com', 'email4@email.com']
+
+
+@mock.patch("dmscripts.upload_dos_opportunities_email_list.find_user_emails", autospec=True)
+@mock.patch.object(SupplierFrameworkData, 'get_supplier_users', spec=SupplierFrameworkData.get_supplier_users)
+def test_main(get_supplier_users, find_user_emails):
+    supplier_users = {
+        100: [{'supplier_id': 100, 'email address': 'email1@email.com'}]
+    }
+    framework_services = iter([
+        {'supplierId': 100}
+    ])
+    lot_data = {
+        "lot_slug": "digital-specialists",
+        "list_id": "my list id",
+        "framework_slug": "digital-outcomes-and-specialists-2"
+    }
+
+    data_api_client = mock.MagicMock(spec=DataAPIClient)
+    data_api_client.find_services_iter.return_value = framework_services
+    get_supplier_users.return_value = supplier_users
+
+    assert main(data_api_client, lot_data) is True
+    data_api_client.find_services_iter.assert_called_once_with(
+        "digital-outcomes-and-specialists-2", "digital-specialists"
+    )
+    get_supplier_users.assert_called_once()
+    find_user_emails.assert_called_once_with(supplier_users, framework_services)

--- a/tests/test_upload_dos_opportunities_email_list.py
+++ b/tests/test_upload_dos_opportunities_email_list.py
@@ -42,7 +42,7 @@ def test_main(get_supplier_users, find_user_emails):
 
     assert main(data_api_client, lot_data) is True
     data_api_client.find_services_iter.assert_called_once_with(
-        "digital-outcomes-and-specialists-2", "digital-specialists"
+        framework="digital-outcomes-and-specialists-2", lot="digital-specialists"
     )
     get_supplier_users.assert_called_once()
     find_user_emails.assert_called_once_with(supplier_users, framework_services)

--- a/tests/test_upload_dos_opportunities_email_list.py
+++ b/tests/test_upload_dos_opportunities_email_list.py
@@ -40,7 +40,10 @@ class TestMain(object):
 
     def test_main(self, get_supplier_users, find_user_emails):
         supplier_users = {
-            100: [{'supplier_id': 100, 'email address': 'email1@email.com'}]
+            100: [
+                {'supplier_id': 100, 'email address': 'email1@email.com'},
+                {'supplier_id': 100, 'email address': 'email2@email.com'}
+            ]
         }
         framework_services = iter([
             {'supplierId': 100}
@@ -49,6 +52,7 @@ class TestMain(object):
         self.data_api_client.find_services_iter.return_value = framework_services
         get_supplier_users.return_value = supplier_users
         find_user_emails.return_value = self.LIST_OF_EMAILS
+        self.dm_mailchimp_client.get_email_addresses_from_list.return_value = ['email1@email.com']
 
         assert main(self.data_api_client, self.dm_mailchimp_client, self.LOT_DATA, self.logger) is True
         self.data_api_client.find_services_iter.assert_called_once_with(
@@ -56,8 +60,10 @@ class TestMain(object):
         )
         get_supplier_users.assert_called_once()
         find_user_emails.assert_called_once_with(supplier_users, framework_services)
-
-        self.dm_mailchimp_client.subscribe_new_emails_to_list.assert_called_once_with("my list id", self.LIST_OF_EMAILS)
+        self.dm_mailchimp_client.get_email_addresses_from_list.assert_called_once_with("my list id")
+        self.dm_mailchimp_client.subscribe_new_emails_to_list.assert_called_once_with(
+            "my list id", ['email2@email.com']
+        )
 
     def test_main_returns_false_if_subscribing_emails_fails(self, get_supplier_users, find_user_emails):
         find_user_emails.return_value = self.LIST_OF_EMAILS

--- a/tests/test_upload_dos_opportunities_email_list.py
+++ b/tests/test_upload_dos_opportunities_email_list.py
@@ -52,7 +52,7 @@ class TestMain(object):
         self.data_api_client.find_services_iter.return_value = framework_services
         get_supplier_users.return_value = supplier_users
         find_user_emails.return_value = self.LIST_OF_EMAILS
-        self.dm_mailchimp_client.get_email_addresses_from_list.return_value = ['email1@email.com']
+        self.dm_mailchimp_client.get_email_addresses_from_list.return_value = ['EMAIL1@email.com']
 
         assert main(self.data_api_client, self.dm_mailchimp_client, self.LOT_DATA, self.logger) is True
         self.data_api_client.find_services_iter.assert_called_once_with(

--- a/tests/test_upload_dos_opportunities_email_list.py
+++ b/tests/test_upload_dos_opportunities_email_list.py
@@ -43,8 +43,9 @@ def test_main(get_supplier_users, find_user_emails):
     get_supplier_users.return_value = supplier_users
     find_user_emails.return_value = list_of_emails
     dm_mailchimp_client = mock.MagicMock(spec=DMMailChimpClient)
+    logger = mock.MagicMock()
 
-    assert main(data_api_client, dm_mailchimp_client, lot_data) is True
+    assert main(data_api_client, dm_mailchimp_client, lot_data, logger) is True
     data_api_client.find_services_iter.assert_called_once_with(
         framework="digital-outcomes-and-specialists-2", lot="digital-specialists"
     )

--- a/tests/test_upload_dos_opportunities_email_list.py
+++ b/tests/test_upload_dos_opportunities_email_list.py
@@ -2,6 +2,7 @@ import mock
 
 from dmapiclient import DataAPIClient
 from dmscripts.upload_dos_opportunities_email_list import find_user_emails, main, SupplierFrameworkData
+from dmutils.email.dm_mailchimp import DMMailChimpClient
 
 
 def test_find_user_emails():
@@ -35,14 +36,19 @@ def test_main(get_supplier_users, find_user_emails):
         "list_id": "my list id",
         "framework_slug": "digital-outcomes-and-specialists-2"
     }
+    list_of_emails = ['email1@email.com', 'email2@email.com']
 
     data_api_client = mock.MagicMock(spec=DataAPIClient)
     data_api_client.find_services_iter.return_value = framework_services
     get_supplier_users.return_value = supplier_users
+    find_user_emails.return_value = list_of_emails
+    dm_mailchimp_client = mock.MagicMock(spec=DMMailChimpClient)
 
-    assert main(data_api_client, lot_data) is True
+    assert main(data_api_client, dm_mailchimp_client, lot_data) is True
     data_api_client.find_services_iter.assert_called_once_with(
         framework="digital-outcomes-and-specialists-2", lot="digital-specialists"
     )
     get_supplier_users.assert_called_once()
     find_user_emails.assert_called_once_with(supplier_users, framework_services)
+
+    dm_mailchimp_client.subscribe_new_emails_to_list.assert_called_once_with("my list id", list_of_emails)


### PR DESCRIPTION
### Changes to existing script that sends mailchimp campaigns for DOS opportunities
- Prevents existing script (`send_dos_opportunities_email`) from calling production mailchimp lists if you call the script to run against a non production environment (instead it will use a test list).
- Removes mailchimp api client functions as these have been moved into the utils library (see https://github.com/alphagov/digitalmarketplace-utils/pull/310)
- Pulls in the new DMMailChimpClient from utils and uses it instead

### New script to add users to mailchimp lists for DOS opportunities
Trello story: https://trello.com/c/XOCeuOYW/254-update-mailchimp-user-list-everyday

- Tests will currently fail until [utils PR](https://github.com/alphagov/digitalmarketplace-utils/pull/310) has been merged
- We have not yet coded in production list ID's to our code. This will be done as the final step just so we definitely avoid running anything against production when we shouldn't do
- Running this on preview will currently fail due to `example.com` email domains being rejected from the mailchimp API. To solve this we intend to change the domains we are using for dummy users in our preview and staging environments (https://github.com/alphagov/digitalmarketplace-aws/pull/281)
- It has been decided that if a user removes themselves as a contributer from a supplier account but their email has already been added to a mailchimp list, we will not go to the effort of also removing them from the mailchimp list. This is because we do not currently do this manually and this process has been ongoing for several months with no user queries/complaints. Users are also able to unsubscribe themselves manually if they so wish at the bottom of any email from mailchimp.