### PR TITLE
Move snapshot framework stats script from api to here

### DIFF
--- a/scripts/snapshot-framework-stats.py
+++ b/scripts/snapshot-framework-stats.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Usage:
+    snapshot_framework_stats.py <framework_slug> <stage> <api_token>
+
+Example:
+    ./snapshot_framework_stats.py g-cloud-7 dev myToken
+"""
+
+import backoff
+from docopt import docopt
+import logging
+import sys
+
+import dmapiclient
+from dmapiclient.audit import AuditTypes
+
+sys.path.insert(0, '.')
+from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage  # noqa
+
+
+logger = logging.getLogger('script')
+logging.basicConfig(level=logging.INFO)
+
+
+@backoff.on_exception(backoff.expo, dmapiclient.HTTPError, max_tries=5)
+def get_stats(data_client, framework_slug):
+    return data_client.get_framework_stats(framework_slug)
+
+
+def snapshot_framework_stats(api_endpoint, api_token, framework_slug):
+    data_client = dmapiclient.DataAPIClient(api_endpoint, api_token)
+
+    stats = get_stats(data_client, framework_slug)
+    data_client.create_audit_event(
+        AuditTypes.snapshot_framework_stats,
+        data=stats,
+        object_type='frameworks',
+        object_id=framework_slug
+    )
+
+    logger.info("Framework stats snapshot saved")
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    snapshot_framework_stats(
+        get_api_endpoint_from_stage(arguments['<stage>']),
+        arguments['<api_token>'],
+        arguments['<framework_slug>'],
+    )


### PR DESCRIPTION
## Summary
Move snapshot_framework_stats script from api to here. Tweak the script slightly to split out the get_framework_stats call as the backoff.on_exception logs the method's parameters, so if we backoff on snapshot_framework_stats then the token will get logged out. Rip out the duplicate get_api_endpoint_from_stage and use the one from dmscripts.

## Corresponding PRs
https://github.com/alphagov/digitalmarketplace-api/pull/733
https://github.com/alphagov/digitalmarketplace-jenkins/pull/66

## Ticket
https://trello.com/c/mtiS5IAx/3-move-scripts-running-python-2-on-jenkins-to-python3-docker