### PR TITLE
Notify suppliers when a brief has been awarded

### DIFF
--- a/dmscripts/notify_suppliers_of_awarded_briefs.py
+++ b/dmscripts/notify_suppliers_of_awarded_briefs.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 
 from dmutils.email.exceptions import EmailError
 from dmutils.email.helpers import hash_string
@@ -13,7 +13,8 @@ def _create_context_for_brief(stage, brief):
             env_helpers.get_web_url_from_stage(stage),
             brief['framework']['family'],
             brief['id']
-        )
+        ),
+        'utm_date': date.today().strftime("%Y%m%d")
     }
 
 

--- a/dmscripts/notify_suppliers_of_awarded_briefs.py
+++ b/dmscripts/notify_suppliers_of_awarded_briefs.py
@@ -1,0 +1,99 @@
+from datetime import datetime, timedelta
+
+from dmutils.email.exceptions import EmailError
+from dmutils.email.helpers import hash_string
+from dmutils.formats import DATE_FORMAT
+from dmscripts.helpers import env_helpers
+
+
+def _create_context_for_brief(stage, brief):
+    return {
+        'brief_title': brief['title'],
+        'brief_link': '{}/{}/opportunities/{}'.format(
+            env_helpers.get_web_url_from_stage(stage),
+            brief['framework']['family'],
+            brief['id']
+        )
+    }
+
+
+def _get_brief_responses_to_be_notified(data_api_client, brief_response_ids, awarded_at):
+    brief_responses = []
+
+    if brief_response_ids:
+        # Used for re-running failed email sending
+        for brief_response_id in brief_response_ids:
+            brief_responses.append(data_api_client.get_brief_response(brief_response_id)['briefResponses'])
+    else:
+        awarded_at_date = awarded_at or (datetime.utcnow() - timedelta(days=1)).strftime(DATE_FORMAT)
+        awarded_brief_responses = data_api_client.find_brief_responses_iter(awarded_at=awarded_at_date)
+
+        for abr in awarded_brief_responses:
+            # Add the successful BriefResponse
+            brief_responses.append(abr)
+            # Get the unsuccessful BriefResponses
+            submitted_brief_responses = data_api_client.find_brief_responses_iter(
+                brief_id=abr['briefId'], status='submitted'
+            )
+            brief_responses.extend(submitted_brief_responses)
+
+    return brief_responses
+
+
+def _build_and_send_emails(brief_responses, mail_client, stage, dry_run, template_id, logger):
+    failed_brief_responses = []
+
+    # Now email everyone whose Brief got awarded
+    for brief_response in brief_responses:
+        email_address = brief_response["respondToEmailAddress"]
+        if not email_address:
+            continue
+
+        brief_email_context = _create_context_for_brief(stage, brief_response['brief'])
+        try:
+            if not dry_run:
+                mail_client.send_email(
+                    email_address, template_id, brief_email_context, allow_resend=False
+                )
+            logger.info(
+                "{dry_run}EMAIL: Award of Brief Response ID: {brief_response_id} to {email_address}",
+                extra={
+                    'dry_run': '[Dry-run] - ' if dry_run else '',
+                    'brief_response_id': brief_response['id'],
+                    'email_address': hash_string(email_address),
+                }
+            )
+        except EmailError:
+            # Log individual failures in more detail
+            logger.error(
+                "Email sending failed for BriefResponse {brief_response_id} (Brief ID {brief_id})",
+                extra={
+                    "brief_id": brief_response['brief']['id'],
+                    "brief_response_id": brief_response['id']
+                }
+            )
+            failed_brief_responses.append(brief_response['id'])
+
+    return failed_brief_responses
+
+
+def main(
+    data_api_client, mail_client, template_id, stage, logger,
+    dry_run=False, brief_response_ids=None, awarded_at=None
+):
+    brief_responses = _get_brief_responses_to_be_notified(data_api_client, brief_response_ids, awarded_at)
+
+    failed_brief_responses = _build_and_send_emails(brief_responses, mail_client, stage, dry_run, template_id, logger)
+
+    # Log a summary of failures at the end of the job
+    if failed_brief_responses:
+        logger.error(
+            "Email sending failed for the following {count} BriefResponses: {brief_response_ids}",
+            extra={
+                "brief_response_ids": ",".join(map(str, failed_brief_responses)),
+                "count": len(failed_brief_responses)
+            }
+        )
+        return False
+
+    return True

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,7 +3,7 @@
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==28.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.1#egg=digitalmarketplace-apiclient==14.0.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.1.0#egg=digitalmarketplace-apiclient==14.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==28.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.1#egg=digitalmarketplace-apiclient==14.0.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.1.0#egg=digitalmarketplace-apiclient==14.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1
 
