### PR TITLE
Docstring formatted incorrectly for docopt

### DIFF
--- a/scripts/update-index-alias.py
+++ b/scripts/update-index-alias.py
@@ -6,9 +6,9 @@ Stage is an optional argument. If left as its default, 'development', the auth t
 access the credentials repo.
 
 If an index is found to already be using the alias <alias>, that index is assigned the alias <alias>-old. If an index is
-found to exist using *that* alias (<alias>-old), it is either deleted or simply has its alias removed according to the
---delete-old-index option. This way, routine use of this option should lead to only two copies of any particular index
-being kept at once: <alias> and <alias>-old.
+found to exist using *that* alias (<alias>-old), it is either deleted or simply has its alias removed according to
+the --delete-old-index option. This way, routine use of this option should lead to only two copies of any particular
+index being kept at once: <alias> and <alias>-old.
 
 Usage:
 scripts/update-index-alias.py <alias> <target> <search-api-endpoint> [options]


### PR DESCRIPTION
## Summary
Fix docstring as docopt interprets any line beginning with "-" as an option. As we have two lines beginning with "--delete-old-index", docopt thinks we have duplicate parameters and the script fails to run.

![screen shot 2018-01-08 at 10 40 15](https://user-images.githubusercontent.com/2920760/34667302-6a7b42da-f460-11e7-8d2c-f87ab3efe899.png)

Discussion on docopt about it: https://github.com/docopt/docopt/issues/287