### PR TITLE
Update import to import send_email from dm_mandrill

### DIFF
--- a/dmscripts/notify_buyers_when_requirements_close.py
+++ b/dmscripts/notify_buyers_when_requirements_close.py
@@ -2,7 +2,7 @@
 from datetime import datetime, timedelta
 
 import dmapiclient
-from dmutils.email import send_email
+from dmutils.email.dm_mandrill import send_email
 from dmutils.email.exceptions import EmailError
 from dmutils.formats import DATE_FORMAT
 


### PR DESCRIPTION

Because we now have 3 different methods of sending emails we should update utils to ensure `send_email` is imported from the client specific sub-directory of emails in utils