@@ -22,8 +22,8 @@ asn1crypto==0.24.0
 backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
-certifi==2017.11.5
-cffi==1.11.2
+certifi==2018.1.18
+cffi==1.11.4
 chardet==3.0.4
 click==6.7
 contextlib2==0.4.0
@@ -43,7 +43,7 @@ mandrill==1.0.57
 Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
-numpy==1.13.3
+numpy==1.14.0
 pycparser==2.18
 PyJWT==1.5.3
 pytz==2015.4

--- a/scripts/notify-suppliers-of-awarded-briefs.py
+++ b/scripts/notify-suppliers-of-awarded-briefs.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""
+If a brief has been awarded suppliers need to be notified. This
+script notifies suppliers of all awarded briefs in the previous day by default.
+Alternatively, when supplied with a list of BriefResponse IDs, it will notify just the suppliers for those responses.
+
+Usage:
+    notify-suppliers-of-awarded-briefs.py <stage> <api_token> <govuk_notify_api_key> <govuk_notify_template_id>
+        [options]
+
+Options:
+    --awarded_at=<awarded_at>                       Notify applicants to briefs awarded on this date, defaults to
+                                                    # yesterday (date format: YYYY-MM-DD)
+    --brief_response_ids=<brief_response_ids>       List of brief response IDs to send to (for resending failures)
+
+Examples:
+    ./scripts/notify-suppliers-of-awarded-briefs.py preview myToken notifyToken t3mp1at3id --awarded_at=2017-10-27
+    ./scripts/notify-suppliers-of-awarded-briefs.py preview myToken notifyToken t3mp1at3id --dry-run --verbose
+
+"""
+
+import logging
+import sys
+from docopt import docopt
+
+from dmutils.email import DMNotifyClient
+from dmapiclient import DataAPIClient
+
+sys.path.insert(0, '.')
+
+from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
+from dmscripts.helpers import logging_helpers
+from dmscripts.notify_suppliers_of_awarded_briefs import main
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    # Get arguments
+    stage = arguments['<stage>']
+    api_token = arguments['<api_token>']
+    govuk_notify_api_key = arguments['<govuk_notify_api_key>']
+    govuk_notify_template_id = arguments['<govuk_notify_template_id>']
+    awarded_at = arguments.get('<awarded_at>', None)
+    brief_response_ids = arguments.get('<brief_response_ids>', None)
+    dry_run = arguments['--dry-run']
+    verbose = arguments['--verbose']
+
+    # Set defaults, instantiate clients
+    logger = logging_helpers.configure_logger(
+        {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
+    )
+    notify_client = DMNotifyClient(govuk_notify_api_key, logger=logger)
+    data_api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(stage), auth_token=api_token)
+
+    list_of_brief_response_ids = list(map(int, brief_response_ids.split(','))) if brief_response_ids else None
+
+    # Do send
+    ok = main(
+        data_api_client=data_api_client,
+        mail_client=notify_client,
+        template_id=govuk_notify_template_id,
+        stage=stage,
+        logger=logger,
+        awarded_at=awarded_at,
+        brief_response_ids=list_of_brief_response_ids,
+        dry_run=dry_run,
+    )
+
+    if not ok:
+        sys.exit(1)

--- a/scripts/notify-suppliers-of-awarded-briefs.py
+++ b/scripts/notify-suppliers-of-awarded-briefs.py
@@ -9,6 +9,9 @@ Usage:
         [options]
 
 Options:
+    -h, --help                                      Display this screen
+    -v, --verbose                                   Verbosity level
+    --dry-run                                       Log without sending emails
     --awarded_at=<awarded_at>                       Notify applicants to briefs awarded on this date, defaults to
                                                     # yesterday (date format: YYYY-MM-DD)
     --brief_response_ids=<brief_response_ids>       List of brief response IDs to send to (for resending failures)

--- a/tests/test_notify_suppliers_of_awarded_briefs.py
+++ b/tests/test_notify_suppliers_of_awarded_briefs.py
@@ -31,7 +31,8 @@ AWARDED_BRIEFS = [
 
 EXPECTED_BRIEF_CONTEXT = {
     'brief_title': "Tea Drinker",
-    'brief_link': 'https://www.preview.marketplace.team/digital-outcomes-and-specialists/opportunities/123'
+    'brief_link': 'https://www.preview.marketplace.team/digital-outcomes-and-specialists/opportunities/123',
+    'utm_date': "20180102"
 }
 
 
@@ -53,7 +54,8 @@ def _get_dummy_brief_response(id_, brief, awarded=False, valid_email=True):
 
 
 def test_create_context_for_brief():
-    assert tested_script._create_context_for_brief('preview', AWARDED_BRIEFS[0]) == EXPECTED_BRIEF_CONTEXT
+    with freeze_time('2018-01-02'):
+        assert tested_script._create_context_for_brief('preview', AWARDED_BRIEFS[0]) == EXPECTED_BRIEF_CONTEXT
 
 
 @mock.patch('dmutils.email.DMNotifyClient', autospec=True)

--- a/tests/test_notify_suppliers_of_awarded_briefs.py
+++ b/tests/test_notify_suppliers_of_awarded_briefs.py
@@ -1,0 +1,192 @@
+import mock
+
+from freezegun import freeze_time
+
+from dmscripts import notify_suppliers_of_awarded_briefs as tested_script
+from dmutils.email.exceptions import EmailError
+from dmutils.email.helpers import hash_string
+
+
+AWARDED_BRIEFS = [
+    {
+        "framework": {
+            "family": "digital-outcomes-and-specialists",
+            "slug": "digital-outcomes-and-specialists-2",
+        },
+        "id": 123,
+        "status": "awarded",
+        "title": "Tea Drinker"
+    },
+    {
+        "framework": {
+            "family": "digital-outcomes-and-specialists",
+            "slug": "digital-outcomes-and-specialists-2",
+        },
+        "id": 456,
+        "status": "awarded",
+        "title": "Cookie Muncher"
+    }
+]
+
+
+EXPECTED_BRIEF_CONTEXT = {
+    'brief_title': "Tea Drinker",
+    'brief_link': 'https://www.preview.marketplace.team/digital-outcomes-and-specialists/opportunities/123'
+}
+
+
+def _get_dummy_brief_response(id_, brief, awarded=False, valid_email=True):
+    brief_response = {
+        "awardedAt": '2018-01-01T23:59:59.999999Z',
+        "briefId": brief['id'],
+        "brief": brief,
+        "id": id_,
+        "respondToEmailAddress": "sore_loser_{}@example.com".format(id_),
+    }
+    if awarded:
+        brief_response['awardedAt'] = '2018-01-01T23:59:59.999999Z'
+        brief_response['status'] = 'awarded'
+        brief_response["respondToEmailAddress"] = "lucky_winner_{}@example.com".format(id_)
+    if not valid_email:
+        brief_response['respondToEmailAddress'] = ""
+    return brief_response
+
+
+def test_create_context_for_brief():
+    assert tested_script._create_context_for_brief('preview', AWARDED_BRIEFS[0]) == EXPECTED_BRIEF_CONTEXT
+
+
+@mock.patch('dmutils.email.DMNotifyClient', autospec=True)
+@mock.patch('dmscripts.notify_suppliers_of_awarded_briefs._create_context_for_brief')
+@mock.patch('dmapiclient.DataAPIClient', autospec=True)
+def test_main_calls_correct_methods(data_api_client, create_context_for_brief, notify_client):
+    data_api_client.find_brief_responses_iter.side_effect = [
+        [   # Only get awarded BRs on the first call
+            _get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True),
+            _get_dummy_brief_response(4322, AWARDED_BRIEFS[1], awarded=True),
+        ],
+        [   # Get submitted BRs for 1st awarded brief on the second call
+            _get_dummy_brief_response(4322, AWARDED_BRIEFS[0]),
+            _get_dummy_brief_response(4323, AWARDED_BRIEFS[0], valid_email=False),
+        ],
+        [   # No submitted BRs for the 2nd awarded brief
+        ]
+    ]
+    tested_script._create_context_for_brief.return_value = EXPECTED_BRIEF_CONTEXT
+
+    with freeze_time('2018-01-02'):
+        assert tested_script.main(data_api_client, notify_client, "notify_template_id", "preview", mock.Mock())
+
+    assert data_api_client.find_brief_responses_iter.call_args_list == [
+        mock.call(awarded_at="2018-01-01"),
+        mock.call(brief_id=123, status='submitted'),
+        mock.call(brief_id=456, status='submitted')
+    ]
+    assert create_context_for_brief.call_args_list == [
+        mock.call("preview", AWARDED_BRIEFS[0]),
+        mock.call("preview", AWARDED_BRIEFS[0]),
+        mock.call("preview", AWARDED_BRIEFS[1])
+    ]
+    # Only email if a valid email address is present
+    assert notify_client.send_email.call_args_list == [
+        mock.call(
+            "lucky_winner_4321@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
+        ),
+        mock.call(
+            "sore_loser_4322@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
+        ),
+        mock.call(
+            "lucky_winner_4322@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
+        )
+    ]
+    # Single BriefResponse API request not called
+    assert data_api_client.get_brief_response.called is False
+
+
+@mock.patch('dmutils.email.DMNotifyClient', autospec=True)
+@mock.patch('dmapiclient.DataAPIClient', autospec=True)
+def test_main_calls_get_brief_response_when_brief_response_ids_specified(data_api_client, notify_client):
+    """Script should only look up brief responses for a given list of ids if they are specified."""
+    data_api_client.get_brief_response.side_effect = [
+        {'briefResponses': _get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True)},
+        {'briefResponses': _get_dummy_brief_response(4322, AWARDED_BRIEFS[0])}
+    ]
+
+    with freeze_time('2018-01-02'):
+        assert tested_script.main(
+            data_api_client, notify_client, 'notify_template_id', 'preview', mock.Mock(),
+            brief_response_ids=[4321, 4322]
+        )
+
+    assert data_api_client.get_brief_response.call_args_list == [
+        mock.call(4321),
+        mock.call(4322)
+    ]
+    assert notify_client.send_email.call_args_list == [
+        mock.call(
+            "lucky_winner_4321@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
+        ),
+        mock.call(
+            "sore_loser_4322@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
+        )
+    ]
+
+
+@mock.patch('dmutils.email.DMNotifyClient', autospec=True)
+@mock.patch('dmapiclient.DataAPIClient', autospec=True)
+def test_main_uses_awarded_at_date_param_if_provided(data_api_client, notify_client):
+    data_api_client.find_brief_responses_iter.return_value = [
+        _get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True)
+    ]
+
+    with freeze_time('2018-02-02'):
+        assert tested_script.main(
+            data_api_client, notify_client, "notify_template_id", "preview", mock.Mock(), awarded_at="2018-01-01"
+        )
+
+    assert data_api_client.find_brief_responses_iter.call_args_list == [
+        mock.call(awarded_at="2018-01-01"),
+        mock.call(brief_id=123, status="submitted")
+    ]
+
+
+@mock.patch('dmutils.email.DMNotifyClient', autospec=True)
+@mock.patch('dmapiclient.DataAPIClient', autospec=True)
+def test_main_catches_email_errors_and_returns_ids(data_api_client, notify_client):
+    logger = mock.Mock()
+    notify_client.send_email.side_effect = [EmailError, True]
+    data_api_client.find_brief_responses_iter.side_effect = [
+        [_get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True)],
+        [_get_dummy_brief_response(1234, AWARDED_BRIEFS[0], awarded=False)],
+    ]
+
+    assert not tested_script.main(
+        data_api_client, notify_client, 'notify_template_id', 'preview', logger
+    )
+
+    assert logger.error.call_args_list == [
+        mock.call(
+            'Email sending failed for BriefResponse {brief_response_id} (Brief ID {brief_id})',
+            extra={
+                "brief_id": 123,
+                "brief_response_id": 4321
+            }
+        ),
+        mock.call(
+            "Email sending failed for the following {count} BriefResponses: {brief_response_ids}",
+            extra={
+                'brief_response_ids': '4321',
+                'count': 1
+            }
+        )
+    ]
+    assert logger.info.call_args_list == [
+        mock.call(
+            "{dry_run}EMAIL: Award of Brief Response ID: {brief_response_id} to {email_address}",
+            extra={
+                'dry_run': '',
+                'brief_response_id': 1234,
+                'email_address': hash_string('sore_loser_1234@example.com'),
+            }
+        )
+    ]


### PR DESCRIPTION
This script will run overnight to collate all brief responses awarded the previous day and notify them by email

https://trello.com/c/LsEbL3jP/306-send-dos-suppliers-an-email-to-let-them-know-the-outcome