### PR TITLE
Ignore s3 key already exists

### DIFF
--- a/scripts/publish-g-cloud-draft-services.py
+++ b/scripts/publish-g-cloud-draft-services.py
@@ -107,7 +107,13 @@ def copy_draft_documents(client, copy_document, draft_service, framework_slug, d
             draft_document_path = get_draft_document_path(parsed_document, framework_slug)
             live_document_path = get_live_document_path(parsed_document, framework_slug, service_id)
 
-            copy_document(draft_document_path, live_document_path)
+            try:
+                copy_document(draft_document_path, live_document_path)
+
+            except S3ResponseError as e:
+                if str(e) != 'Target key already exists in S3':
+                    raise e
+
             document_updates[document_key] = get_live_asset_url(live_document_path)
 
     if dry_run:


### PR DESCRIPTION
 ## Summary
If the document has already been copied across for a service, ignore the
error and continue - in case other documents haven't been copied across.