### PR TITLE
boto to boto3

### DIFF
--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -45,9 +45,8 @@ from dmscripts.helpers.logging_helpers import logging
 
 from docopt import docopt
 from dmapiclient import DataAPIClient, APIError
-from boto.exception import S3ResponseError
 
-from dmutils.s3 import S3
+from dmutils.s3 import S3, S3ResponseError
 from dmutils.email.dm_notify import DMNotifyClient
 from dmutils.email.exceptions import EmailError
 


### PR DESCRIPTION
 ## Summary
Some of the scripts are still trying to use the `boto` library. dm-utils
has been updated to use boto3 and create its own S3ResponseError, so
let's update this to do the same.