### PR TITLE
Remove cyber fields for DOS3 from export applicants script

### DIFF
--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -117,8 +117,6 @@ DECLARATION_FIELDS = {
         "subcontracting",
         "contactNameContractNotice",
         "contactEmailContractNotice",
-        "cyberEssentials",
-        "cyberEssentialsPlus",
     ),
 }
 


### PR DESCRIPTION
These questions were not asked as part of the DOS3 declaration, and as
such should not be included. They just generate two empty columns.