### PR TITLE
Add a description of send_dos_opportunities_email.py script to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ The `scripts` folder in this repository contains scripts that interact with the 
 
   Checks all free-text fields in G-Cloud services for "bad words" and generates a CSV report of any bad words found.
 
+* `send_dos_opportunities_email.py`
+
+  **Runs Mon-Fri 8:00am on Jenkins**. Send emails with new opportunities on a lot to suppliers who are on this lot.
+
 * `send-stats-to-performance-platform.py`
 
   Fetches application statistics for a framework from the API and pushes them to the Performance Platform.

--- a/dmscripts/notify_suppliers_of_new_questions_answers.py
+++ b/dmscripts/notify_suppliers_of_new_questions_answers.py
@@ -147,6 +147,14 @@ def main(data_api_url, data_api_token, email_api_key, stage, dry_run, supplier_i
                     'brief_ids_list': ", ".join(map(str, brief_ids))
                 }
             )
+        elif len(email_addresses) == 0:
+            logger.info(
+                "Email not sent for the following supplier ID due to no active users: {supplier_id}",
+                extra={
+                    'supplier_id': supplier_id,
+                    'brief_ids_list': ", ".join(map(str, brief_ids))
+                }
+            )
         else:
             logger.info(
                 "Notifying supplier ID {supplier_id} of new questions/answers for brief IDs {brief_ids_list}",


### PR DESCRIPTION
Script with description still missing:

notify-suppliers-whether-application-made-for-framework.py
