### PR TITLE
Log list of supplier IDs that we intend to send emails to

### DIFF
--- a/dmscripts/notify_suppliers_of_new_questions_answers.py
+++ b/dmscripts/notify_suppliers_of_new_questions_answers.py
@@ -128,7 +128,10 @@ def main(data_api_url, data_api_token, email_api_key, stage, dry_run, supplier_i
             if supplier_id in supplier_ids
         )
     logger.info(
-        "{} suppliers found interested in these briefs".format(len(interested_suppliers))
+        "{} suppliers found interested in these briefs with the following IDs: {}".format(
+            len(interested_suppliers),
+            ",".join(map(str, interested_suppliers.keys()))
+        )
     )
 
     failed_supplier_ids = []


### PR DESCRIPTION
If our script fails middway, we rerun it and include a specific
list of supplier IDs only to send to.  If the script fails middway
though we don't know which IDs these are as they are never logged
out. This commit will log them meaning they can be easily be
copied and pasted back into the job (from the supplier ID of
failure).