### PR TITLE
Open file in binary mode for upload

### DIFF
--- a/dmscripts/upload_counterpart_agreements.py
+++ b/dmscripts/upload_counterpart_agreements.py
@@ -53,8 +53,8 @@ def upload_counterpart_file(
     )
     try:
         if not dry_run:
-            # Upload file
-            with open(file_path) as source_file:
+            # Upload file - need to open in binary mode as it's not plain text
+            with open(file_path, 'rb') as source_file:
                 bucket.save(upload_path, source_file, acl='bucket-owner-full-control',
                             download_filename=download_filename)
                 logger.info("UPLOADED: '{}' to '{}'".format(file_path, upload_path))


### PR DESCRIPTION
 ## Summary
We are uploading PDFs to S3 so need to open the file in binary mode or
S3 complains about trying to decode it as UTF-8.