### PR TITLE
Add an entrypoint to forward API ports from Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 *
 
 !dmscripts/
+!docker_for_mac_entrypoint.sh
 !email_templates/
 !requirements.txt
 !schemas/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6.1-slim
 ENV APP_DIR /app
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc g++ make git libffi-dev libssl-dev libc6-dev wget curl && \
+    apt-get install -y --no-install-recommends gcc g++ make git libffi-dev libssl-dev libc6-dev wget curl socat && \
     wget --quiet -O /usr/local/bin/sops https://s3-eu-west-1.amazonaws.com/digitalmarketplace-public/sops_linux_amd64 && chmod 0755 /usr/local/bin/sops && \
     wget --quiet -O /usr/local/bin/aws-auth https://raw.githubusercontent.com/alphagov/aws-auth/1741ad8b8454f54dd40fb730645fc2d6e3ed9ea9/aws-auth.sh && chmod 0755 /usr/local/bin/aws-auth && \
     wget --quiet -O /usr/local/bin/jq https://s3-eu-west-1.amazonaws.com/digitalmarketplace-public/jq-linux64 && chmod 0755 /usr/local/bin/jq
@@ -14,6 +14,7 @@ COPY requirements.txt ${APP_DIR}
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . ${APP_DIR}
+RUN mv docker_for_mac_entrypoint.sh /usr/local/bin
 
 ARG release_name
 RUN echo ${release_name} > ${APP_DIR}/version_label

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ in the container using a volume:
 docker run --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/get-model-data.py ...
 ```
 
-### Docker for Mac workaround
+### Docker for Mac workaround
 
 If you are running in Docker on macOS and have local apps/services then `--net=host` will not work for you.
 Instead, a workaround script has been provided that runs inside the container to forward the scripts to the

--- a/README.md
+++ b/README.md
@@ -155,11 +155,23 @@ container. The easiest way to do this is to use `--net=host` argument for `docke
 docker run --net=host digitalmarketplace/scripts scripts/index-to-search-service.py services dev ...
 ```
 
+This won't work however if you are running Docker for Mac; instead, see [below](#docker-for-mac-workaround).
+
 If the script is generating output files you need to map a local directory to the output directory
 in the container using a volume:
 
 ```
 docker run --user $(id -u) --volume $(pwd)/data:/app/data digitalmarketplace/scripts scripts/get-model-data.py ...
+```
+
+### Docker for Mac workaround
+
+If you are running in Docker on macOS and have local apps/services then `--net=host` will not work for you.
+Instead, a workaround script has been provided that runs inside the container to forward the scripts to the
+Docker host. To use it, run Docker like this:
+
+```
+docker run --entrypoint docker_for_mac_entrypoint.sh digitalmarketplace/scripts scripts/index-to-search-service.py dev ...
 ```
 
 ## A general approach to writing new scripts

--- a/docker_for_mac_entrypoint.sh
+++ b/docker_for_mac_entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+socat tcp-listen:5000,reuseaddr,fork tcp:host.docker.internal:5000 &
+socat tcp-listen:5001,reuseaddr,fork tcp:host.docker.internal:5001 &
+echo "Forwarding localhost:5000-5001 to host.docker.internal"
+
+exec "$@"


### PR DESCRIPTION
Ticket: [Trello](https://trello.com/c/R5tAKXEA/301-testing-dm-scripts-against-local-environment-within-the-docker-container-is-broken)

This is useful for macOS development environments, if services are
running on the host machine they are not normally accessible to the
container.

This commit adds a script `docker_for_mac_entrypoint.sh`, that
forwards the ports within the container transparently to the Docker
host, so that the API services can be accessed as if they were
running within the container.

By default the entrypoint is not used; it is copied into PATH in the
container but must be enabled when `docker run` is called. An
explanation of how to do this has been added to the readme file.