### PR TITLE
Add missing help option.

### DIFF
--- a/scripts/index-to-search-service.py
+++ b/scripts/index-to-search-service.py
@@ -10,6 +10,7 @@ Usage:
     --frameworks=<frameworks>                     Comma-separated list of framework slugs that should be indexed
 
 Options:
+    -h --help                                     Show this screen.
     --create-with-mapping=<mapping>               Create the named index using mapping <mapping>. Don't specify this
                                                   option when running from a batch/Jenkins job, as creating indexes
                                                   should be done under user control. This mapping is a filename (without


### PR DESCRIPTION
trivial PR huh...

 - without this, docopt doesn't give you a way to see the options.
