### PR TITLE
Use framework.family instead of frameworkFramework

### DIFF
--- a/dmscripts/notify_suppliers_of_brief_withdrawal.py
+++ b/dmscripts/notify_suppliers_of_brief_withdrawal.py
@@ -13,7 +13,7 @@ def create_context_for_brief(stage, brief):
         'brief_title': brief['title'],
         'brief_link': '{}/{}/opportunities/{}'.format(
             env_helpers.get_web_url_from_stage(stage),
-            brief['frameworkFramework'],
+            brief['framework']['family'],
             brief['id']
         )
     }

--- a/dmscripts/notify_suppliers_of_new_questions_answers.py
+++ b/dmscripts/notify_suppliers_of_new_questions_answers.py
@@ -74,7 +74,7 @@ def create_context_for_supplier(stage, supplier_briefs):
                 'brief_title': brief['title'],
                 'brief_link': '{0}/{1}/opportunities/{2}?utm_id={3}qa'.format(
                     env_helpers.get_web_url_from_stage(stage),
-                    brief['frameworkFramework'], brief['id'],
+                    brief['framework']['family'], brief['id'],
                     datetime.utcnow().strftime("%Y%m%d")
                 )
             } for brief in supplier_briefs

--- a/tests/test_notify_suppliers_of_brief_withdrawal.py
+++ b/tests/test_notify_suppliers_of_brief_withdrawal.py
@@ -9,13 +9,13 @@ WITHDRAWN_BRIEFS = (
         "id": 123,
         "withdrawnAt": "2016-01-28 16:23:50.618053",
         "title": "Tea Drinker",
-        "frameworkFramework": "digital-outcomes-and-specialists"
+        'framework': {'family': 'digital-outcomes-and-specialists'},
     },
     {
         "id": 235,
         "withdrawnAt": "2016-01-28 08:23:50.618053",
         "title": "Cookie Muncher",
-        "frameworkFramework": "digital-outcomes-and-specialists"
+        'framework': {'family': 'digital-outcomes-and-specialists'},
     }
 )
 

--- a/tests/test_notify_suppliers_of_new_questions_answers.py
+++ b/tests/test_notify_suppliers_of_new_questions_answers.py
@@ -38,19 +38,19 @@ ALL_BRIEFS = [
     # a brief with a question inside of the date range
     {"id": 3, "clarificationQuestions": [
         {"publishedAt": "2017-03-23T06:00:00.669156Z"}
-    ], 'title': 'Amazing Title', 'frameworkFramework': 'digital-outcomes-and-specialists'},
+    ], 'title': 'Amazing Title', 'framework': {'family': 'digital-outcomes-and-specialists'}},
 
     # a brief with two questions inside of the date range
     {"id": 4, "clarificationQuestions": [
         {"publishedAt": "2017-03-22T18:00:00.669156Z"},
         {"publishedAt": "2017-03-23T06:00:00.669156Z"}
-    ], 'title': 'Brilliant Title', 'frameworkFramework': 'digital-outcomes-and-specialists'},
+    ], 'title': 'Brilliant Title', 'framework': {'family': 'digital-outcomes-and-specialists'}},
 
     # a brief with two questions, one of them outside the range and one inside the range
     {"id": 5, "clarificationQuestions": [
         {"publishedAt": "2017-03-22T06:00:00.669156Z"},
         {"publishedAt": "2017-03-23T06:00:00.669156Z"}
-    ], 'title': 'Confounded Title', 'frameworkFramework': 'digital-outcomes-and-specialists'},
+    ], 'title': 'Confounded Title', 'framework': {'family': 'digital-outcomes-and-specialists'}},
 
     # a brief with questions over the weekend
     {"id": 6, "clarificationQuestions": [


### PR DESCRIPTION
Trello: https://trello.com/c/R3DsCXFa/22-use-frameworkfamily-frameworkfamily-in-apps-apiclient-rather-than-frameworkframework-frameworkframework

Two scripts updated to use the nested `framework.family` instead of `frameworkFramework`.