### PR TITLE
Generalize the indexer for briefs

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,7 +3,7 @@
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==28.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.0.0#egg=digitalmarketplace-apiclient==12.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.2.0#egg=digitalmarketplace-apiclient==12.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.0.0#egg=notifications-python-client==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==28.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.0.0#egg=digitalmarketplace-apiclient==12.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.2.0#egg=digitalmarketplace-apiclient==12.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.0.0#egg=notifications-python-client==4.0.0
 

--- a/scripts/index-to-search-service.py
+++ b/scripts/index-to-search-service.py
@@ -23,7 +23,8 @@ Options:
     --search-api-token=<search_api_access_token>  Override search API token (otherwise automatically populated)
 
 Example:
-    ./index-to-search-service.py services dev --index=g-cloud-9-2017-10-17 --frameworks=g-cloud-9
+    ./index-to-search-service.py services dev --index=g-cloud-9-2017-10-17 --frameworks=g-cloud-9 \
+--mapping=g-cloud-9-services
 """
 
 import sys

--- a/scripts/index-to-search-service.py
+++ b/scripts/index-to-search-service.py
@@ -2,7 +2,8 @@
 """Read services from the API endpoint and write to search-api for indexing.
 
 Usage:
-    index.py <doc-type> <stage> [--create] --index=<index> --frameworks=<frameworks> --mapping=<mapping> [options]
+    index-to-search-service.py <doc-type> <stage> [--create] --index=<index> --frameworks=<frameworks> \
+--mapping=<mapping> [options]
 
     <doc-type>                                    One of briefs or services
     <stage>                                       One of dev, preview, staging or production
@@ -22,7 +23,7 @@ Options:
     --search-api-token=<search_api_access_token>  Override search API token (otherwise automatically populated)
 
 Example:
-    ./index.py services dev --index=g-cloud-9-2017-10-17 --frameworks=g-cloud-9
+    ./index-to-search-service.py services dev --index=g-cloud-9-2017-10-17 --frameworks=g-cloud-9
 """
 
 import sys

--- a/scripts/index.py
+++ b/scripts/index.py
@@ -6,6 +6,10 @@ Usage:
 
     <doc-type>                                    One of briefs or services
     <stage>                                       One of dev, preview, staging or production
+    --create                                      Use this flag to create the index if it doesn't exist. If it does
+                                                  exist, the mapping for the index will be updated. Don't specify this
+                                                  option when running from a batch/Jenkins job, as both creating indexes
+                                                  and updating mappings should be done under user control.
     --index=<index>                               Search API index name, usually of the form <framework>-YYYY-MM-DD
     --frameworks=<frameworks>                     Comma-separated list of framework slugs that should be indexed
     --mapping=<mapping>                           One of the mappings supported by the Search API.
@@ -91,7 +95,7 @@ class IndexerBase(object):
 
 class BriefIndexer(IndexerBase):
     def request_items(self, frameworks):
-        # despite the name, frameworks takes a string containing a comma-separated list of framework slugs
+        # despite the name, `framework` takes a string containing a comma-separated list of framework slugs
         return self.data_client.find_briefs_iter(framework=frameworks)
 
     def include_in_index(self, item):
@@ -136,8 +140,8 @@ def do_index(doc_type, search_api_url, search_api_access_token, data_api_url, da
     counter = 0
     start_time = datetime.utcnow()
     status = True
-    services = indexer.request_items(frameworks)
-    for result in mapper(indexer, services):
+    items = indexer.request_items(frameworks)
+    for result in mapper(indexer, items):
         counter += 1
         status = status and result
         print_progress(counter, start_time)


### PR DESCRIPTION
Generalize the indexer to work with briefs as well as services.
 - must specify document type (`doc-type`) on command line;
 - index and mapping are not updated unless `--create-with-mapping` is specified.

This is not backwards-compatible so we'll have to look at updating Jenkins jobs etc as part of planning the release for this.

https://trello.com/c/5oIKvS1s/100-search-service-for-briefs-plus-indexing-script