### PR TITLE
Fix scripts notify helper

### DIFF
--- a/dmscripts/helpers/email_helpers.py
+++ b/dmscripts/helpers/email_helpers.py
@@ -5,12 +5,14 @@ from mandrill import Mandrill
 from dmutils.email import DMNotifyClient
 
 
-def scripts_notify_client(notify_api_key, logger):
-    return partial(DMNotifyClient, govuk_notify_api_key=notify_api_key, logger=logger, redirect_domains_to_address={
-        "example.com": "success@simulator.amazonses.com",
-        "example.gov.uk": "success@simulator.amazonses.com",
-        "user.marketplace.team": "success@simulator.amazonses.com",
-    })
+DEFAULT_REDIRECT_DOMAINS = {
+    "example.com": "success@simulator.amazonses.com",
+    "example.gov.uk": "success@simulator.amazonses.com",
+    "user.marketplace.team": "success@simulator.amazonses.com",
+}
+
+
+scripts_notify_client = partial(DMNotifyClient, redirect_domains_to_address=DEFAULT_REDIRECT_DOMAINS)
 
 
 def get_sent_emails(mandrill_api_key, tags, date_from=None):


### PR DESCRIPTION
 ## Summary
https://ci.marketplace.team/job/notify-buyers-to-award-closed-briefs-4-weeks-production/240/consoleFull
broke because the partial invocation was bad (returns a callable, but
wasn't calling it).  This fixes it.