### PR TITLE
Update Dockerfile to use latest Python 3.6 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.1-slim
+FROM python:3.6-slim
 
 ENV APP_DIR /app
 


### PR DESCRIPTION
Change the base image to be the latest 3.6 image available in the official Python repository

Closes https://trello.com/c/clauyQUN/121-update-docker-base-image-for-digitalmarketplace-scripts