### PR TITLE
Add script to programatically update an ES alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ The `scripts` folder in this repository contains scripts that interact with the 
   `bulk-upload-documents.py` because the "countersigned agreement path" needs to be set in the DB at the same time as
   the file is uploaded.
 
+* `update-index-alias.py`
+
+  Makes it easier for humans and computers (namely Jenkins) to update the alias of an elasticsearch index. It was written to assist with indexing services after migrating data between environments periodically with Jenkins.
+
 ## A general approach to writing new scripts
 
 Historically (and currently), this respository has been filled with small files that slightly diverge from one another. The idea has been that scripts are written for things that happen once (slash infrequently) in the lifecycle of a framework -- so we write our script, run it once, and then walk away.

--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+import yaml
+
+
+def get_auth_token(api, stage):
+    DM_CREDENTIALS_REPO = os.environ.get('DM_CREDENTIALS_REPO')
+    token_prefix = 'J' if subprocess.check_output(["whoami"]) == 'jenkins' else 'D'
+    creds = subprocess.check_output([
+        "{}/sops-wrapper".format(DM_CREDENTIALS_REPO),
+        "-d",
+        "{}/vars/{}.yaml".format(DM_CREDENTIALS_REPO, stage)
+    ])
+    auth_tokens = yaml.load(creds)[api]['auth_tokens']
+    auth_token = [token for token in auth_tokens if token.startswith(token_prefix)]
+
+    return auth_token[0]

--- a/scripts/update-index-alias.py
+++ b/scripts/update-index-alias.py
@@ -36,7 +36,7 @@ def update_index_alias(alias, target, stage, endpoint, delete_old_index):
     if delete_old_index:
         _delete_old_index(old_index_to_delete, endpoint, auth_token)
 
-    url = "https://{}/{}".format(endpoint, alias)
+    url = "{}/{}".format(endpoint, alias)
     data = {'type': 'alias', 'target': "{}".format(target)}
 
     response = requests.put(url, headers=headers, json=data)
@@ -57,7 +57,7 @@ def _get_auth_token(stage):
 
 def _rename_current_alias_to_old(alias, endpoint, headers):
     old_alias = "{}-old".format(alias)
-    url = "https://{}/{}".format(endpoint, old_alias)
+    url = "{}/{}".format(endpoint, old_alias)
     data = {'type': 'alias', 'target': "{}".format(alias)}
 
     response = requests.put(url, headers=headers, json=data)
@@ -66,7 +66,7 @@ def _rename_current_alias_to_old(alias, endpoint, headers):
 
 
 def _get_old_index_to_delete(alias, endpoint):
-    status_url = "https://{}/_status".format(endpoint.replace('search-api', 'www'))
+    status_url = "{}/_status".format(endpoint.replace('search-api', 'www'))
 
     response = requests.get(status_url)
     _check_response_status(response, 'fetching indexes')
@@ -84,7 +84,7 @@ def _delete_old_index(old_index_to_delete, endpoint, auth_token):
         'Authorization': "Bearer {}".format(auth_token),
     }
 
-    response = requests.delete("https://{}/{}".format(endpoint, old_index_to_delete), headers=headers)
+    response = requests.delete("{}/{}".format(endpoint, old_index_to_delete), headers=headers)
     _check_response_status(response, "deleting {} index".format(old_index_to_delete))
 
 

--- a/scripts/update-index-alias.py
+++ b/scripts/update-index-alias.py
@@ -53,7 +53,9 @@ def _get_auth_token(stage):
         "-d",
         "{}/vars/{}.yaml".format(DM_CREDENTIALS_REPO, stage)
     ])
-    return yaml.load(creds)['search_api']['auth_tokens'][2]
+    auth_tokens = yaml.load(creds)['search_api']['auth_tokens']
+    dev_token = [token for token in auth_tokens if token[0] == 'D']
+    return dev_token[0]
 
 
 def _delete_old_indexes(endpoint, auth_token):

