### PR TITLE
Ensure existing behaviour for new 'awarded' brief status

### DIFF
--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -198,7 +198,7 @@ CONFIGS = [
             'join': ('id', 'briefId'),
             'group_by': 'essentialRequirements'
         },
-        'filter_query': "status in ['live', 'closed', 'withdrawn']",
+        'filter_query': "status in ['live', 'closed', 'awarded', withdrawn']",
         'keys': (
             'id',
             'lot',


### PR DESCRIPTION
As part of this trello story - https://trello.com/c/kGVfzXuH/749-3-collect-award-status-on-buyer-dashboard - we are adding a new 'awarded' status for a brief.

This PR ensures the scripts app retains all existing functionality when this new status lands.