### PR TITLE
Convert country codes to names

### DIFF
--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -2,6 +2,7 @@ from itertools import chain
 
 from dmscripts.helpers.csv_helpers import write_csv
 from dmscripts.helpers.framework_helpers import find_suppliers_with_details_and_draft_service_counts
+from dmscripts.helpers.supplier_data_helpers import country_code_to_name
 
 DECLARATION_FIELDS = {
     "g-cloud-8": (
@@ -164,6 +165,13 @@ def _pass_fail_from_record(record):
         )
 
 
+def _format_field(field_name, field_value):
+    if field_name == 'supplierRegisteredCountry':
+        field_value = country_code_to_name(field_value)
+
+    return field_name, field_value
+
+
 def _create_row(framework_slug, record, count_statuses, framework_lot_slugs):
     return dict(chain(
         (
@@ -179,7 +187,7 @@ def _create_row(framework_slug, record, count_statuses, framework_lot_slugs):
             (lot, sum(record["counts"][(lot, status)] for status in count_statuses))
             for lot in framework_lot_slugs
         ),
-        ((field, record["declaration"].get(field, "")) for field in DECLARATION_FIELDS[framework_slug]),
+        (_format_field(field, record["declaration"].get(field, "")) for field in DECLARATION_FIELDS[framework_slug]),
     ))
 
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,6 +8,7 @@ git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=
 
 
 awscli==1.14.31
+backoff==1.0.7
 clamd==1.0.2
 Jinja2==2.7.3
 jsonschema==2.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ ipython-genutils==0.2.0
 lxml==3.7.2
 mock==2.0.0
 pytest==3.2.3
+requests-mock==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=
 
 
 awscli==1.14.31
+backoff==1.0.7
 clamd==1.0.2
 Jinja2==2.7.3
 jsonschema==2.5.1
@@ -23,7 +24,6 @@ yq==2.4.1
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
-backoff==1.0.7
 boto3==1.4.8
 botocore==1.8.35
 certifi==2018.4.16

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import json
 import os
 import pytest
 from mock import Mock
+import requests_mock
 
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
@@ -32,3 +33,19 @@ def mock_data_client():
     with open(os.path.join(FIXTURES_DIR, 'test_supplier_frameworks_response.json')) as supplier_frameworks_response:
         mock_data_client.find_framework_suppliers.return_value = json.loads(supplier_frameworks_response.read())
     return mock_data_client
+
+
+@pytest.yield_fixture
+def rmock():
+    with requests_mock.mock() as rmock:
+        real_register_uri = rmock.register_uri
+
+        def register_uri_with_complete_qs(*args, **kwargs):
+            if 'complete_qs' not in kwargs:
+                kwargs['complete_qs'] = True
+
+            return real_register_uri(*args, **kwargs)
+
+        rmock.register_uri = register_uri_with_complete_qs
+
+        yield rmock

--- a/tests/helpers/test_supplier_data_helpers.py
+++ b/tests/helpers/test_supplier_data_helpers.py
@@ -1,0 +1,93 @@
+import pytest
+import requests
+
+from dmscripts.helpers.supplier_data_helpers import country_code_to_name
+
+
+class TestCountryCodeToName:
+    GB_COUNTRY_JSON = {
+        "GB": {
+            "index-entry-number": "6",
+            "entry-number": "6",
+            "entry-timestamp": "2016-04-05T13:23:05Z",
+            "key": "GB",
+            "item": [{
+                "country": "GB",
+                "official-name": "The United Kingdom of Great Britain and Northern Ireland",
+                "name": "United Kingdom",
+                "citizen-names": "Briton;British citizen"
+            }]
+        }
+    }
+
+    GG_TERRITORY_JSON = {
+        "GG": {
+            "index-entry-number": "35",
+            "entry-number": "35",
+            "entry-timestamp": "2016-12-15T12:15:07Z",
+            "key": "GG",
+            "item": [{
+                "official-name": "Bailiwick of Guernsey",
+                "name": "Guernsey",
+                "territory": "GG"
+            }]
+        }
+    }
+
+    def setup(self):
+        country_code_to_name.cache_clear()
+
+    @pytest.mark.parametrize('full_code, expected_url, response, expected_name',
+                             (
+                                 ('country:GB', 'https://country.register.gov.uk/records/GB.json',
+                                  GB_COUNTRY_JSON, 'United Kingdom'),
+                                 ('territory:GG', 'https://territory.register.gov.uk/records/GG.json',
+                                  GG_TERRITORY_JSON, 'Guernsey'),
+                             ))
+    def test_correct_url_requested_and_code_converted_to_name(self, rmock, full_code, expected_url, response,
+                                                              expected_name):
+        rmock.get(
+            expected_url,
+            json=response,
+            status_code=200
+        )
+
+        country_name = country_code_to_name(full_code)
+
+        assert country_name == expected_name
+
+    def test_404_raises(self, rmock):
+        rmock.get(
+            'https://country.register.gov.uk/records/GB.json',
+            status_code=404,
+        )
+
+        with pytest.raises(requests.exceptions.RequestException):
+            country_code_to_name('country:GB')
+
+    def test_responses_are_cached(self, rmock):
+        rmock.get(
+            'https://country.register.gov.uk/records/GB.json',
+            json=self.GB_COUNTRY_JSON,
+            status_code=200
+        )
+
+        country_code_to_name('country:GB')
+        country_code_to_name('country:GB')
+
+        assert len(rmock.request_history) == 1
+        assert country_code_to_name.cache_info().hits == 1
+        assert country_code_to_name.cache_info().misses == 1
+        assert country_code_to_name.cache_info().maxsize == 128
+
+    def test_retries_if_not_200(self, rmock):
+        rmock.get(
+            'https://country.register.gov.uk/records/GB.json',
+            [{'json': {}, 'status_code': 500},
+             {'json': self.GB_COUNTRY_JSON, 'status_code': 200}],
+        )
+
+        country_name = country_code_to_name('country:GB')
+
+        assert country_name == 'United Kingdom'
+        assert len(rmock.request_history) == 2


### PR DESCRIPTION
 ## Summary
We store supplier country details in the database as country codes that
relate to a Country or Territory Register. These are not intended for
human consumption, so we should convert these back to the proper
representation of the country (e.g. `country:GB` -> `United Kingdom`),
otherwise we need to do this manually before sharing the data with our
partners (e.g. CCS).

 ## Ticket
https://trello.com/c/bx6MXS0V/173