### PR TITLE
Prevent github api token from being echoed in rotate api tokens script

### DIFF
--- a/scripts/rotate-api-tokens.sh
+++ b/scripts/rotate-api-tokens.sh
@@ -54,7 +54,7 @@ function commit_and_create_github_pr() {
   git config user.email "support@digitalmarketplace.service.gov.uk"
   git config user.name "dm-ssp-jenkins"
   git commit -a -m "$1" -m "$2"
-  git push origin "${GIT_CREDS_UPDATE_BRANCH_NAME}"
+  git push -q origin "${GIT_CREDS_UPDATE_BRANCH_NAME}"
   post_data="{\"title\": \"$1\", \"body\": \"$2\", \"base\": \"master\", \"head\": \"${GIT_CREDS_UPDATE_BRANCH_NAME}\"}"
   response_data=$(curl -XPOST -H "Accept: application/vnd.github.v3.full+json" -d "$post_data" "https://${GITHUB_ACCESS_TOKEN}@api.github.com/repos/alphagov/digitalmarketplace-credentials/pulls")
   echo "Created PR#$(echo "${response_data}" | jq -crM '.number') on alphagov/digitalmarketplace-credentials."


### PR DESCRIPTION
Ticket: https://trello.com/c/eBl3yUUT/27-jenkins-credentials-shown-in-plain-text-in-job-scripts-and-logs

rotate-api-tokens.sh uses a GitHub API token to get the digitalmarketplace-credentials repo; however when a push is made the token is echoed to the screen, which means it will end up in all sorts of logs.

This commit adds the quiet flag to the push so that it will only echo if there is an issue.

Note that this means the API token will be leaked if there is an issue with the push.