--- a/scripts/update-index-alias.py
+++ b/scripts/update-index-alias.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+"""
+A script to update the search index an alias is assoiciated with.
+
+To delete old indexes (those with no alias), set --delete-old-indexes=yes
+
+Usage:
+scripts/update-index-alias.py <alias> <target> <stage> <search-api-endpoint> [options]
+
+Options:
+    --delete-old-indexes=<delete-old-indexes>  [default: ]
+"""
+import os
+import sys
+import subprocess
+import yaml
+import json
+import requests
+from requests.exceptions import HTTPError
+from docopt import docopt
+
+
+def update_index_alias(alias, target, stage, endpoint, delete_old_indexes):
+    url = "https://{}/{}".format(endpoint, alias)
+    auth_token = _get_auth_token(stage)
+    headers = {
+        'Authorization': "Bearer {}".format(auth_token),
+        'Content-type': 'application/json'
+    }
+    data = {'type': 'alias', 'target': "{}".format(target)}
+
+    response = requests.put(url, headers=headers, json=data)
+
+    try:
+        response.raise_for_status()
+    except HTTPError as e:
+        print("HTTPError updating alias: {}".format(e.args[0]))
+        sys.exit(1)
+    except Exception as e:
+        print("Error updating alias: {}".format(e))
+        sys.exit(2)
+
+    print('Successfully updated alias')
+
+    if delete_old_indexes == 'yes':
+        _delete_old_indexes(endpoint, auth_token)
+
+
+def _get_auth_token(stage):
+    DM_CREDENTIALS_REPO = os.environ.get('DM_CREDENTIALS_REPO')
+    creds = subprocess.check_output([
+        "{}/sops-wrapper".format(DM_CREDENTIALS_REPO),
+        "-d",
+        "{}/vars/{}.yaml".format(DM_CREDENTIALS_REPO, stage)
+    ])
+    return yaml.load(creds)['search_api']['auth_tokens'][2]
+
+
+def _delete_old_indexes(endpoint, auth_token):
+    status_url = "https://{}/_status".format(endpoint.replace('search-api', 'www'))
+    response = requests.get(status_url)
+
+    try:
+        response.raise_for_status()
+    except HTTPError as e:
+        print("HTTPError fetching indexes: {}".format(e.args[0]))
+        sys.exit(1)
+    except Exception as e:
+        print("Error fetching indexes: {}".format(e))
+        sys.exit(2)
+
+    current_indexes = json.loads(response.content)['search_api_status']['es_status']
+    indexes_to_delete = [
+        index for index in current_indexes.keys() if not current_indexes[index]['aliases']
+    ]
+
+    if len(indexes_to_delete) >= len(current_indexes):
+        print('Error: Can not delete all indexes')
+        sys.exit(3)
+
+    base_url = "https://{}/{}"
+    headers = {
+        'Authorization': "Bearer {}".format(auth_token),
+    }
+    for index in indexes_to_delete:
+        response = requests.delete(base_url.format(endpoint, index), headers=headers)
+
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            print("HTTPError deleting index {}: {}".format(index, e.args[0]))
+            sys.exit(1)
+        except Exception as e:
+            print("Error deleting index {}: {}".format(index, e))
+            sys.exit(2)
+
+    print('Completed deleting indexes')
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+    alias = arguments['<alias>']
+    target = arguments['<target>']
+    stage = arguments['<stage>']
+    endpoint = arguments['<search-api-endpoint>']
+    delete_old_indexes = arguments['--delete-old-indexes']
+    update_index_alias(alias, target, stage, endpoint, delete_old_indexes)

--- a/scripts/update-index-alias.py
+++ b/scripts/update-index-alias.py
@@ -8,7 +8,7 @@ Usage:
 scripts/update-index-alias.py <alias> <target> <stage> <search-api-endpoint> [options]
 
 Options:
-    --delete-old-indexes=<delete-old-indexes>  [default: ]
+    --delete-old-indexes=<delete-old-indexes>  [default: no]
 """
 import os
 import sys

--- a/scripts/update-index-alias.py
+++ b/scripts/update-index-alias.py
@@ -44,12 +44,12 @@ def update_index_alias(alias, target, stage, endpoint, delete_old_index):
 
 
 def _get_index_from_alias(alias, endpoint):
-    status_url = "{}/_status".format(endpoint.replace('search-api', 'www'))
+    status_url = "{}/_status".format(endpoint)
 
     response = requests.get(status_url)
     _check_response_status(response, 'fetching indexes')
 
-    all_indexes = json.loads(response.content)['search_api_status']['es_status']
+    all_indexes = json.loads(response.content)['es_status']
     index_name = [index for index in all_indexes.keys() if alias in all_indexes[index]['aliases']][0]
 
     return index_name


### PR DESCRIPTION
Also see this PR on the Jenkins repo: [https://github.com/alphagov/digitalmarketplace-jenkins/pull/18](https://github.com/alphagov/digitalmarketplace-jenkins/pull/18)

Currently adding or moving an elasticsearch index alias is a manual job
involving constructing a bespoke request with curl.

You can do the same thing by giving this script the arguments required.
It will fetch the correct auth token for the search api from the
credentials repo.

It's being written for use by Jenkins, but could be used locally.

If invoked with `--delete-old-index=yes` it will remove whichever index
is losing the `<alias>-old`alias.