### PR TITLE
Fix timeouts when calling Mailchimp

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
-git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==28.7.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==34.4.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.3.0#egg=digitalmarketplace-apiclient==14.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
-git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==28.7.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==34.4.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.3.0#egg=digitalmarketplace-apiclient==14.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1
@@ -23,7 +23,7 @@ backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
 certifi==2018.1.18
-cffi==1.11.4
+cffi==1.11.5
 chardet==3.0.4
 click==6.7
 contextlib2==0.4.0
@@ -43,9 +43,9 @@ mandrill==1.0.57
 Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
-numpy==1.14.0
+numpy==1.14.1
 pycparser==2.18
-PyJWT==1.5.3
+PyJWT==1.6.0
 pytz==2015.4
 PyYAML==3.11
 requests==2.18.4


### PR DESCRIPTION
This is to pull in this update to the utils - https://github.com/alphagov/digitalmarketplace-utils/pull/365

We're pulling in the updated Mailchimp client which should mitigate timeouts when fetching email lists from Mailchimp.

All of the major versions don't affect the scripts repo.

Once this is merged the scripts docker image will need rebuilding and pushing up to Dockerhub.