### PR TITLE
Add g-cloud services to extract-model-data.py

### DIFF
--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -109,6 +109,23 @@ CONFIGS = [
         'sort_by': ['frameworkSlug', 'supplierId', 'lotSlug']
     },
     {
+        'name': 'g_cloud_services',
+        'base_model': 'services',
+        'get_data_kwargs': {'framework': 'g-cloud-8, g-cloud-9'},
+        'keys': (
+            [
+                'id',
+                'frameworkSlug',
+                'lotSlug',
+                'serviceName',
+                'status',
+                'supplierId',
+                'supplierName'
+            ]
+        ),
+        'sort_by': ['frameworkSlug', 'supplierId', 'lotSlug']
+    },
+    {
         'name': 'briefs',
         'base_model': 'briefs',
         'keys': (


### PR DESCRIPTION
CCS have requested a CSV of all current G9 services, including the service id, supplier, name of service and lot. This is so they can confirm there spend data before publishing it. The data that this will give them will allow them to cross reference against their own datasets and ensure they have the correct figures.