### PR TITLE
Migrate supplier trading status

### DIFF
--- a/scripts/oneoff/migrate-supplier-trading-status.py
+++ b/scripts/oneoff/migrate-supplier-trading-status.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""Migrate supplier trading status to more restricted answer set
+
+We currently have a large number of possible values that suppliers can select to describe their trading status, and if
+they do not match one that we define, they can enter a freetext description. After moving this question from the
+declaration to the account level, we are restricting the number of options they can provide and removing the freetext
+box in place of just 'other'.
+
+If we cannot exactly match up options, we will drop the data altogether, which will force the supplier to provide it
+again. This is because it feels safer to do this than to incorrectly change a supplier's trading status. We also have
+an extra option defined that was not available before, so suppliers without a clear state should have this option
+clearly presented to them.
+
+See: https://trello.com/c/Wvvtb1yW/52
+
+Usage:
+    ./scripts/oneoff/migrate-supplier-trading-status.py <stage> <api_token> [--dry-run]
+"""
+import sys
+sys.path.insert(0, '.')  # noqa
+
+import backoff
+import getpass
+import requests
+from docopt import docopt
+from dmapiclient import DataAPIClient, HTTPError
+from dmapiclient.errors import HTTPTemporaryError
+from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
+
+
+NEW_TRADING_STATUS_MAPPING = {
+    'limited company': 'limited company (LTD)',
+    'limited liability company': 'limited liability company (LLC)',
+    'public limited company': 'public limited company (PLC)',
+    'limited liability partnership': 'limited liability partnership (LLP)',
+    'sole trader': 'sole trader',
+}
+
+_backoff_wrap = backoff.on_exception(
+    backoff.expo,
+    (HTTPError, HTTPTemporaryError, requests.exceptions.ConnectionError, RuntimeError),
+    max_tries=5,
+)
+
+
+def migrate_trading_statuses(client, dry_run):
+    prefix = '[DRY RUN]: ' if dry_run else ''
+    success_counter, failure_counter = 0, 0
+
+    print(f'{prefix}Retrieving suppliers from API ...')
+    for i, supplier in enumerate(client.find_suppliers_iter()):
+        mapped_trading_status = NEW_TRADING_STATUS_MAPPING.get(supplier.get('tradingStatus'), None)
+
+        if not dry_run:
+            try:
+                _backoff_wrap(
+                    lambda: client.update_supplier(
+                        supplier_id=supplier['id'],
+                        supplier={'tradingStatus': mapped_trading_status},
+                        user=f'{getpass.getuser()} (migrate trading status script)',
+                    )
+                )()
+                success_counter += 1
+
+            except HTTPError as e:
+                print(f"{prefix}Error updating supplier {supplier['id']}: {e.message}")
+                failure_counter += 1
+
+        if i % 100 == 0:
+            print(f'{prefix}{i} suppliers processed ...')
+
+    print(f'{prefix}Finished processing {i} suppliers.')
+
+    print(f"{prefix}Succssfully updated: {success_counter}")
+    print(f"{prefix}Failed to update: {failure_counter}")
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    stage = arguments['<stage>']
+    api_token = arguments['<api_token>']
+    dry_run = arguments['--dry-run']
+    api_url = get_api_endpoint_from_stage(stage)
+
+    migrate_trading_statuses(DataAPIClient(api_url, api_token), dry_run)


### PR DESCRIPTION
## Summary
One-off script for migrating suppliers existing trading status
(submitted during framework applications) to our new set of values now
that this is an account-level question. If we can map it perfectly
across, we'll do so, but if we can't then we'll drop the value
altogether - the result of this being the supplier will need to provide
it again.

## Note
At the moment, the idea behind this (dropping values that we can't map correctly) doesn't work as the API requires a value to be submitted. I don't know how I feel about coercing values to 'other' rather than None, so open to input here. If we decide to go ahead with this script as-is, we'll need to change validation (probably just temporarily), or do some other magic.

## Ticket
https://trello.com/c/Wvvtb1yW/52-new-editable-page-trading-status