### PR TITLE
Update generate framework master csv

### DIFF
--- a/dmscripts/generate_framework_master_csv.py
+++ b/dmscripts/generate_framework_master_csv.py
@@ -76,7 +76,7 @@ class GenerateMasterCSV(GenerateCSVFromAPI):
         for sf in supplier_frameworks:
             # This bit takes care of the columns in static_fieldnames.
             supplier_id = sf['supplierId']
-            declaration = sf['declaration']['status'] if sf['declaration'] else ''
+            declaration = sf['declaration'].get('status', '') if sf['declaration'] else ''
             supplier_info = [
                 supplier_id,
                 sf['supplierName'],


### PR DESCRIPTION
 ## Summary
We now inject company details into the supplier framework when a
framework changes from open to pending. This means that suppliers who
haven't started a declaration no longer have a 'False-y' declaration if
they haven't answered any questions, so we need to do a `get('status')`
rather than a direct `['status']` on the dict.