### PR TITLE
Bump utils to 36.7.0 and notify client to 4.8.2

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,10 +2,9 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.0.0#egg=digitalmarketplace-utils==36.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.7.0#egg=digitalmarketplace-utils==36.7.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.3.0#egg=digitalmarketplace-apiclient==14.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
-git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1
 
 
 awscli==1.14.31
@@ -14,6 +13,7 @@ Jinja2==2.7.3
 jsonschema==2.5.1
 lorem==0.1.1
 mailchimp3==2.0.11
+notifications-python-client==4.8.2
 pandas==0.19.1
 python-dateutil==2.4.2
 unicodecsv==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,9 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.0.0#egg=digitalmarketplace-utils==36.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.7.0#egg=digitalmarketplace-utils==36.7.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.3.0#egg=digitalmarketplace-apiclient==14.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
-git+https://github.com/alphagov/notifications-python-client.git@4.7.1#egg=notifications-python-client==4.7.1
 
 
 awscli==1.14.31
@@ -15,6 +14,7 @@ Jinja2==2.7.3
 jsonschema==2.5.1
 lorem==0.1.1
 mailchimp3==2.0.11
+notifications-python-client==4.8.2
 pandas==0.19.1
 python-dateutil==2.4.2
 unicodecsv==0.14.1
@@ -24,32 +24,31 @@ yq==2.4.1
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 backoff==1.0.7
-boto3==1.4.4
+boto3==1.4.8
 botocore==1.8.35
-certifi==2018.1.18
+certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
-click==6.7
 colorama==0.3.7
 contextlib2==0.4.0
 cryptography==1.9
 docopt==0.6.2
 docutils==0.14
-Flask==0.12.2
+Flask==0.10.1
 Flask-FeatureFlags==0.6
 Flask-Login==0.4.1
 Flask-Script==2.0.5
-Flask-WTF==0.12
+Flask-WTF==0.14.2
 future==0.16.0
 idna==2.6
-inflection==0.2.1
+inflection==0.3.1
 itsdangerous==0.24
 jmespath==0.9.3
 mandrill==1.0.57
 Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
-numpy==1.14.2
+numpy==1.14.3
 odfpy==1.3.6
 pyasn1==0.4.2
 pycparser==2.18
@@ -59,9 +58,9 @@ PyYAML==3.11
 requests==2.18.4
 rsa==3.4.2
 s3transfer==0.1.13
-six==1.9.0
+six==1.11.0
 urllib3==1.22
-Werkzeug==0.11.9
+Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.1
 xmltodict==0.11.0


### PR DESCRIPTION
The new utils has a fix for a bug in the DM Mailchimp client. It'll
catch and handle errors if a response has malformed or missing json
data. See here:
https://github.com/alphagov/digitalmarketplace-utils/pull/390

The Notify client has a fix for issues installing with pip v10.
Interestingly their internal tagging script has an issue which means
that installing 4.8.2 directly from Github won't work. We can instead
install from PyPI though.