### PR TITLE
Acknowledge draft service updates

### DIFF
--- a/scripts/oneoff/acknowledge_publish_draft_service_updates.py
+++ b/scripts/oneoff/acknowledge_publish_draft_service_updates.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import argparse
+import backoff
+import multiprocessing as mp
+from multiprocessing.pool import ThreadPool
+import sys
+
+from dmapiclient import HTTPError
+from dmapiclient.audit import AuditTypes
+from dmapiclient.data import DataAPIClient
+
+sys.path.insert(0, '.')  # noqa
+
+from dmscripts.helpers.auth_helpers import get_api_url, get_auth_token
+
+
+ACKNOWLEDGE_USER = 'scripts/oneoff/acknowledge_publish_draft_service_updates.py'
+
+
+@backoff.on_exception(backoff.expo, HTTPError, max_tries=5)
+def acknowledge_update(audit_event):
+    response = data.acknowledge_audit_event(audit_event['id'], user=ACKNOWLEDGE_USER)['auditEvents']
+    print(f'Acknowledged {audit_event["id"]} on service id #{audit_event["data"]["serviceId"]} by '
+          f'supplier `{audit_event["data"]["supplierName"]}`: {response["acknowledged"]}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('stage', default='development', choices=['development', 'preview', 'staging', 'production'],
+                        help="Which stage's API to communicate with.")
+    parser.add_argument('date', type=str, help='The date on which the updates occurred, used to filter audit events '
+                                               '(YYYY-MM-DD).')
+    args = parser.parse_args()
+
+    data = DataAPIClient(get_api_url('api', args.stage), get_auth_token('api', args.stage))
+
+    audit_events = data.find_audit_events_iter(audit_type=AuditTypes.update_service,
+                                               user='Moving documents to live bucket',
+                                               audit_date=args.date,
+                                               acknowledged='false')
+
+    # Need to slurp them all into memory, or the ThreadPool loses track of some of them.
+    print('Retrieving audit events ...')
+    audit_events = [audit_event for audit_event in audit_events]
+
+    # Significantly IO bound, so use threads - and no reason not to use plenty of them.
+    pool = ThreadPool(processes=mp.cpu_count() * 2)
+
+    count = 0
+    for x in pool.imap(acknowledge_update, audit_events):
+        count += 1
+
+    pool.close()
+    pool.join()
+
+    print(f'All done - acknowledged {count} audit events')


### PR DESCRIPTION
 ## Summary
When moving G-Cloud 10 services from drafts to 'published', we generate
a lot of `update_service` audit events. We have an admin page that
allows CCS to review and acknowledge `update_service` audit events, but
this is only intended for services which are currently live (i.e. the
framework is open). Service changes from the script which promotes the
drafts, `publish-g-cloud-draft-services.py` (and
`publish-dos-draft-services.py`) should not need to be acknowledged by
CCS.

This script will go through and acknowledge all audit events created by
the publishing scripts.