### PR TITLE
208 delete users code that takes the user and strips all the personal data out

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,7 +3,7 @@
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.1.0#egg=digitalmarketplace-utils==39.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.3.0#egg=digitalmarketplace-apiclient==15.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.4.1#egg=digitalmarketplace-apiclient==16.4.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.1.0#egg=digitalmarketplace-utils==39.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.3.0#egg=digitalmarketplace-apiclient==15.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.4.1#egg=digitalmarketplace-apiclient==16.4.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
 

--- a/scripts/data-retention-remove-contact-information-data.py
+++ b/scripts/data-retention-remove-contact-information-data.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""
+Our data retention policy is that suppliers with no users that still have personal data should have the personal data
+stripped from their contact details.
+
+This script is very simple and has not been upgraded to accept any arguments to prevent the possibility of accidental
+deletion. If you are in doubt use the dry run option.
+
+Usage: data-retention-remove-contact-information-data.py <stage> [--dry-run] [--verbose]
+
+Options:
+    --stage=<stage>                                       Stage to target
+
+    --dry-run                                             List account that would have data stripped
+    --verbose
+    -h, --help                                            Show this screen
+
+Examples:
+    ./scripts/data-retention-remove-contact-information-data.py preview
+    ./scripts/data-retention-remove-contact-information-data.py preview --dry-run --verbose
+
+"""
+import logging
+import sys
+from docopt import docopt
+from itertools import groupby
+from dmapiclient import DataAPIClient
+from datetime import datetime
+
+sys.path.insert(0, '.')
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
+from dmscripts.helpers import logging_helpers
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    # Get script arguments
+    stage = arguments['<stage>']
+
+    dry_run = arguments['--dry-run']
+    verbose = arguments['--verbose']
+
+    # Set defaults, instantiate clients
+    prefix = '[DRY RUN]: ' if dry_run else ''
+    logger = logging_helpers.configure_logger(
+        {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
+    )
+    data_api_client = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(stage),
+        auth_token=get_auth_token('api', stage)
+    )
+
+    users = sorted(
+        data_api_client.find_users_iter(role='supplier', personal_data_removed=True),
+        key=lambda i: i['supplier']['supplierId']
+    )
+    users_by_supplier_id = groupby(users, lambda i: i['supplier']['supplierId'])
+
+    for supplier_id, users in users_by_supplier_id:
+        if all(user['personalDataRemoved'] for user in users):
+            supplier = data_api_client.get_supplier(supplier_id)['suppliers']
+            for contact_information in supplier['contactInformation']:
+                if not contact_information['personalDataRemoved']:
+
+                    logger.warn("""{}Removing contact information #{} data for supplier {}""".format(
+                        prefix,
+                        contact_information['id'],
+                        supplier_id)
+                    )
+                    if not dry_run:
+                        data_api_client.remove_contact_information_personal_data(
+                            supplier['id'],
+                            contact_information['id'],
+                            'Data Retention Script {}'.format(datetime.now().isoformat())
+                        )

--- a/scripts/data-retention-remove-user-data.py
+++ b/scripts/data-retention-remove-user-data.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""
+Our data retention policy is that users have accounts deactivated and personal data stripped after 3 years without
+a login.
+
+This script is very simple and has not been upgraded to accept any arguments to prevent the possibility of accidental
+deletion. If you are in doubt use the dry run option.
+
+Usage: data-retention-remove-user-data.py <stage> [--dry-run] [--verbose]
+
+Options:
+    --stage=<stage>                                       Stage to target
+
+    --dry-run                                             List account that would have data stripped
+    --verbose
+    -h, --help                                            Show this screen
+
+Examples:
+    ./scripts/data-retention-remove-user-data.py preview
+    ./scripts/data-retention-remove-user-data.py preview --dry-run --verbose
+
+"""
+import logging
+import sys
+from datetime import datetime, timedelta
+from docopt import docopt
+
+from dmapiclient import DataAPIClient
+
+sys.path.insert(0, '.')
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
+from dmscripts.helpers import logging_helpers
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    # Get script arguments
+    stage = arguments['<stage>']
+
+    dry_run = arguments['--dry-run']
+    verbose = arguments['--verbose']
+
+    # Set defaults, instantiate clients
+    prefix = '[DRY RUN]: ' if dry_run else ''
+    logger = logging_helpers.configure_logger(
+        {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
+    )
+    data_api_client = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(stage),
+        auth_token=get_auth_token('api', stage)
+    )
+    cutoff_date = datetime.now() - timedelta(days=365 * 3)
+
+    all_users = list(data_api_client.find_users_iter(personal_data_removed=False))
+
+    for user in all_users:
+        last_logged_in_at = datetime.strptime(user['loggedInAt'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        if last_logged_in_at < cutoff_date and not user['personalDataRemoved']:
+            logger.warn(
+                f"{prefix}Removing personal data for user: {user['id']}"
+            )
+            if not dry_run:
+                data_api_client.remove_user_personal_data(
+                    user['id'],
+                    'Data Retention Script {}'.format(datetime.now().isoformat())
+                )


### PR DESCRIPTION
** Requires alphagov/digitalmarketplace-apiclient#142 **
** Requires https://github.com/alphagov/digitalmarketplace-api/pull/802 **

* Brings in new `apiclient` version
* Adds `scripts/data-retention-remove-user-data.py`
  * If the users last login was greater than 3 * 365 days ago then remove the personal data using the `apiclient` methods that use the new `api` views
  * verbosity and dryrun options
* Adds `scripts/data-retention-remove-contact-information-data.py`
  * If all users of a supplier have had their personal data removed then remove the personal data from that supplier