### PR TITLE
Update scripts for G10 standstill

### DIFF
--- a/dmscripts/bulk_upload_documents.py
+++ b/dmscripts/bulk_upload_documents.py
@@ -1,9 +1,6 @@
 import os
 import re
-try:
-    import unicodecsv as csv
-except ImportError:
-    import csv
+import csv
 
 from dmutils.documents import get_document_path, generate_download_filename
 
@@ -28,9 +25,8 @@ def upload_file(bucket, dry_run, file_path, framework_slug, bucket_category,
         download_filename = generate_download_filename(
             supplier_id, document_name, supplier_name)
     if not dry_run:
-        with open(file_path) as source_file:
-            bucket.save(upload_path, source_file, acl='bucket-owner-full-control',
-                        download_filename=download_filename)
+        with open(file_path, 'rb') as source_file:
+            bucket.save(upload_path, source_file, acl='bucket-owner-full-control', download_filename=download_filename)
         print(supplier_id)
     else:
         print("[Dry-run] UPLOAD: '{}' to '{}'".format(file_path, upload_path))
@@ -63,8 +59,8 @@ def get_document_name_from_file_path(path):
 
 def get_supplier_name_dict_from_tsv(tsv_path):
     suppliers_name_dict = {}
-    with open(tsv_path, 'r') as csvfile:
-        tsv_path = csv.reader(csvfile, delimiter='\t')
-        for row in tsv_path:
+    with open(tsv_path, 'r') as tsvfile:
+        tsv_reader = csv.reader(tsvfile, delimiter='\t')
+        for row in tsv_reader:
             suppliers_name_dict[row[0]] = row[1]
     return suppliers_name_dict

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -35,10 +35,10 @@ def render_html_for_successful_suppliers(rows, framework, template_dir, output_d
     shutil.copyfile(template_css_path, os.path.join(output_dir, 'framework-agreement-signature-page.css'))
 
 
-def render_html_for_suppliers_awaiting_countersignature(rows, framework, template_dir, output_dir):
+def render_html_for_suppliers_awaiting_countersignature(rows, framework, template_dir, output_dir,
+                                                        countersignature_img_path):
     template_path = os.path.join(template_dir, 'framework-agreement-signature-page.html')
     template_css_path = os.path.join(template_dir, 'framework-agreement-signature-page.css')
-    countersignature_img_path = os.path.join(template_dir, 'framework-agreement-countersignature.png')
     for data in rows:
         if data['pass_fail'] == 'fail' or data['countersigned_path'] or not data['countersigned_at']:
             logger.info("SKIPPING {}: pass_fail={} countersigned_at={} countersigned_path={}".format(
@@ -49,7 +49,7 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework, templat
             )
             continue
         data['framework'] = framework
-        data['awardedLots'] = [lot for lot in framework['lotOrder'] if int(data[lot]) > 0]
+        data['awardedLots'] = [lot for lot in framework['frameworkAgreementDetails']['lotOrder'] if int(data[lot]) > 0]
         data['countersigned_at'] = datetime.strptime(
             data['countersigned_at'], '%Y-%m-%dT%H:%M:%S.%fZ'
         ).strftime('%d %B %Y')

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -30,9 +30,12 @@ The 'frameworkAgreementDetails' JSON object from the API should look something l
     "signaturePageNumber": 3
 }
 
+`countersignature_path` is a path pointing at an image file of a signature to use when 'signing' the agreement,
+which should be at `digitalmarketplace-credentials/signatures/<name>.png`
+
 Usage:
-    scripts/generate-framework-agreement-counterpart-signature-pages.py <stage> <api_token> <framework_slug>
-    <template_folder> <output_folder> [<supplier_id_file>]
+    scripts/generate-framework-agreement-counterpart-signature-pages.py <stage> <framework_slug>
+    <countersignature_path> <output_folder> [<supplier_id_file>]
 
 """
 import os
@@ -45,6 +48,7 @@ sys.path.insert(0, '.')  # noqa
 from docopt import docopt
 from dmscripts.export_framework_applicant_details import get_csv_rows
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
+from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.framework_helpers import find_suppliers_with_details_and_draft_service_counts
 from dmscripts.helpers.supplier_data_helpers import get_supplier_ids_from_file
 from dmscripts.generate_framework_agreement_signature_pages import (
@@ -57,11 +61,9 @@ if __name__ == '__main__':
     args = docopt(__doc__)
 
     framework_slug = args['<framework_slug>']
-    client = DataAPIClient(get_api_endpoint_from_stage(args['<stage>']), args['<api_token>'])
+    client = DataAPIClient(get_api_endpoint_from_stage(args['<stage>']), get_auth_token('api', args['<stage>']))
     framework = client.get_framework(framework_slug)['frameworks']
     framework_lot_slugs = tuple([lot['slug'] for lot in client.get_framework(framework_slug)['frameworks']['lots']])
-    framework_kwargs = framework['frameworkAgreementDetails']
-    framework_kwargs['frameworkName'] = framework['name']
 
     supplier_id_file = args['<supplier_id_file>']
     supplier_ids = get_supplier_ids_from_file(supplier_id_file)
@@ -69,7 +71,8 @@ if __name__ == '__main__':
 
     records = find_suppliers_with_details_and_draft_service_counts(client, framework_slug, supplier_ids)
     headers, rows = get_csv_rows(records, framework_slug, framework_lot_slugs, count_statuses=("submitted",))
-    render_html_for_suppliers_awaiting_countersignature(rows, framework_kwargs, args['<template_folder>'], html_dir)
+    render_html_for_suppliers_awaiting_countersignature(rows, framework, 'templates/framework_signature_page', html_dir,
+                                                        args['<countersignature_path>'])
     html_pages = os.listdir(html_dir)
     html_pages.remove('framework-agreement-signature-page.css')
     html_pages.remove('framework-agreement-countersignature.png')

--- a/templates/framework_signature_page/framework-agreement-signature-page.html
+++ b/templates/framework_signature_page/framework-agreement-signature-page.html
@@ -177,7 +177,7 @@
                 </li>
                 <li>
                   <strong>Name:</strong>
-                    Dan Saxby
+                    Niall Quinn
                 </li>
                 <li>
                   <strong>Role:</strong>


### PR DESCRIPTION
 ## Summary
Updates the countersigned framework agreement page generator to use the
new templates in the scripts directory and take a path to the signature
image stored in credentials.

 ## Summary
Need to read the file in binary mode or Python3 complains about utf-8
decoding errors.