### PR TITLE
Add default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 __pycache__
 output/
 venv*
+
+# local environment customizations
+local.nix

--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,8 @@
       pythonPackages.virtualenv
       pkgs.libffi
       pkgs.libyaml
+      # pip requires git to fetch some of its dependencies
+      pkgs.git
       # for `cryptography`
       pkgs.openssl
     ] ++ pkgs.stdenv.lib.optionals (!pkgs.stdenv.isDarwin) [

--- a/default.nix
+++ b/default.nix
@@ -8,8 +8,9 @@ let
     localOverridesPath = ./local.nix;
   } // argsOuter;
 in (with args; {
-  digitalMarketplaceScriptsEnv = (pkgs.stdenv.mkDerivation {
+  digitalMarketplaceScriptsEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-scripts-env";
+    shortName = "dm-scripts";
     buildInputs = [
       pythonPackages.virtualenv
       pkgs.libffi
@@ -37,6 +38,8 @@ in (with args; {
     LANG="en_GB.UTF-8";
 
     shellHook = ''
+      export PS1="\[\e[0;34m\](nix-shell\[\e[0m\]:\[\e[0;34m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;34m\]\w\[\e[0m\]\$ "
+
       if [ ! -e $VIRTUALENV_ROOT ]; then
         ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT
       fi

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,40 @@
+{
+  pkgs ? import <nixpkgs> {},
+  pythonPackages ? pkgs.python36Packages,
+  forTest ? true
+}:
+{
+  digitalMarketplaceScriptsEnv = pkgs.stdenv.mkDerivation {
+    name = "digitalmarketplace-scripts-env";
+    buildInputs = [
+      pythonPackages.virtualenv
+      pkgs.libffi
+      pkgs.libyaml
+      pkgs.wkhtmltopdf
+      # for `cryptography`
+      pkgs.openssl_1_1_0
+    ] ++ pkgs.stdenv.lib.optionals forTest ([
+        # for lxml
+        pkgs.libxml2
+        pkgs.libxslt
+      ]
+    );
+
+    hardeningDisable = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "format" ];
+
+    VIRTUALENV_ROOT = "venv${pythonPackages.python.pythonVersion}";
+    VIRTUAL_ENV_DISABLE_PROMPT = "1";
+    SOURCE_DATE_EPOCH = "315532800";
+
+    # if we don't have this, we get unicode troubles in a --pure nix-shell
+    LANG="en_GB.UTF-8";
+
+    shellHook = ''
+      if [ ! -e $VIRTUALENV_ROOT ]; then
+        ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT
+      fi
+      source $VIRTUALENV_ROOT/bin/activate
+      pip install -r requirements${pkgs.stdenv.lib.optionalString forTest "_for_test"}.txt
+    '';
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -38,7 +38,7 @@ in (with args; {
     LANG="en_GB.UTF-8";
 
     shellHook = ''
-      export PS1="\[\e[0;34m\](nix-shell\[\e[0m\]:\[\e[0;34m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;34m\]\w\[\e[0m\]\$ "
+      export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
 
       if [ ! -e $VIRTUALENV_ROOT ]; then
         ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT

--- a/default.nix
+++ b/default.nix
@@ -10,15 +10,16 @@
       pythonPackages.virtualenv
       pkgs.libffi
       pkgs.libyaml
-      pkgs.wkhtmltopdf
       # for `cryptography`
       pkgs.openssl_1_1_0
-    ] ++ pkgs.stdenv.lib.optionals forTest ([
-        # for lxml
-        pkgs.libxml2
-        pkgs.libxslt
-      ]
-    );
+    ] ++ pkgs.stdenv.lib.optionals (!pkgs.stdenv.isDarwin) [
+      # package not available on darwin for now - sorry you're on your own...
+      pkgs.wkhtmltopdf
+    ] ++ pkgs.stdenv.lib.optionals forTest [
+      # for lxml
+      pkgs.libxml2
+      pkgs.libxslt
+    ];
 
     hardeningDisable = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "format" ];
 

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@
       pkgs.libffi
       pkgs.libyaml
       # for `cryptography`
-      pkgs.openssl_1_1_0
+      pkgs.openssl
     ] ++ pkgs.stdenv.lib.optionals (!pkgs.stdenv.isDarwin) [
       # package not available on darwin for now - sorry you're on your own...
       pkgs.wkhtmltopdf

--- a/local.example.nix
+++ b/local.example.nix
@@ -1,0 +1,22 @@
+# default.nix calls out to the file local.nix if it exists, expecting a function which it will call, applying first
+# the args passed to the original default.nix and then `oldAttrs`, the attrset originally applied to mkDerivation.
+#
+# the function should return an attrset altered to the local user's desires, as they would wish to be applied to
+# mkDerivation to produce the env
+
+args: oldAttrs: oldAttrs // {
+  # here we add some of our favourite packages to the environment which aren't necessarily to everyone's tastes
+  buildInputs = oldAttrs.buildInputs ++ [
+    args.pkgs.vim
+    args.pythonPackages.ipython
+  ];
+
+  shellHook =  oldAttrs.shellHook + ''
+    # PS1 can't be set as a normal derivation attr as it gets clobbered early on in the upstream shellHook script
+    export PS1="⚡$PS1⚡"
+
+    # inject some whimsy into our session - note here we access a package which we don't actually end up
+    # explicitly exposing to the final environment
+    ${args.pkgs.fortune}/bin/fortune
+  '';
+}

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==2.7.0
+pytest==2.9.2
 pep8==1.5.7
 mock==2.0.0
 freezegun==0.3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pep8]
-exclude = ./venv,./venv3
+exclude = ./venv*
 max-line-length = 120
 
 [pytest]
-norecursedirs= venv venv3
+norecursedirs= venv*


### PR DESCRIPTION
See https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/719 for discussion of general issues.

It's a pity, but one of the dependencies I was most hoping to sort out here was `wkhtmltopdf` - but as of the nix 17.03 branch this is disabled for darwin for a couple of reasons. So for now, mac users needing generate pdfs will need to provide their own `wkhtmltopdf`. Sorry about that.