### PR TITLE
Revert "Remove code that relies on sops/credentials repo"

### DIFF
--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import yaml
 
 DEV_ALIASES = ('dev', 'development', 'local')
 
@@ -10,13 +12,18 @@ def get_auth_token(api, stage):
     env_var_api_name = 'data-api' if api == 'api' else api
     env_var_api_name = env_var_api_name.replace('-', '_')
     env_var = "DM_{}_TOKEN_{}".format(env_var_api_name.upper(), stage.upper())
+    auth_token = os.environ.get(env_var)
 
-    try:
-        auth_token = os.environ[env_var]
-    except KeyError:
-        raise RuntimeError(
-            "Unable to find api token in environment."
-            " Please ensure that ${} has been exported correctly.".format(env_var))
+    if not auth_token:
+        DM_CREDENTIALS_REPO = os.environ.get('DM_CREDENTIALS_REPO', '../digitalmarketplace-credentials')
+        token_prefix = 'J' if subprocess.check_output(["whoami"]) == 'jenkins' else 'D'
+        creds = subprocess.check_output([
+            "{}/sops-wrapper".format(DM_CREDENTIALS_REPO),
+            "-d",
+            "{}/vars/{}.yaml".format(DM_CREDENTIALS_REPO, stage)
+        ])
+        auth_tokens = yaml.safe_load(creds)[api]['auth_tokens']
+        auth_token = next(token for token in auth_tokens if token.startswith(token_prefix))
 
     return auth_token
 


### PR DESCRIPTION
This reverts commit 3e7b1ae9c6bd4201bb6d40ce84e6983cb2358d42.

This code is used when running scripts locally, such as
`scripts/api-clients-shell.py` and `scripts/get-user.py`