### PR TITLE
Update indexing script to use g-cloud-9 alias

### DIFF
--- a/scripts/index-services.py
+++ b/scripts/index-services.py
@@ -6,7 +6,7 @@ Usage:
 --search-api-token=<search_api_access_token> [options]
 
     --serial                  Do not run in parallel (useful for debugging)
-    --index=<index>           Search API index name [default: g-cloud]
+    --index=<index>           Search API index name [default: g-cloud-9]
     --frameworks=<frameworks> Comma-separated list of framework slugs that should be indexed
 
 Example:

--- a/scripts/oneoff/generate-fake-g-cloud-services.py
+++ b/scripts/oneoff/generate-fake-g-cloud-services.py
@@ -211,7 +211,7 @@ if __name__ == '__main__':
     subprocess.call(['python', 'scripts/make-dos-live.py', args.new_slug, args.env, args.data_api_token])
 
     # 6) Runs the `index-services.py` script to index the new services
-    index_name = 'g-cloud-{}'.format(date.today().isoformat())
+    index_name = '{}-{}'.format(args.new_slug, date.today().isoformat())
     subprocess.call(['python', 'scripts/index-services.py', '--index', index_name, '--frameworks', args.new_slug,
                      '--api-token', args.data_api_token, '--search-api-token', args.search_api_token, args.env])
 


### PR DESCRIPTION
## Summary
Change default for indexing script to be g-cloud-9. We are moving away from using `g-cloud` as a the index name to use the name of the current iteration of the framework, e.g. `g-cloud-9`.