### PR TITLE
Redirect Notify emails in scripts

### DIFF
--- a/dmscripts/helpers/email_helpers.py
+++ b/dmscripts/helpers/email_helpers.py
@@ -1,4 +1,16 @@
+from functools import partial
+
 from mandrill import Mandrill
+
+from dmutils.email import DMNotifyClient
+
+
+def scripts_notify_client(notify_api_key, logger):
+    return partial(DMNotifyClient, govuk_notify_api_key=notify_api_key, logger=logger, redirect_domains_to_address={
+        "example.com": "success@simulator.amazonses.com",
+        "example.gov.uk": "success@simulator.amazonses.com",
+        "user.marketplace.team": "success@simulator.amazonses.com",
+    })
 
 
 def get_sent_emails(mandrill_api_key, tags, date_from=None):

--- a/dmscripts/notify_buyers_to_award_closed_briefs.py
+++ b/dmscripts/notify_buyers_to_award_closed_briefs.py
@@ -2,11 +2,12 @@
 from datetime import datetime, date, timedelta
 
 import dmapiclient
-from dmutils.email import DMNotifyClient
 from dmutils.email.exceptions import EmailError
 from dmutils.formats import DATE_FORMAT
 
 from dmscripts.helpers import logging_helpers, brief_data_helpers
+
+from dmscripts.helpers.email_helpers import scripts_notify_client
 
 logger = logging_helpers.configure_logger({'dmapiclient': logging_helpers.logging.INFO})
 
@@ -116,7 +117,7 @@ def main(
         return False
 
     data_api_client = dmapiclient.DataAPIClient(data_api_url, data_api_access_token)
-    notify_client = DMNotifyClient(notify_api_key, logger=logger)
+    notify_client = scripts_notify_client(notify_api_key, logger=logger)
 
     closed_briefs = brief_data_helpers.get_briefs_closed_on_date(data_api_client, date_closed)
     if not closed_briefs:

--- a/scripts/notify-successful-suppliers-for-framework.py
+++ b/scripts/notify-successful-suppliers-for-framework.py
@@ -19,7 +19,7 @@ sys.path.insert(0, '.')
 from docopt import docopt
 
 from dmapiclient import DataAPIClient
-from dmutils.email.dm_notify import DMNotifyClient
+from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     GOVUK_NOTIFY_API_KEY = arguments['<govuk_notify_api_key>']
     GOVUK_NOTIFY_TEMPLATE_ID = arguments['<govuk_notify_template_id>']
 
-    mail_client = DMNotifyClient(GOVUK_NOTIFY_API_KEY, logger=logger)
+    mail_client = scripts_notify_client(GOVUK_NOTIFY_API_KEY, logger=logger)
     api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(STAGE), auth_token=API_TOKEN)
 
     context_helper = SuccessfulSupplierContextForNotify(api_client, FRAMEWORK_SLUG)

--- a/scripts/notify-suppliers-of-awarded-briefs.py
+++ b/scripts/notify-suppliers-of-awarded-briefs.py
@@ -26,11 +26,11 @@ import logging
 import sys
 from docopt import docopt
 
-from dmutils.email import DMNotifyClient
 from dmapiclient import DataAPIClient
 
 sys.path.insert(0, '.')
 
+from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.helpers import logging_helpers
 from dmscripts.notify_suppliers_of_awarded_briefs import main
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     logger = logging_helpers.configure_logger(
         {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
     )
-    notify_client = DMNotifyClient(govuk_notify_api_key, logger=logger)
+    notify_client = scripts_notify_client(govuk_notify_api_key, logger=logger)
     data_api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(stage), auth_token=api_token)
 
     list_of_brief_response_ids = list(map(int, brief_response_ids.split(','))) if brief_response_ids else None

--- a/scripts/notify-suppliers-of-brief-withdrawal.py
+++ b/scripts/notify-suppliers-of-brief-withdrawal.py
@@ -30,12 +30,12 @@ import sys
 from datetime import datetime, timedelta
 from docopt import docopt
 
