### PR TITLE
Notify suppliers for cancelled and unsuccessful Briefs

### DIFF
--- a/dmscripts/notify_suppliers_of_awarded_briefs.py
+++ b/dmscripts/notify_suppliers_of_awarded_briefs.py
@@ -30,13 +30,22 @@ def _get_brief_responses_to_be_notified(data_api_client, brief_response_ids, awa
         awarded_brief_responses = data_api_client.find_brief_responses_iter(awarded_at=awarded_at_date)
 
         for abr in awarded_brief_responses:
-            # Add the successful BriefResponse
+            # Add the awarded BriefResponse
             brief_responses.append(abr)
-            # Get the unsuccessful BriefResponses
-            submitted_brief_responses = data_api_client.find_brief_responses_iter(
-                brief_id=abr['briefId'], status='submitted'
+            # Get the other non-awarded BriefResponses for the same Brief
+            brief_responses.extend(
+                data_api_client.find_brief_responses_iter(brief_id=abr['briefId'], status='submitted')
             )
-            brief_responses.extend(submitted_brief_responses)
+
+        # Get BriefResponses for any Briefs cancelled or unsuccessful on the same date
+        for brief in data_api_client.find_briefs_iter(cancelled_on=awarded_at_date):
+            brief_responses.extend(
+                data_api_client.find_brief_responses_iter(brief_id=brief['id'])
+            )
+        for brief in data_api_client.find_briefs_iter(unsuccessful_on=awarded_at_date):
+            brief_responses.extend(
+                data_api_client.find_brief_responses_iter(brief_id=brief['id'])
+            )
 
     return brief_responses
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,7 +3,7 @@
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==28.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.1.0#egg=digitalmarketplace-apiclient==14.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.3.0#egg=digitalmarketplace-apiclient==14.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==28.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.1.0#egg=digitalmarketplace-apiclient==14.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.3.0#egg=digitalmarketplace-apiclient==14.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1
 
@@ -49,7 +49,7 @@ PyJWT==1.5.3
 pytz==2015.4
 PyYAML==3.11
 requests==2.18.4
-s3transfer==0.1.12
+s3transfer==0.1.13
 six==1.9.0
 urllib3==1.22
 Werkzeug==0.11.9

--- a/tests/test_notify_suppliers_of_awarded_briefs.py
+++ b/tests/test_notify_suppliers_of_awarded_briefs.py
@@ -28,6 +28,32 @@ AWARDED_BRIEFS = [
     }
 ]
 
+CANCELLED_BRIEFS = [
+    {
+        "framework": {
+            "family": "digital-outcomes-and-specialists",
+            "slug": "digital-outcomes-and-specialists-2",
+        },
+        "id": 333,
+        "status": "cancelled",
+        "title": "Biscuit Dunker",
+        "cancelledAt": "2018-01-01T15:07:07.946308Z"
+    }
+]
+
+UNSUCCESSFUL_BRIEFS = [
+    {
+        "framework": {
+            "family": "digital-outcomes-and-specialists",
+            "slug": "digital-outcomes-and-specialists-2",
+        },
+        "id": 555,
+        "status": "unsuccessful",
+        "title": "Coffee Grinder",
+        "unsuccessfulAt": "2018-01-01T15:07:07.946308Z"
+    }
+]
+
 
 EXPECTED_BRIEF_CONTEXT = {
     'brief_title': "Tea Drinker",
@@ -63,16 +89,25 @@ def test_create_context_for_brief():
 @mock.patch('dmapiclient.DataAPIClient', autospec=True)
 def test_main_calls_correct_methods(data_api_client, create_context_for_brief, notify_client):
     data_api_client.find_brief_responses_iter.side_effect = [
-        [   # Only get awarded BRs on the first call
+        [   # Awarded brief responses for each awarded brief
             _get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True),
             _get_dummy_brief_response(4322, AWARDED_BRIEFS[1], awarded=True),
         ],
-        [   # Get submitted BRs for 1st awarded brief on the second call
+        [   # 'Losing' brief responses for the first awarded brief
             _get_dummy_brief_response(4322, AWARDED_BRIEFS[0]),
             _get_dummy_brief_response(4323, AWARDED_BRIEFS[0], valid_email=False),
         ],
-        [   # No submitted BRs for the 2nd awarded brief
-        ]
+        [   # No 'losing' brief responses for the 2nd awarded brief
+        ],
+        [   # One brief response for the cancelled brief
+            _get_dummy_brief_response(4325, CANCELLED_BRIEFS[0]),
+        ],
+        [   # One brief response for the unsuccessful brief
+            _get_dummy_brief_response(4326, UNSUCCESSFUL_BRIEFS[0]),
+        ],
+    ]
+    data_api_client.find_briefs_iter.side_effect = [
+        CANCELLED_BRIEFS, UNSUCCESSFUL_BRIEFS
     ]
     tested_script._create_context_for_brief.return_value = EXPECTED_BRIEF_CONTEXT
 
@@ -82,12 +117,16 @@ def test_main_calls_correct_methods(data_api_client, create_context_for_brief, n
     assert data_api_client.find_brief_responses_iter.call_args_list == [
         mock.call(awarded_at="2018-01-01"),
         mock.call(brief_id=123, status='submitted'),
-        mock.call(brief_id=456, status='submitted')
+        mock.call(brief_id=456, status='submitted'),
+        mock.call(brief_id=333),
+        mock.call(brief_id=555)
     ]
     assert create_context_for_brief.call_args_list == [
         mock.call("preview", AWARDED_BRIEFS[0]),
         mock.call("preview", AWARDED_BRIEFS[0]),
-        mock.call("preview", AWARDED_BRIEFS[1])
+        mock.call("preview", AWARDED_BRIEFS[1]),
+        mock.call("preview", CANCELLED_BRIEFS[0]),
+        mock.call("preview", UNSUCCESSFUL_BRIEFS[0])
     ]
     # Only email if a valid email address is present
     assert notify_client.send_email.call_args_list == [
@@ -99,6 +138,12 @@ def test_main_calls_correct_methods(data_api_client, create_context_for_brief, n
         ),
         mock.call(
             "lucky_winner_4322@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
+        ),
+        mock.call(
+            "sore_loser_4325@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
+        ),
+        mock.call(
+            "sore_loser_4326@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
         )
     ]
     # Single BriefResponse API request not called
@@ -137,8 +182,22 @@ def test_main_calls_get_brief_response_when_brief_response_ids_specified(data_ap
 @mock.patch('dmutils.email.DMNotifyClient', autospec=True)
 @mock.patch('dmapiclient.DataAPIClient', autospec=True)
 def test_main_uses_awarded_at_date_param_if_provided(data_api_client, notify_client):
-    data_api_client.find_brief_responses_iter.return_value = [
-        _get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True)
+    data_api_client.find_brief_responses_iter.side_effect = [
+        [   # Awarded brief response for the awarded brief
+            _get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True),
+        ],
+        [
+            # No 'losing' brief responses for the awarded brief
+        ],
+        [   # Brief response for a cancelled brief
+            _get_dummy_brief_response(4321, CANCELLED_BRIEFS[0])
+        ],
+        [   # Brief response for an unsuccessful brief
+            _get_dummy_brief_response(4321, UNSUCCESSFUL_BRIEFS[0])
+        ]
+    ]
+    data_api_client.find_briefs_iter.side_effect = [
+        CANCELLED_BRIEFS, UNSUCCESSFUL_BRIEFS
     ]
 
     with freeze_time('2018-02-02'):
@@ -148,7 +207,9 @@ def test_main_uses_awarded_at_date_param_if_provided(data_api_client, notify_cli
 
     assert data_api_client.find_brief_responses_iter.call_args_list == [
         mock.call(awarded_at="2018-01-01"),
-        mock.call(brief_id=123, status="submitted")
+        mock.call(brief_id=123, status="submitted"),
+        mock.call(brief_id=333),
+        mock.call(brief_id=555)
     ]
 
 


### PR DESCRIPTION
Trello: https://trello.com/c/LsEbL3jP/306-send-dos-suppliers-an-email-to-let-them-know-the-outcome

Extends the script to include Briefs that were marked as `unsuccessful` or `cancelled` on the same date. This means an extra query to the `/briefs` endpoint to get all briefs for those statuses (there shouldn't be many - currently less than 10 each since Oct 2017), then filtering those Briefs by date within the script. We then get the associated Brief Responses for those briefs as normal.

Retrying the script with the list of IDs should be unaffected.