### PR TITLE
Add clamd s3 virus scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ The `scripts` folder in this repository contains scripts that interact with the 
 
   Makes it easier for humans and computers (namely Jenkins) to update the alias of an elasticsearch index. It was written to assist with indexing services after migrating data between environments periodically with Jenkins.
 
+* `virus-scan-s3-bucket.py`
+
+  Runs a virus scan utilising a provided clamd (ClamAV) backend against a given S3 bucket, optionally restricting by path prefix and last modified datetime.
+
 ## Running scripts with Docker
 
 One way to run common scripts locally without setting up dependencies is to use the pre-built

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,11 +7,12 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.3.0#egg=digi
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1
 
-unicodecsv==0.14.1
-python-dateutil==2.4.2
+clamd==1.0.2
 Jinja2==2.7.3
 jsonschema==2.5.1
-pandas==0.19.1
-xeger==0.3.1
 lorem==0.1.1
 mailchimp3==2.0.11
+pandas==0.19.1
+python-dateutil==2.4.2
+unicodecsv==0.14.1
+xeger==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,15 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.3.0#egg=digi
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1
 
-unicodecsv==0.14.1
-python-dateutil==2.4.2
+clamd==1.0.2
 Jinja2==2.7.3
 jsonschema==2.5.1
-pandas==0.19.1
-xeger==0.3.1
 lorem==0.1.1
 mailchimp3==2.0.11
+pandas==0.19.1
+python-dateutil==2.4.2
+unicodecsv==0.14.1
+xeger==0.3.1
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0

--- a/scripts/virus-scan-s3-bucket.py
+++ b/scripts/virus-scan-s3-bucket.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Virus scan the contents of an S3 bucket, optionally from a given date onwards.
+Requires a clamd backend to be provided (e.g. https://github.com/UKHomeOffice/docker-clamav)
+
+You'll need to configure the required AWS environment variables, normally either AWS_PROFILE, or
+AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY.
+
+Example:
+    ./scripts/virus-scan-s3-bucket.py --since 2018-01-01T00:00:00Z --prefix g-cloud-9/documents \
+        digitalmarketplace-dev-uploads
+"""
+
+import argparse
+import clamd
+import dateutil.parser as dateutil_parser
+import logging
+import io
+import sys
+
+sys.path.insert(0, '.')  # noqa
+
+from dmutils.s3 import S3
+from dmscripts.helpers.logging_helpers import INFO, configure_logger
+
+
+logger = logging.getLogger("script")
+
+
+def virus_scan_bucket(s3, clam, prefix, since, dry_run=True):
+    scanned_files, clean, infected = 0, 0, 0
+
+    # s3.list can block for a significant amount of time against large buckets when loading with timestamps. During
+    # this time there will be no output.
+    logger.info('Gathering objects. This may take some time depending on the size of the bucket ...')
+    for file_meta in s3.list(prefix=prefix, load_timestamps=True):
+        if since and file_meta.get('last_modified') and dateutil_parser.parse(file_meta['last_modified']) < since:
+            logger.info(f'Ignoring file from {file_meta["last_modified"]}: {file_meta["path"]}')
+            continue
+
+        logger.info(f'Processing file from {file_meta["last_modified"]}: {file_meta["path"]}')
+
+        with io.BytesIO() as file_buffer:
+            if not dry_run:
+                s3._bucket.download_fileobj(Key=file_meta['path'], Fileobj=file_buffer)
+
+            file_buffer.seek(0)
+            scanned_files += 1
+            result = clam.instream(file_buffer)
+
+            if result['stream'][0] == 'OK':
+                logger.info(f'Result: {result["stream"][0]}, {result["stream"][1]}')
+                clean += 1
+            else:
+                logger.warning(f'Result: {result["stream"][0]}, {result["stream"][1]}')
+                infected += 1
+
+    logger.info(f'')
+    logger.info(f' Total files scanned: {scanned_files}')
+    logger.info(f'   Total clean files: {clean}')
+    logger.info(f'Total infected files: {infected}')
+
+    sys.exit(infected)
+
+
+if __name__ == '__main__':
+    configure_logger({"script": INFO})
+
+    a = argparse.ArgumentParser()
+    a.add_argument('bucket',
+                   type=str,
+                   help='The s3 bucket to use (e.g. `digitalmarketplace-dev-uploads`).')
+    a.add_argument('--prefix',
+                   default='',
+                   type=str,
+                   help='The s3 object prefix to filter on (e.g. `g-cloud-9/documents/`).')
+    a.add_argument('--host',
+                   default='localhost',
+                   type=str,
+                   help='The exposed host on which clamd is available (default: `localhost`).')
+    a.add_argument('--port',
+                   default=3310,
+                   type=int,
+                   help='The exposed port on which clamd is available (default: 3310).')
+    a.add_argument('--since',
+                   type=dateutil_parser.parse,
+                   help='A timezone-aware ISO8601 datetime string; if provided, only scan objects uploaded after '
+                        'this point in time (Example: 2018-01-01T12:00:00Z).')
+    a.add_argument('--dry-run',
+                   action='store_true',
+                   default=False,
+                   help='Perform a dry run - will bypass downloading and scanning files from S3.')
+
+    args = a.parse_args()
+
+    if args.since and not args.since.tzinfo:
+        logger.error('You must supply a timezone-aware ISO8601 datetime string. You probably just need to append `Z`'
+                     'to the end of your datetime string. Example: 2018-01-01T12:00:00Z')
+        sys.exit(-1)
+
+    s3 = S3(bucket_name=args.bucket)
+    clam = clamd.ClamdNetworkSocket(host=args.host, port=args.port)
+
+    try:
+        pong = clam.ping()
+        if pong != 'PONG':
+            raise clamd.ConnectionError(f'Invalid ping response: {pong}')
+
+    except clamd.ConnectionError as e:
+        logger.error(f'Clamd backend not responding to ping: {e}')
+        sys.exit(-2)
+
+    logger.info(f' Configuration:')
+    logger.info(f' Target bucket: {args.bucket}')
+    logger.info(f' Filter prefix: {args.prefix}')
+    logger.info(f'Modified since: {args.since}')
+    logger.info(f'ClamAV backend: {args.host}:{args.port}')
+    logger.info(f'       Dry run: {args.dry_run}')
+
+    virus_scan_bucket(s3=s3, clam=clam, prefix=args.prefix, since=args.since, dry_run=args.dry_run)


### PR DESCRIPTION
## Summary
A small script which streams objects from s3 to a clamd server.

## Ticket
https://trello.com/c/i30jDD69/317-automatically-virus-scan-uploaded-files-framework-agreements