### PR TITLE
Update notify suppliers script

### DIFF
--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -119,7 +119,7 @@ class SuccessfulSupplierContextForNotify(SupplierFrameworkData):
 class AppliedToFrameworkSupplierContextForNotify(SupplierFrameworkData):
     """Get the personalisation/ context for 'You application result - if successful email'"""
 
-    def __init__(self, client, target_framework_slug, successful_notification_date):
+    def __init__(self, client, target_framework_slug, intention_to_award_at):
         """Get the target framework to operate on and list the lots.
 
         :param client: Instantiated api client
@@ -127,7 +127,7 @@ class AppliedToFrameworkSupplierContextForNotify(SupplierFrameworkData):
         """
         super(AppliedToFrameworkSupplierContextForNotify, self).__init__(client, target_framework_slug)
 
-        self.successful_notification_date = successful_notification_date
+        self.intention_to_award_at = intention_to_award_at
         self.framework = client.get_framework(self.target_framework_slug)['frameworks']
 
     def get_users_personalisations(self):
@@ -142,7 +142,7 @@ class AppliedToFrameworkSupplierContextForNotify(SupplierFrameworkData):
     def get_user_personalisation(self, user):
         """Get dict of all info required by template given a user and framework."""
         personalisation = {
-            'successful_notification_date': self.successful_notification_date,
+            'intention_to_award_at': self.intention_to_award_at,
             'framework_name': self.framework['name'],
             'framework_slug': self.framework['slug'],
             'applied': user['application_status'] == 'application'

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.7.0#egg=digitalmarketplace-utils==36.7.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.11.0#egg=digitalmarketplace-utils==36.11.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.3.0#egg=digitalmarketplace-apiclient==15.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.7.0#egg=digitalmarketplace-utils==36.7.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.11.0#egg=digitalmarketplace-utils==36.11.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.3.0#egg=digitalmarketplace-apiclient==15.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
@@ -37,7 +37,7 @@ docutils==0.14
 Flask==0.10.1
 Flask-FeatureFlags==0.6
 Flask-Login==0.4.1
-Flask-Script==2.0.5
+Flask-Script==2.0.6
 Flask-WTF==0.14.2
 future==0.16.0
 idna==2.6
@@ -52,7 +52,7 @@ numpy==1.14.3
 odfpy==1.3.6
 pyasn1==0.4.2
 pycparser==2.18
-PyJWT==1.6.1
+PyJWT==1.6.3
 pytz==2015.4
 PyYAML==3.11
 requests==2.18.4

--- a/scripts/notify-suppliers-whether-application-made-for-framework.py
+++ b/scripts/notify-suppliers-whether-application-made-for-framework.py
@@ -4,29 +4,33 @@ Uses the Notify API to send emails.
 
 Usage:
     scripts/notify-suppliers-whether-application-made-for-framework.py <stage> <api_token> <framework_slug>
-        <govuk_notify_api_key> <successful_notification_date> [--dry-run]
+        <govuk_notify_api_key> [--dry-run]
 
 Example:
     scripts/notify-suppliers-whether-application-made-for-framework.py preview myToken g-cloud-9
-        my-awesome-key "29th March 2017" --dry-run
+        my-awesome-key --dry-run
 
 Options:
     -h, --help  Show this screen
 """
 import sys
 
-sys.path.insert(0, '.')
+sys.path.insert(0, '.')  # noqa
 from docopt import docopt
 
 from dmapiclient import DataAPIClient
 from dmutils.email.dm_notify import DMNotifyClient
 from dmutils.email.exceptions import EmailError
+from dmutils.dates import update_framework_with_formatted_dates
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
 from dmscripts.helpers.supplier_data_helpers import AppliedToFrameworkSupplierContextForNotify
 
 logger = logging_helpers.configure_logger({"dmapiclient": logging.INFO})
+
+NOTIFY_TEMPLATE_APPLICATION_MADE = 'de02a7e3-80f6-4391-818c-48326e1f4688'
+NOTIFY_TEMPLATE_NO_APPLICATION = '87a126b4-7909-4b63-b981-d3c3d6a558ff'
 
 
 if __name__ == '__main__':
@@ -36,21 +40,25 @@ if __name__ == '__main__':
     API_TOKEN = arguments['<api_token>']
     FRAMEWORK_SLUG = arguments['<framework_slug>']
     GOVUK_NOTIFY_API_KEY = arguments['<govuk_notify_api_key>']
-    NOTIFICATION_DATE = arguments['<successful_notification_date>']
     DRY_RUN = arguments['--dry-run']
 
     mail_client = DMNotifyClient(GOVUK_NOTIFY_API_KEY, logger=logger)
     api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(STAGE), auth_token=API_TOKEN)
 
-    context_helper = AppliedToFrameworkSupplierContextForNotify(api_client, FRAMEWORK_SLUG, NOTIFICATION_DATE)
+    framework_data = api_client.get_framework(FRAMEWORK_SLUG)['frameworks']
+    update_framework_with_formatted_dates(framework_data)
+
+    context_helper = AppliedToFrameworkSupplierContextForNotify(api_client,
+                                                                FRAMEWORK_SLUG,
+                                                                framework_data['intentionToAwardAt'])
     context_helper.populate_data()
     context_data = context_helper.get_users_personalisations()
     error_count = 0
     for user_email, personalisation in context_data.items():
         logger.info(user_email)
-        template_id = ('de02a7e3-80f6-4391-818c-48326e1f4688'
+        template_id = (NOTIFY_TEMPLATE_APPLICATION_MADE
                        if personalisation['applied']
-                       else '87a126b4-7909-4b63-b981-d3c3d6a558ff')
+                       else NOTIFY_TEMPLATE_NO_APPLICATION)
         if DRY_RUN:
             logger.info("[Dry Run] Sending email {} to {}".format(template_id, user_email))
         else:


### PR DESCRIPTION
 ## Summary
We don't need to pass the `successful notification date` in any more as
this is now stored on the API. It is called the `intention to award at`
date there, so we'll update references to keep language consistent.

I'll update the two Notify templates using this personalisation when
this PR is merged.