### PR TITLE
Remove code that relies on sops/credentials repo

### DIFF
--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -1,6 +1,4 @@
 import os
-import subprocess
-import yaml
 
 DEV_ALIASES = ('dev', 'development', 'local')
 
@@ -12,18 +10,13 @@ def get_auth_token(api, stage):
     env_var_api_name = 'data-api' if api == 'api' else api
     env_var_api_name = env_var_api_name.replace('-', '_')
     env_var = "DM_{}_TOKEN_{}".format(env_var_api_name.upper(), stage.upper())
-    auth_token = os.environ.get(env_var)
 
-    if not auth_token:
-        DM_CREDENTIALS_REPO = os.environ.get('DM_CREDENTIALS_REPO', '../digitalmarketplace-credentials')
-        token_prefix = 'J' if subprocess.check_output(["whoami"]) == 'jenkins' else 'D'
-        creds = subprocess.check_output([
-            "{}/sops-wrapper".format(DM_CREDENTIALS_REPO),
-            "-d",
-            "{}/vars/{}.yaml".format(DM_CREDENTIALS_REPO, stage)
-        ])
-        auth_tokens = yaml.safe_load(creds)[api]['auth_tokens']
-        auth_token = next(token for token in auth_tokens if token.startswith(token_prefix))
+    try:
+        auth_token = os.environ[env_var]
+    except KeyError:
+        raise RuntimeError(
+            "Unable to find api token in environment."
+            " Please ensure that ${} has been exported correctly.".format(env_var))
 
     return auth_token
 


### PR DESCRIPTION
When running scripts in Docker, the credentials repo and SOPS are not available.

If the user forgets to expose the api token environment variable (like I did, today 😱), they will get confusing errors about SOPS not being available, when really the error should be that the api token is not available in the environment.

As we are going to be running scripts in Docker from now on, this sops code is dead, and so I have replaced it with a helpful error message.