### PR TITLE
758-2-add-contract-info-to-data-script

### DIFF
--- a/dmscripts/models/queries.py
+++ b/dmscripts/models/queries.py
@@ -64,3 +64,10 @@ def add_counts(join, group_by, model, data, directory):
         )['_count'].fillna(0)
 
     return data
+
+
+def assign_json_subfields(field, subfields, data):
+    """Apply subfields from field to data."""
+    for subfield in subfields:
+        data[subfield] = data.apply(lambda row: row[field].get(subfield, '') if row[field] else '', axis=1)
+    return data


### PR DESCRIPTION
https://trello.com/c/ohWdLfJO/758-2-add-contract-info-to-data-script

Add new method `expand_json_subfields` to handle incoming json and add fields to the parent object
 * Add `awardedContractStartDate` to parent `brief_response`
 * Add `awardedContractValue` to parent `brief_response`

Add new fields to base model csvs
 * `briefs.csv` `awardedBriefResponseId`
 * `brief_responses.csv` `id,supplierOrganisationSize,awardedContractStartDate,awardedContractValue`

Test