### PR TITLE
Check for correct keys in declaration

### DIFF
--- a/dmscripts/upload_counterpart_agreements.py
+++ b/dmscripts/upload_counterpart_agreements.py
@@ -30,7 +30,11 @@ def upload_counterpart_file(
     supplier_id = get_supplier_id_from_framework_file_path(file_path)
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework["slug"])
     supplier_framework = supplier_framework['frameworkInterest']
-    supplier_name = supplier_framework['declaration']['supplierRegisteredName']
+    supplier_name = (
+        supplier_framework['declaration']['supplierRegisteredName']
+        if 'supplierRegisteredName' in supplier_framework['declaration'] else
+        supplier_framework['declaration']['nameOfOrganisation']
+    )
     download_filename = generate_download_filename(supplier_id, COUNTERPART_FILENAME, supplier_name)
 
     email_addresses_to_notify = dm_notify_client and frozenset(chain(

--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 PREREQUISITE: You'll need AWS credentials set up for the environment that you're uploading to:
               Save your aws_access_key_id and aws_secret_access_key in ~/.aws/credentials
@@ -27,7 +29,7 @@ This will:
    * if <notify_key> and <notify_template_id> are provided, will send a notification email to all the supplier's active
      users (and their primaryContactEmail for that framework)
 
-Usage: scripts/upload-counterpart-agreements.py <stage> <api_token> <documents_directory> <framework_slug> [options]
+Usage: scripts/upload-counterpart-agreements.py <stage> <documents_directory> <framework_slug> [options]
 
 Options:
     --dry-run                                   # Don't actually do anything
@@ -40,6 +42,7 @@ import sys
 sys.path.insert(0, '.')
 
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
+from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.bulk_upload_documents import get_bucket_name, get_all_files_of_type
 from dmscripts.upload_counterpart_agreements import upload_counterpart_file
 from dmscripts.helpers import logging_helpers
@@ -67,7 +70,7 @@ if __name__ == '__main__':
         raise ValueError("Either specify both --notify-key and --notify-template-id or neither")
 
     stage = arguments['<stage>']
-    data_api_client = DataAPIClient(get_api_endpoint_from_stage(stage), arguments['<api_token>'])
+    data_api_client = DataAPIClient(get_api_endpoint_from_stage(stage), get_auth_token('api', stage))
     framework = data_api_client.get_framework(arguments['<framework_slug>'])["frameworks"]
     document_directory = arguments['<documents_directory>']
     dry_run = arguments['--dry-run']


### PR DESCRIPTION
 ## Summary
We need to check the declaration for the presence of two keys in order
to support old and new framework iterations: supplierRegisteredName (G10
and onwards) and nameOfOrganisation (DOS2 and older).

Also updates the upload-counterpart-signatures.py script to derive the
api token from the environment.