### PR TITLE
Include supplier contact details for dos labs export

### DIFF
--- a/dmscripts/export_dos_labs.py
+++ b/dmscripts/export_dos_labs.py
@@ -1,0 +1,11 @@
+def append_contact_information_to_services(records, required_contact_fields):
+    for record in records:
+        all_contact_info = record['supplier']['contactInformation'][0]  # assumption made of one and only one record
+
+        required_contact_info = {
+            key: all_contact_info[key] for key in all_contact_info.keys() if key in required_contact_fields
+        }
+
+        record['services'] = [{**service, **required_contact_info} for service in record['services']]
+
+    return records

--- a/scripts/export-dos-labs.py
+++ b/scripts/export-dos-labs.py
@@ -11,14 +11,18 @@ import sys
 sys.path.insert(0, '.')
 
 from docopt import docopt
+from dmapiclient import DataAPIClient
+
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.helpers.framework_helpers import find_suppliers_with_details_and_draft_services
-from dmapiclient import DataAPIClient
+from dmscripts.export_dos_labs import append_contact_information_to_services
 
 if sys.version_info[0] < 3:
     import unicodecsv as csv
 else:
     import csv
+
+REQUIRED_CONTACT_DETAILS_KEYS = ['email', 'contactName', 'phoneNumber']
 
 
 def find_all_labs(client):
@@ -27,9 +31,9 @@ def find_all_labs(client):
                                                              lot="user-research-studios",
                                                              statuses="submitted"
                                                              )
-    records = filter(lambda record: record['onFramework'], records)
+    records = list(filter(lambda record: record['onFramework'], records))
+    records = append_contact_information_to_services(records, REQUIRED_CONTACT_DETAILS_KEYS)
     services = itertools.chain.from_iterable(record['services'] for record in records)
-
     return services
 
 

--- a/tests/test_export_dos_labs.py
+++ b/tests/test_export_dos_labs.py
@@ -1,0 +1,30 @@
+from dmscripts.export_dos_labs import append_contact_information_to_services
+
+
+def test_append_contact_information_to_services():
+    records = [
+        {
+            'services': [{'serviceName': 'service1'}, {'serviceName': 'service2'}],
+            'supplier': {'contactInformation': [{'email': 'me@me.com', 'phone': '1234', 'other': 'value'}]}
+        },
+        {
+            'services': [{'serviceName': 'service3'}],
+            'supplier': {'contactInformation': [{'email': 'me2@me2.com', 'phone': '56789', 'other': 'value'}]}
+        },
+    ]
+
+    res = append_contact_information_to_services(records, ['email', 'phone'])
+
+    assert res == [
+        {
+            'services': [
+                {'serviceName': 'service1', 'email': 'me@me.com', 'phone': '1234'},
+                {'serviceName': 'service2', 'email': 'me@me.com', 'phone': '1234'},
+            ],
+            'supplier': {'contactInformation': [{'email': 'me@me.com', 'phone': '1234', 'other': 'value'}]}
+        },
+        {
+            'services': [{'serviceName': 'service3', 'email': 'me2@me2.com', 'phone': '56789'}],
+            'supplier': {'contactInformation': [{'email': 'me2@me2.com', 'phone': '56789', 'other': 'value'}]}
+        },
+    ]


### PR DESCRIPTION
https://trello.com/c/7msYuJ6c/184-links-for-dos-labs-suppliers-not-working

I had to put up a new version of the labs spreadsheet on https://www.digitalmarketplace.service.gov.uk/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/user-research-studios

I used this script (which I assumed was how it was done in the past). I had to do a bunch of manual formatting to make it look pretty for an end user. I will details of this to the manual in the framework lifecycle section.