### PR TITLE
Rename `make-<framework-family>-live` scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ The `scripts` folder in this repository contains scripts that interact with the 
   a framework and posts to the API to set the `on_framework` value in the
   `supplier_frameworks` table.
 
-* `make-dos-live.py`
+* `publish-dos-draft-services.py`
   For a DOS-style framework (with no documents to migrate) this will make draft services for suppliers "on framework"
   into real services.
 
-* `make-g-cloud-live.py`
+* `publish-g-cloud-draft-services.py`
   For a G-Cloud-style framework (with documents to migrate) this will make draft services for suppliers "on framework"
   into real services.
 

--- a/scripts/publish-dos-draft-services.py
+++ b/scripts/publish-dos-draft-services.py
@@ -6,7 +6,7 @@ For a DOS-style framework (with no documents to migrate) this will:
  3. Migrate these from drafts to "real" services
 
 Usage:
-    scripts/make-dos-live.py <framework_slug> <stage> <api_token> [--dry-run]
+    scripts/publish-dos-draft-services.py <framework_slug> <stage> <api_token> [--dry-run]
 """
 import sys
 sys.path.insert(0, '.')
@@ -23,7 +23,7 @@ def make_draft_service_live(client, draft, dry_run):
         print("    > no-op")
     else:
         try:
-            services = client.publish_draft_service(draft['id'], "make dos live script")
+            services = client.publish_draft_service(draft['id'], "publish dos draft services script")
             service_id = services['services']['id']
             print(u"    > draft service published - new service ID {}".format(service_id))
         except Exception as e:

--- a/scripts/publish-g-cloud-draft-services.py
+++ b/scripts/publish-g-cloud-draft-services.py
@@ -13,7 +13,7 @@ For a G-Cloud style framework (with uploaded documents to migrate) this will:
  3. Migrate these from drafts to "real" services, which includes moving documents to the live documents bucket
     and updating document URLs in the migrated version of the services
 Usage:
-    scripts/make-g-cloud-live.py <framework_slug> <stage> <api_token> <draft_bucket> <documents_bucket> [--dry-run]
+    scripts/publish-g-cloud-draft-services.py <framework_slug> <stage> <api_token> <draft_bucket> <documents_bucket> [--dry-run]
 """
 import backoff
 import collections
@@ -97,7 +97,7 @@ def make_draft_service_live(client, copy_document, draft_service, framework_slug
         service_id = random.randint(1000, 10000)
         print("    > dry run: generating random test service ID: {}".format(service_id))
     else:
-        services = client.publish_draft_service(draft_service['id'], 'make-g-cloud-live script')
+        services = client.publish_draft_service(draft_service['id'], 'publish g-cloud draft services script')
         service_id = services['services']['id']
         print("    > draft service published - new service ID {}".format(service_id))
 


### PR DESCRIPTION
The script names were a little confusing and implied that they actually
made the framework 'live'. They actually just promote draft-services
into "real" services.