### PR TITLE
Remove python2.7 test runner from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-  - "2.7"
   - "3.6"
 install:
   - make requirements-dev


### PR DESCRIPTION
## Summary
Yep. Let's remove Python2 tests from Travis now that scripts is Py3 compatible.