-from dmutils.email import DMNotifyClient
 from dmutils.formats import DATE_FORMAT
 from dmapiclient import DataAPIClient
 
 sys.path.insert(0, '.')
 
+from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.helpers import logging_helpers
 from dmscripts.notify_suppliers_of_brief_withdrawal import main
@@ -62,7 +62,7 @@ if __name__ == "__main__":
         withdrawn_date and datetime.strptime(withdrawn_date, DATE_FORMAT).date() or
         datetime.today().date() - timedelta(days=1)
     )
-    notify_client = DMNotifyClient(govuk_notify_api_key, logger=logger)
+    notify_client = scripts_notify_client(govuk_notify_api_key, logger=logger)
     data_api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(stage), auth_token=api_token)
 
     # Do send

--- a/scripts/notify-suppliers-whether-application-made-for-framework.py
+++ b/scripts/notify-suppliers-whether-application-made-for-framework.py
@@ -19,9 +19,9 @@ sys.path.insert(0, '.')  # noqa
 from docopt import docopt
 
 from dmapiclient import DataAPIClient
-from dmutils.email.dm_notify import DMNotifyClient
 from dmutils.email.exceptions import EmailError
 from dmutils.dates import update_framework_with_formatted_dates
+from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
@@ -42,7 +42,7 @@ if __name__ == '__main__':
     GOVUK_NOTIFY_API_KEY = arguments['<govuk_notify_api_key>']
     DRY_RUN = arguments['--dry-run']
 
-    mail_client = DMNotifyClient(GOVUK_NOTIFY_API_KEY, logger=logger)
+    mail_client = scripts_notify_client(GOVUK_NOTIFY_API_KEY, logger=logger)
     api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(STAGE), auth_token=API_TOKEN)
 
     framework_data = api_client.get_framework(FRAMEWORK_SLUG)['frameworks']

--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -47,8 +47,9 @@ from docopt import docopt
 from dmapiclient import DataAPIClient, APIError
 
 from dmutils.s3 import S3, S3ResponseError
-from dmutils.email.dm_notify import DMNotifyClient
 from dmutils.email.exceptions import EmailError
+
+from dmscripts.helpers.email_helpers import scripts_notify_client
 
 
 logger = logging_helpers.configure_logger({
@@ -68,7 +69,7 @@ if __name__ == '__main__':
     framework = data_api_client.get_framework(arguments['<framework_slug>'])["frameworks"]
     document_directory = arguments['<documents_directory>']
     dry_run = arguments['--dry-run']
-    dm_notify_client = arguments.get("--notify-key") and DMNotifyClient(arguments["--notify-key"], logger=logger)
+    dm_notify_client = arguments.get("--notify-key") and scripts_notify_client(arguments["--notify-key"], logger=logger)
 
     if dry_run:
         bucket = None

--- a/tests/test_notify_buyers_to_award_closed_briefs.py
+++ b/tests/test_notify_buyers_to_award_closed_briefs.py
@@ -135,7 +135,7 @@ class TestSendEmailToBriefUserViaNotify:
         notify_client.assert_not_called()
 
 
-@mock.patch('dmscripts.notify_buyers_to_award_closed_briefs.DMNotifyClient', autospec=True)
+@mock.patch('dmscripts.notify_buyers_to_award_closed_briefs.scripts_notify_client')
 @mock.patch('dmscripts.notify_buyers_to_award_closed_briefs.send_email_to_brief_user_via_notify')
 @mock.patch('dmscripts.helpers.brief_data_helpers.get_briefs_closed_on_date')
 @mock.patch('dmscripts.notify_buyers_to_award_closed_briefs.logger', autospec=True)


### PR DESCRIPTION
 ## Summary
We send a lot of fake emails with scripts that run against preview.
Doing this regularly and repeatedly will degrade Notify's reputation
with its email provider, so we need to stop sending emails to addresses
that we know are bad. We should make a concerted effort to stop doing
this wherever possible.

This is an alternative to centralising the email redirects in utils as
put forward in
https://github.com/alphagov/digitalmarketplace-utils/pull/405.

 ## Ticket
https://trello.com/c/YIJ25eiP/479