### PR TITLE
Bump mailchimp client to 2.0.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ jsonschema==2.5.1
 pandas==0.19.1
 xeger==0.3.1
 lorem==0.1.1
-mailchimp3==2.0.8
+mailchimp3==2.0.11


### PR DESCRIPTION
The bugfixes introduced since 2.0.8 mean exceptions will not
be raised when validating email addresses that contain
apostrophes in the local part of the email address. These
are in fact valid email addresses that mailchimp accepts.

In our production database we have emails as such as we don't
want our script to fail when it tries to send them to the API.