### PR TITLE
Update utils for MailChimp client

### DIFF
--- a/dmscripts/upload_dos_opportunities_email_list.py
+++ b/dmscripts/upload_dos_opportunities_email_list.py
@@ -10,10 +10,6 @@ def find_user_emails(supplier_users, services):
     return email_addresses
 
 
-def lowercase_list(x):
-    return [item.lower() for item in x]
-
-
 def main(data_api_client, mailchimp_client, lot_data, logger):
     logger.info(
         "Begin mailchimp email list updating process for {} lot".format(lot_data["lot_slug"]),
@@ -26,19 +22,16 @@ def main(data_api_client, mailchimp_client, lot_data, logger):
         framework=lot_data["framework_slug"], lot=lot_data["lot_slug"]
     )
 
-    emails = find_user_emails(supplier_users, framework_services)
+    emails = frozenset(x.lower() for x in find_user_emails(supplier_users, framework_services))
     logger.info(
         "{} emails have been found for lot {}".format(len(emails), lot_data["lot_slug"])
     )
 
     existing_mailchimp_emails = mailchimp_client.get_email_addresses_from_list(lot_data["list_id"])
-    logger.info(
-        "{} existing emails found on list {}".format(len(existing_mailchimp_emails), lot_data["list_id"])
-    )
 
     # lowercase required because mailchimp may capatalise emails addresses returned from the mailchimp API based on it's
     # on how it stores both the lowercase hash but also the original (potentially capatilised) email address
-    new_emails = list(set(lowercase_list(emails)) - set(lowercase_list(existing_mailchimp_emails)))
+    new_emails = set(emails).difference(x.lower() for x in existing_mailchimp_emails)
     logger.info(
         "Subscribing {} new emails to mailchimp list {}".format(len(new_emails), lot_data["list_id"])
     )

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
-git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==34.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.0.0#egg=digitalmarketplace-utils==36.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.3.0#egg=digitalmarketplace-apiclient==14.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
-git+https://github.com/alphagov/digitalmarketplace-utils.git@28.7.0#egg=digitalmarketplace-utils==34.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.0.0#egg=digitalmarketplace-utils==36.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.3.0#egg=digitalmarketplace-apiclient==14.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1
@@ -33,6 +33,7 @@ docopt==0.6.2
 docutils==0.14
 Flask==0.12.2
 Flask-FeatureFlags==0.6
+Flask-Login==0.4.1
 Flask-Script==2.0.5
 Flask-WTF==0.12
 future==0.16.0
@@ -44,9 +45,10 @@ mandrill==1.0.57
 Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
-numpy==1.14.1
+numpy==1.14.2
+odfpy==1.3.6
 pycparser==2.18
-PyJWT==1.6.0
+PyJWT==1.6.1
 pytz==2015.4
 PyYAML==3.11
 requests==2.18.4

--- a/tests/test_upload_dos_opportunities_email_list.py
+++ b/tests/test_upload_dos_opportunities_email_list.py
@@ -62,7 +62,7 @@ class TestMain(object):
         find_user_emails.assert_called_once_with(supplier_users, framework_services)
         self.dm_mailchimp_client.get_email_addresses_from_list.assert_called_once_with("my list id")
         self.dm_mailchimp_client.subscribe_new_emails_to_list.assert_called_once_with(
-            "my list id", ['email2@email.com']
+            "my list id", {'email2@email.com'}
         )
 
     def test_main_returns_false_if_subscribing_emails_fails(self, get_supplier_users, find_user_emails):


### PR DESCRIPTION
 ## Summary
Pull in latest dm-utils which updates the MailChimp client to use a
generator and have a smaller page size when retrieving email addresses
from an existing list, which should hopefully result in fewer 504
timeouts with MailChimp servers.

 ## Ticket
https://trello.com/c/4cK1wTvq/236