### PR TITLE
Backwards compatibility for new Brief statuses

### DIFF
--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -198,7 +198,7 @@ CONFIGS = [
             'join': ('id', 'briefId'),
             'group_by': 'essentialRequirements'
         },
-        'filter_query': "status in ['live', 'closed', 'awarded', 'withdrawn']",
+        'filter_query': "status in ['live', 'closed', 'awarded', 'withdrawn', 'cancelled', 'unsuccessful']",
         'keys': (
             'id',
             'lot',


### PR DESCRIPTION
Third of 5 backwards compatibility PRs to handle the two new Brief statuses, `cancelled` and `unsuccessful`.

1. Admin FE alphagov/digitalmarketplace-admin-frontend#293
2. Buyer FE https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/588
3. Scripts 
4. Brief Responses FE https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/5
5. Briefs FE https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/17

See #137 for the equivalent changes for the awarded status.

- Adds new cancelled and unsuccessful statuses to the model query.