### PR TITLE
When creating an index, a mapping name is now required.

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,7 +3,7 @@
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==28.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.2.0#egg=digitalmarketplace-apiclient==11.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.0.0#egg=digitalmarketplace-apiclient==12.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.0.0#egg=notifications-python-client==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==28.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.2.0#egg=digitalmarketplace-apiclient==11.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.0.0#egg=digitalmarketplace-apiclient==12.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.0.0#egg=notifications-python-client==4.0.0
 

--- a/scripts/index-services.py
+++ b/scripts/index-services.py
@@ -83,7 +83,7 @@ class ServiceIndexer(object):
         logger.info("Creating {index} index", extra={'index': self.index})
 
         try:
-            result = client.create_index(self.index)
+            result = client.create_index(self.index, mapping='services')
             logger.info("Index creation response: {response}", extra={'response': result})
         except dmapiclient.HTTPError as e:
             if 'already exists as alias' in str(e.message):


### PR DESCRIPTION
This is the minimum change we need in order to carry on supporting G-Cloud indexes (i.e. being able to create them). A script of some sort (potentially a refactoring of this one, i.e. the G-Cloud services indexing script) will follow for indexing DOS opportunities.

https://trello.com/c/5oIKvS1s/100-search-service-for-briefs-plus-indexing-script