### PR TITLE
Update docstrings of scripts that use aws on Jenkins

### DIFF
--- a/scripts/make-g-cloud-live.py
+++ b/scripts/make-g-cloud-live.py
@@ -4,6 +4,8 @@ PREREQUISITE: For document migration to work you'll need AWS credentials set up 
               Save your aws_access_key_id and aws_secret_access_key in ~/.aws/credentials
               If you have more than one set of credentials in there then be sure to set your AWS_PROFILE environment
               variable to reference the right credentials before running the script.
+              Alternatively, if this script is being run from Jenkins, do not provide any credentials and boto will use
+              the Jenkins IAM role. It should have the required permissions for the buckets.
 
 For a G-Cloud style framework (with uploaded documents to migrate) this will:
  1. Find all suppliers awarded onto the framework

--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -3,6 +3,8 @@ PREREQUISITE: You'll need AWS credentials set up for the environment that you're
               Save your aws_access_key_id and aws_secret_access_key in ~/.aws/credentials
               If you have more than one set of credentials in there then be sure to set your AWS_PROFILE environment
               variable to reference the right credentials before running the script.
+              Alternatively, if this script is being run from Jenkins, do not provide any credentials and boto will use
+              the Jenkins IAM role. It should have the required permissions for the buckets.
 
 This will:
  * scan a directory for pdf files (they should be in the format <supplier_id>-some-ignored-words.pdf but this isn't


### PR DESCRIPTION
See these associated PRs:
https://github.com/alphagov/digitalmarketplace-aws/pull/403
https://github.com/alphagov/digitalmarketplace-credentials/pull/119
https://github.com/alphagov/digitalmarketplace-jenkins/pull/90

Some scripts on Jenkins were using a config file for creds when they
should use the jenkins role instead.