### PR TITLE
Change from flake8-putty to per-file-ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 # Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
 # D203: 1 blank line required before class docstring
-# F401: 'identifier' imported but unused
 # E402: module level import not at top of file
 # W503: line break before binary operator
 # C901: 'Methodname' is too complex ('n')
@@ -9,7 +8,6 @@ exclude = venv*,__pycache__,node_modules,bower_components,.git
 ignore = D203,W503
 max-complexity = 19
 max-line-length = 120
-putty-ignore =
-    **/__init__.py : +F401
-    scripts/ : +E402
-    scripts/get-model-data.py : +C901
+per-file-ignores =
+    scripts/* : E402
+    scripts/get-model-data.py : C901

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 freezegun==0.3.7
 ipython==6.2.1
 ipython-genutils==0.2.0

--- a/scripts/make-dos-live.py
+++ b/scripts/make-dos-live.py
@@ -32,6 +32,7 @@ def make_draft_service_live(client, draft, dry_run):
             else:
                 print(u"    > ERROR MIGRATING DRAFT {} - {}".format(draft['id'], e.message))
 
+
 if __name__ == "__main__":
     arguments = docopt(__doc__)
 

--- a/scripts/oneoff/generate-fake-g-cloud-services.py
+++ b/scripts/oneoff/generate-fake-g-cloud-services.py
@@ -123,6 +123,7 @@ def get_args():
 def filepath_service_lot_schema(validation_schema_path, new_slug, chosen_lot):
     return '{}/services-{}-{}.json'.format(validation_schema_path, new_slug, chosen_lot)
 
+
 if __name__ == '__main__':
     args = get_args()
 

--- a/scripts/scan-g-cloud-services-for-bad-words.py
+++ b/scripts/scan-g-cloud-services-for-bad-words.py
@@ -170,6 +170,7 @@ def output_bad_words(
     logger.info("{} - {}".format(blacklisted_word, service_id))
     writer.writerow(row)
 
+
 if __name__ == '__main__':
     arguments = docopt(__doc__)
     main(

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -56,6 +56,7 @@ def test_get_live_briefs_between_two_dates():
         {"publishedAt": "2017-03-18T09:52:17.669156Z"}
     ]
 
+
 ONE_BRIEF = [
     {
         "title": "Brief 1",


### PR DESCRIPTION
## Summary
This allows us to upgrade to flake8==3.5.0 which brings support for
Python 3 features like f-strings and type annotations.

Flake8 report:
```
/Users/samuelwilliams/git/digitalmarketplace-scripts/venv/bin/flake8 .
./dmscripts/__init__.py:0:1: X100 Superfluous per-file-ignores for F401
./dmscripts/helpers/__init__.py:0:1: X100 Superfluous per-file-ignores for F401
./dmscripts/models/__init__.py:0:1: X100 Superfluous per-file-ignores for F401
./scripts/bulk-upload-ccs-documents.py:31:1: E402 module level import not at top of file
./scripts/bulk-upload-ccs-documents.py:33:1: E402 module level import not at top of file
./scripts/bulk-upload-ccs-documents.py:35:1: E402 module level import not at top of file
./scripts/bulk-upload-documents.py:44:1: E402 module level import not at top of file
./scripts/bulk-upload-documents.py:47:1: E402 module level import not at top of file
./scripts/bulk-upload-documents.py:49:1: E402 module level import not at top of file
./scripts/clients.py:22:1: E402 module level import not at top of file
./scripts/export-dos-labs.py:13:1: E402 module level import not at top of file
./scripts/export-dos-labs.py:14:1: E402 module level import not at top of file
./scripts/export-dos-labs.py:15:1: E402 module level import not at top of file
./scripts/export-dos-labs.py:16:1: E402 module level import not at top of file
./scripts/export-dos-outcomes.py:13:1: E402 module level import not at top of file
./scripts/export-dos-outcomes.py:15:1: E402 module level import not at top of file
./scripts/export-dos-outcomes.py:16:1: E402 module level import not at top of file
./scripts/export-dos-outcomes.py:18:1: E402 module level import not at top of file
./scripts/export-dos-outcomes.py:19:1: E402 module level import not at top of file
./scripts/export-dos-outcomes.py:20:1: E402 module level import not at top of file
./scripts/export-dos-participants.py:13:1: E402 module level import not at top of file
./scripts/export-dos-participants.py:14:1: E402 module level import not at top of file
./scripts/export-dos-participants.py:16:1: E402 module level import not at top of file
./scripts/export-dos-participants.py:17:1: E402 module level import not at top of file
./scripts/export-dos-participants.py:18:1: E402 module level import not at top of file
./scripts/export-dos-participants.py:19:1: E402 module level import not at top of file
./scripts/export-dos-participants.py:20:1: E402 module level import not at top of file
./scripts/export-dos-participants.py:21:1: E402 module level import not at top of file
./scripts/export-dos-participants.py:22:1: E402 module level import not at top of file
./scripts/export-dos-specialists.py:13:1: E402 module level import not at top of file
./scripts/export-dos-specialists.py:14:1: E402 module level import not at top of file
./scripts/export-dos-specialists.py:15:1: E402 module level import not at top of file
./scripts/export-dos-specialists.py:16:1: E402 module level import not at top of file
./scripts/export-dos-specialists.py:17:1: E402 module level import not at top of file
./scripts/export-dos-specialists.py:18:1: E402 module level import not at top of file
./scripts/export-dos-specialists.py:19:1: E402 module level import not at top of file
./scripts/export-dos-specialists.py:20:1: E402 module level import not at top of file
./scripts/export-framework-applicant-details.py:23:1: E402 module level import not at top of file
./scripts/export-framework-applicant-details.py:24:1: E402 module level import not at top of file
./scripts/export-framework-applicant-details.py:25:1: E402 module level import not at top of file
./scripts/export-framework-applicant-details.py:26:1: E402 module level import not at top of file
./scripts/export-framework-results-reasons.py:26:1: E402 module level import not at top of file
./scripts/export-framework-results-reasons.py:27:1: E402 module level import not at top of file
./scripts/export-framework-results-reasons.py:28:1: E402 module level import not at top of file
./scripts/export-framework-results-reasons.py:29:1: E402 module level import not at top of file
./scripts/export-framework-results-reasons.py:30:1: E402 module level import not at top of file
./scripts/export-framework-results-reasons.py:31:1: E402 module level import not at top of file
./scripts/generate-buyer-email-list.py:11:1: E402 module level import not at top of file
./scripts/generate-buyer-email-list.py:12:1: E402 module level import not at top of file
./scripts/generate-buyer-email-list.py:13:1: E402 module level import not at top of file
./scripts/generate-buyer-email-list.py:14:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-counterpart-signature-pages.py:50:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-counterpart-signature-pages.py:51:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-counterpart-signature-pages.py:52:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-counterpart-signature-pages.py:53:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-counterpart-signature-pages.py:54:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-counterpart-signature-pages.py:55:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-counterpart-signature-pages.py:58:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-signature-pages.py:50:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-signature-pages.py:51:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-signature-pages.py:52:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-signature-pages.py:53:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-signature-pages.py:54:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-signature-pages.py:55:1: E402 module level import not at top of file
./scripts/generate-framework-agreement-signature-pages.py:57:1: E402 module level import not at top of file
./scripts/generate-framework-master-csv.py:29:1: E402 module level import not at top of file
./scripts/generate-framework-master-csv.py:30:1: E402 module level import not at top of file
./scripts/generate-g8-agreement-signature-pages.py:29:1: E402 module level import not at top of file
./scripts/generate-g8-agreement-signature-pages.py:30:1: E402 module level import not at top of file
./scripts/generate-g8-agreement-signature-pages.py:31:1: E402 module level import not at top of file
./scripts/generate-g8-agreement-signature-pages.py:32:1: E402 module level import not at top of file
./scripts/generate-g8-agreement-signature-pages.py:33:1: E402 module level import not at top of file
./scripts/generate-g8-agreement-signature-pages.py:34:1: E402 module level import not at top of file
./scripts/generate-g8-agreement-signature-pages.py:36:1: E402 module level import not at top of file
./scripts/generate-g8-counterpart-signature-pages.py:30:1: E402 module level import not at top of file
./scripts/generate-g8-counterpart-signature-pages.py:31:1: E402 module level import not at top of file
./scripts/generate-g8-counterpart-signature-pages.py:32:1: E402 module level import not at top of file
./scripts/generate-g8-counterpart-signature-pages.py:33:1: E402 module level import not at top of file
./scripts/generate-g8-counterpart-signature-pages.py:34:1: E402 module level import not at top of file
./scripts/generate-g8-counterpart-signature-pages.py:35:1: E402 module level import not at top of file
./scripts/generate-g8-counterpart-signature-pages.py:37:1: E402 module level import not at top of file
./scripts/generate-questions-csv.py:29:1: E402 module level import not at top of file
./scripts/generate-questions-csv.py:30:1: E402 module level import not at top of file
./scripts/generate-questions-csv.py:31:1: E402 module level import not at top of file
./scripts/generate-questions-csv.py:32:1: E402 module level import not at top of file
./scripts/get-model-data.py:36:1: E402 module level import not at top of file
./scripts/get-model-data.py:38:1: E402 module level import not at top of file
./scripts/get-model-data.py:40:1: E402 module level import not at top of file
./scripts/get-model-data.py:41:1: E402 module level import not at top of file
./scripts/get-model-data.py:42:1: E402 module level import not at top of file
./scripts/get-model-data.py:43:1: E402 module level import not at top of file
./scripts/get-model-data.py:46:1: E402 module level import not at top of file
./scripts/index-to-search-service.py:39:1: E402 module level import not at top of file
./scripts/index-to-search-service.py:40:1: E402 module level import not at top of file
./scripts/index-to-search-service.py:41:1: E402 module level import not at top of file
./scripts/index-to-search-service.py:42:1: E402 module level import not at top of file
./scripts/insert-framework-results.py:22:1: E402 module level import not at top of file
./scripts/insert-framework-results.py:23:1: E402 module level import not at top of file
./scripts/insert-framework-results.py:24:1: E402 module level import not at top of file
./scripts/insert-framework-results.py:25:1: E402 module level import not at top of file
./scripts/make-dos-live.py:14:1: E402 module level import not at top of file
./scripts/make-dos-live.py:15:1: E402 module level import not at top of file
./scripts/make-dos-live.py:16:1: E402 module level import not at top of file
./scripts/make-dos-live.py:17:1: E402 module level import not at top of file
./scripts/make-dos-live.py:35:1: E305 expected 2 blank lines after class or function definition, found 1
./scripts/make-g-cloud-live.py:25:1: E402 module level import not at top of file
./scripts/make-g-cloud-live.py:26:1: E402 module level import not at top of file
./scripts/make-g-cloud-live.py:28:1: E402 module level import not at top of file
./scripts/make-g-cloud-live.py:29:1: E402 module level import not at top of file
./scripts/make-g-cloud-live.py:30:1: E402 module level import not at top of file
./scripts/make-g-cloud-live.py:31:1: E402 module level import not at top of file
./scripts/make-g-cloud-live.py:32:1: E402 module level import not at top of file
./scripts/mark-definite-framework-results.py:37:1: E402 module level import not at top of file
./scripts/mark-definite-framework-results.py:38:1: E402 module level import not at top of file
./scripts/mark-definite-framework-results.py:41:1: E402 module level import not at top of file
./scripts/mark-definite-framework-results.py:42:1: E402 module level import not at top of file
./scripts/mark-definite-framework-results.py:43:1: E402 module level import not at top of file
./scripts/mark-definite-framework-results.py:44:1: E402 module level import not at top of file
./scripts/mark-definite-framework-results.py:45:1: E402 module level import not at top of file
./scripts/notify-buyers-to-award-closed-briefs.py:23:1: E402 module level import not at top of file
./scripts/notify-buyers-to-award-closed-briefs.py:25:1: E402 module level import not at top of file
./scripts/notify-buyers-to-award-closed-briefs.py:26:1: E402 module level import not at top of file
./scripts/notify-buyers-when-requirements-close.py:19:1: E402 module level import not at top of file
./scripts/notify-buyers-when-requirements-close.py:20:1: E402 module level import not at top of file
./scripts/notify-successful-suppliers-for-framework.py:19:1: E402 module level import not at top of file
./scripts/notify-successful-suppliers-for-framework.py:21:1: E402 module level import not at top of file
./scripts/notify-successful-suppliers-for-framework.py:22:1: E402 module level import not at top of file
./scripts/notify-successful-suppliers-for-framework.py:23:1: E402 module level import not at top of file
./scripts/notify-successful-suppliers-for-framework.py:24:1: E402 module level import not at top of file
./scripts/notify-successful-suppliers-for-framework.py:25:1: E402 module level import not at top of file
./scripts/notify-successful-suppliers-for-framework.py:26:1: E402 module level import not at top of file
./scripts/notify-suppliers-of-brief-withdrawal.py:39:1: E402 module level import not at top of file
./scripts/notify-suppliers-of-brief-withdrawal.py:40:1: E402 module level import not at top of file
./scripts/notify-suppliers-of-brief-withdrawal.py:41:1: E402 module level import not at top of file
./scripts/notify-suppliers-of-new-questions-answers.py:26:1: E402 module level import not at top of file
./scripts/notify-suppliers-of-new-questions-answers.py:27:1: E402 module level import not at top of file
./scripts/notify-suppliers-whether-application-made-for-framework.py:19:1: E402 module level import not at top of file
./scripts/notify-suppliers-whether-application-made-for-framework.py:21:1: E402 module level import not at top of file
./scripts/notify-suppliers-whether-application-made-for-framework.py:22:1: E402 module level import not at top of file
./scripts/notify-suppliers-whether-application-made-for-framework.py:23:1: E402 module level import not at top of file
./scripts/notify-suppliers-whether-application-made-for-framework.py:24:1: E402 module level import not at top of file
./scripts/notify-suppliers-whether-application-made-for-framework.py:25:1: E402 module level import not at top of file
./scripts/notify-suppliers-whether-application-made-for-framework.py:26:1: E402 module level import not at top of file
./scripts/notify-suppliers-whether-application-made-for-framework.py:27:1: E402 module level import not at top of file
./scripts/scan-g-cloud-services-for-bad-words.py:16:1: E402 module level import not at top of file
./scripts/scan-g-cloud-services-for-bad-words.py:21:1: E402 module level import not at top of file
./scripts/scan-g-cloud-services-for-bad-words.py:22:1: E402 module level import not at top of file
./scripts/scan-g-cloud-services-for-bad-words.py:23:1: E402 module level import not at top of file
./scripts/scan-g-cloud-services-for-bad-words.py:24:1: E402 module level import not at top of file
./scripts/scan-g-cloud-services-for-bad-words.py:25:1: E402 module level import not at top of file
./scripts/scan-g-cloud-services-for-bad-words.py:26:1: E402 module level import not at top of file
./scripts/scan-g-cloud-services-for-bad-words.py:27:1: E402 module level import not at top of file
./scripts/scan-g-cloud-services-for-bad-words.py:173:1: E305 expected 2 blank lines after class or function definition, found 1
./scripts/send-stats-to-performance-platform.py:10:1: E402 module level import not at top of file
./scripts/send-stats-to-performance-platform.py:12:1: E402 module level import not at top of file
./scripts/send-stats-to-performance-platform.py:14:1: E402 module level import not at top of file
./scripts/send-stats-to-performance-platform.py:15:1: E402 module level import not at top of file
./scripts/send_dos_opportunities_email.py:47:1: E402 module level import not at top of file
./scripts/send_dos_opportunities_email.py:48:1: E402 module level import not at top of file
./scripts/send_dos_opportunities_email.py:49:1: E402 module level import not at top of file
./scripts/send_dos_opportunities_email.py:50:1: E402 module level import not at top of file
./scripts/set-search-alias.py:14:1: E402 module level import not at top of file
./scripts/set-search-alias.py:15:1: E402 module level import not at top of file
./scripts/update-framework-results.py:18:1: E402 module level import not at top of file
./scripts/update-framework-results.py:20:1: E402 module level import not at top of file
./scripts/update-framework-results.py:22:1: E402 module level import not at top of file
./scripts/update-framework-results.py:24:1: E402 module level import not at top of file
./scripts/update-framework-results.py:25:1: E402 module level import not at top of file
./scripts/update-framework-results.py:26:1: E402 module level import not at top of file
./scripts/update-index-alias.py:25:1: E402 module level import not at top of file
./scripts/upload-counterpart-agreements.py:40:1: E402 module level import not at top of file
./scripts/upload-counterpart-agreements.py:41:1: E402 module level import not at top of file
./scripts/upload-counterpart-agreements.py:42:1: E402 module level import not at top of file
./scripts/upload-counterpart-agreements.py:43:1: E402 module level import not at top of file
./scripts/upload-counterpart-agreements.py:44:1: E402 module level import not at top of file
./scripts/upload-counterpart-agreements.py:46:1: E402 module level import not at top of file
[flake8]
./scripts/upload-counterpart-agreements.py:47:1: E402 module level import not at top of file
./scripts/upload-counterpart-agreements.py:48:1: E402 module level import not at top of file
./scripts/upload-counterpart-agreements.py:50:1: E402 module level import not at top of file
./scripts/upload-counterpart-agreements.py:51:1: E402 module level import not at top of file
./scripts/upload-counterpart-agreements.py:52:1: E402 module level import not at top of file
./scripts/upload-file-to-s3.py:23:1: E402 module level import not at top of file
./scripts/upload-file-to-s3.py:25:1: E402 module level import not at top of file
./scripts/upload_dos_opportunities_email_list.py:32:1: E402 module level import not at top of file
./scripts/upload_dos_opportunities_email_list.py:33:1: E402 module level import not at top of file
./scripts/upload_dos_opportunities_email_list.py:34:1: E402 module level import not at top of file
./scripts/upload_dos_opportunities_email_list.py:35:1: E402 module level import not at top of file
./scripts/oneoff/generate-fake-g-cloud-services.py:77:1: E402 module level import not at top of file
./scripts/oneoff/generate-fake-g-cloud-services.py:82:1: E402 module level import not at top of file
./scripts/oneoff/generate-fake-g-cloud-services.py:126:1: E305 expected 2 blank lines after class or function definition, found 1
./scripts/oneoff/migrate-supplier-data-from-declarations.py:22:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:23:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:24:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:25:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:27:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:28:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:29:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:30:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:31:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:32:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:34:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:35:1: E402 module level import not at top of file
./scripts/oneoff/migrate-supplier-data-from-declarations.py:36:1: E402 module level import not at top of file
./scripts/oneoff/move-communications.py:10:1: E402 module level import not at top of file
./scripts/oneoff/move-communications.py:11:1: E402 module level import not at top of file
./scripts/oneoff/move-communications.py:12:1: E402 module level import not at top of file
./scripts/oneoff/move-communications.py:14:1: E402 module level import not at top of file
./scripts/oneoff/move-communications.py:15:1: E402 module level import not at top of file
./scripts/oneoff/rename-dos-locations.py:11:1: E402 module level import not at top of file
./scripts/oneoff/rename-dos-locations.py:12:1: E402 module level import not at top of file
./scripts/oneoff/rename-dos-locations.py:13:1: E402 module level import not at top of file
./scripts/oneoff/rename-dos-locations.py:14:1: E402 module level import not at top of file
./scripts/oneoff/rename-dos-locations.py:15:1: E402 module level import not at top of file
./scripts/oneoff/rename-west-england.py:11:1: E402 module level import not at top of file
./scripts/oneoff/rename-west-england.py:12:1: E402 module level import not at top of file
./scripts/oneoff/rename-west-england.py:13:1: E402 module level import not at top of file
./scripts/oneoff/rename-west-england.py:14:1: E402 module level import not at top of file
./scripts/oneoff/rename-west-england.py:15:1: E402 module level import not at top of file
./scripts/oneoff/save-signed-agreement-path.py:13:1: E402 module level import not at top of file
./scripts/oneoff/save-signed-agreement-path.py:14:1: E402 module level import not at top of file
./scripts/oneoff/save-signed-agreement-path.py:16:1: E402 module level import not at top of file
./scripts/oneoff/save-signed-agreement-path.py:17:1: E402 module level import not at top of file
./scripts/oneoff/save-signed-agreement-path.py:18:1: E402 module level import not at top of file
./scripts/oneoff/save-signed-agreement-path.py:20:1: E402 module level import not at top of file
./scripts/oneoff/save-signed-agreement-path.py:21:1: E402 module level import not at top of file
./scripts/oneoff/set-agreements-content-disposition.py:11:1: E402 module level import not at top of file
./scripts/oneoff/set-agreements-content-disposition.py:12:1: E402 module level import not at top of file
./scripts/oneoff/set-agreements-content-disposition.py:13:1: E402 module level import not at top of file
./scripts/oneoff/set-agreements-content-disposition.py:15:1: E402 module level import not at top of file
./scripts/oneoff/set-agreements-content-disposition.py:16:1: E402 module level import not at top of file
./scripts/oneoff/set-agreements-content-disposition.py:18:1: E402 module level import not at top of file
./tests/__init__.py:0:1: X100 Superfluous per-file-ignores for F401
./tests/test_send_dos_opportunities_email.py:59:1: E305 expected 2 blank lines after class or function definition, found 1
make: *** [test-flake8] Error 1
```