### PR TITLE
Convert scripts to use environment var for api token

### DIFF
--- a/scripts/notify-buyers-when-requirements-close.py
+++ b/scripts/notify-buyers-when-requirements-close.py
@@ -3,8 +3,7 @@
 """Send email notifications to buyer users about closed requirements.
 
 Usage:
-    notify-buyers-when-requirements-close.py <stage> --api-token=<api_access_token>
-                                                     --email-api-key=<email_api_key> [options]
+    notify-buyers-when-requirements-close.py <stage> --email-api-key=<email_api_key> [options]
 
     --date-closed=<date>  Notify about requirements that closed on the given date (date format: YYYY-MM-DD)
     --dry-run  List notifications that would be sent without sending the emails
@@ -17,6 +16,7 @@ from docopt import docopt
 
 sys.path.insert(0, '.')
 from dmscripts.helpers.env_helpers import get_api_endpoint_from_stage
+from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.notify_buyers_when_requirements_close import main
 
 
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     arguments = docopt(__doc__)
     ok = main(
         data_api_url=get_api_endpoint_from_stage(arguments['<stage>'], 'api'),
-        data_api_access_token=arguments['--api-token'],
+        data_api_access_token=get_auth_token('api', arguments['<stage>']),
         email_api_key=arguments['--email-api-key'],
         date_closed=arguments['--date-closed'],
         dry_run=arguments['--dry-run']


### PR DESCRIPTION
Trello: https://trello.com/c/XJEqu5gI/15-spike-audit-tokens-used-by-jenkins-jobs

Use the `get_auth_token` helper to fetch the API token for the relevant stage. 

**Do not merge yet** as the corresponding Jenkins job needs to be updated first to remove the old argument (see https://github.com/alphagov/digitalmarketplace-jenkins/pull/106).