### PR TITLE
Fix docopt options for Notify Suppliers of awarded Briefs script

### DIFF
--- a/scripts/notify-suppliers-of-awarded-briefs.py
+++ b/scripts/notify-suppliers-of-awarded-briefs.py
@@ -44,8 +44,8 @@ if __name__ == "__main__":
     api_token = arguments['<api_token>']
     govuk_notify_api_key = arguments['<govuk_notify_api_key>']
     govuk_notify_template_id = arguments['<govuk_notify_template_id>']
-    awarded_at = arguments.get('<awarded_at>', None)
-    brief_response_ids = arguments.get('<brief_response_ids>', None)
+    awarded_at = arguments.get('--awarded_at', None)
+    brief_response_ids = arguments.get('--brief_response_ids', None)
     dry_run = arguments['--dry-run']
     verbose = arguments['--verbose']
 


### PR DESCRIPTION
Trello: https://trello.com/c/LsEbL3jP/306-send-dos-suppliers-an-email-to-let-them-know-the-outcome

(Hit merge too quickly on the previous PR!)

We should add 'consistent usage for docopt options/params' to the list of things to sort out for our scripts.