### PR TITLE
Clients in Python interpreter

### DIFF
--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -4,6 +4,9 @@ import yaml
 
 
 def get_auth_token(api, stage):
+    if stage == 'development':
+        return 'myToken'
+
     DM_CREDENTIALS_REPO = os.environ.get('DM_CREDENTIALS_REPO', '../digitalmarketplace-credentials')
     token_prefix = 'J' if subprocess.check_output(["whoami"]) == 'jenkins' else 'D'
     creds = subprocess.check_output([
@@ -15,3 +18,14 @@ def get_auth_token(api, stage):
     auth_token = [token for token in auth_tokens if token.startswith(token_prefix)]
 
     return auth_token[0]
+
+
+def get_api_url(api, stage):
+    if stage == 'development':
+        url = 'http://localhost:{}'.format(5001 if api == 'search-api' else 5000)
+    elif stage == 'production':
+        url = 'https://{}.digitalmarketplace.service.gov.uk'
+    else:
+        url = 'https://{{}}.{}.marketplace.team'.format(stage)
+
+    return url.format(api)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,8 @@
 flake8==2.6.2
 flake8-putty==0.4.0
 freezegun==0.3.7
+ipython==6.2.1
+ipython-genutils==0.2.0
 lxml==3.7.2
 mock==2.0.0
 pytest==2.9.2

--- a/scripts/api-clients-shell.py
+++ b/scripts/api-clients-shell.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""Drops you into an IPython shell with the DataAPIClient and SearchAPIClient instantiated and targetting the specified
+stage as `data` and `search` respectively.
+
+Usage:
+  api-clients-shell.py [<stage>]
+
+Optional:
+  --api-url           Override the implicit API URL
+  --api-token         Override for the API key (don't decrypt from dm-credentials)
+  --search-api-url    Override the implicit SearchAPI URL
+  --search-api-token  Override for the SearchAPI key (don't decrypt from dm-credentials)
+
+Example:
+  ./scripts/api-clients-shell.py
+  ./scripts/api-clients-shell.py development
+  ./scripts/api-clients-shell.py preview
+  ./scripts/api-clients-shell.py staging
+"""
+
+import argparse
+import IPython
+import sys
+
+from dmapiclient import DataAPIClient, SearchAPIClient
+
+sys.path.insert(0, '.')
+from dmscripts.helpers.auth_helpers import get_auth_token, get_api_url  # noqa
+
+
+def clients_in_shell(stage, api_url, api_token, search_api_url, search_api_token):
+    print('Retrieving credentials...')
+    api_token = api_token or get_auth_token('api', stage),
+    search_api_token = search_api_token or get_auth_token('search_api', stage)
+
+    print('Creating clients...')
+    data = DataAPIClient(api_url or get_api_url('api', stage), api_token)  # noqa
+    search = SearchAPIClient(search_api_url or get_api_url('search-api', stage), search_api_token)  # noqa
+
+    print('Dropping into shell...')
+    IPython.embed()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('stage', default='development', help='The stage your clients should target',
+                        choices=['development', 'preview', 'staging'], nargs='?')
+
+    parser.add_argument('--api-url', help='Override the implicit API URL', type=str)
+    parser.add_argument('--api-token', help='Override for the API key (don\'t decrypt from dm-credentials)', type=str)
+
+    parser.add_argument('--search-api-url', help='Override the implicit SearchAPI URL', type=str)
+    parser.add_argument('--search-api-token',
+                        help='Override for the SearchAPI key (don\'t decrypt from dm-credentials)', type=str)
+
+    args = parser.parse_args()
+
+    clients_in_shell(stage=args.stage.lower(), api_url=args.api_url, api_token=args.api_token,
+                     search_api_url=args.search_api_url, search_api_token=args.search_api_token)

--- a/scripts/clients.py
+++ b/scripts/clients.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""Drops you into an IPython shell with the DataAPIClient and SearchAPIClient instantiated and targetting the specified
+stage as `data` and `search` respectively.
+
+Usage:
+  clients.py [<stage>]
+
+Example:
+  ./clients.py
+  ./clients.py development
+  ./clients.py preview
+  ./clients.py staging
+"""
+
+import argparse
+import IPython
+import sys
+
+from dmapiclient import DataAPIClient, SearchAPIClient
+
+sys.path.insert(0, '.')
+from dmscripts.helpers.auth_helpers import get_auth_token, get_api_url
+
+
+def clients_in_shell(stage):
+    print('Retrieving credentials...')
+    api_token = 'myToken'
+    search_api_token = 'myToken'
+
+    if stage != 'development':
+        api_token = get_auth_token('api', stage),
+        search_api_token = get_auth_token('search_api', stage)
+
+    print('Creating clients...')
+    data = DataAPIClient(get_api_url('api', stage), api_token)  # noqa
+    search = SearchAPIClient(get_api_url('search-api', stage), search_api_token)  # noqa
+
+    print('Dropping into shell...')
+    IPython.embed()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('stage', default='development', help='The stage your clients should target',
+                        choices=['development', 'preview', 'staging'], nargs='?')
+
+    args = parser.parse_args()
+
+    clients_in_shell(stage=args.stage.lower())

--- a/scripts/get-user.py
+++ b/scripts/get-user.py
@@ -7,8 +7,9 @@ filtering by suppliers who have published services on the given framewok and lot
 Usage:
     get-user.py <role> [<framework>] [<lot>] [options]
 
-    --api-url=<api_url>  API URL [default: http://localhost:5000]
-    --stage=<stage>  Stage to target [default: development]
+    --api-url=<api_url>     API URL (overrides --stage)
+    --api-token=<api_token  API Token (overrides --stage)
+    --stage=<stage>         Stage to target; automatically derive/decrypt api url and token [default: development]
 
 Example:
     ./get-user.py supplier g9 cloud-hosting
@@ -25,7 +26,7 @@ import dmapiclient
 from docopt import docopt
 
 sys.path.insert(0, '.')  # noqa
-from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.auth_helpers import get_auth_token, get_api_url
 
 
 def get_full_framework_slug(framework):
@@ -65,8 +66,11 @@ def get_random_user(api_client, role, supplier_id=None):
     ])
 
 
-def get_user(api_url, stage, role, framework, lot):
-    api_token = 'myToken' if stage == 'development' else get_auth_token('api', stage)
+def get_user(api_url, api_token, stage, role, framework, lot):
+    if not api_url:
+        api_url = get_api_url('api', stage)
+
+    api_token = api_token or get_auth_token('api', stage)
     api_client = dmapiclient.DataAPIClient(api_url, api_token)
 
     if role == 'supplier' and framework is not None:
@@ -85,6 +89,7 @@ if __name__ == "__main__":
     arguments = docopt(__doc__)
     user = get_user(
         api_url=arguments['--api-url'],
+        api_token=arguments['--api-token'],
         stage=arguments['--stage'],
         role=arguments['<role>'].lower(),
         framework=arguments['<framework>'].lower() if arguments['<framework>'] else None,


### PR DESCRIPTION
## Summary
Add script to quickly access clients for dev/preview/staging; tweak scripts to build api urls automatically
Also tweaks the get-user script so you don't need to provide the api-url; you can just provide the stage.

Here for discussion.