### PR TITLE
Add tests for indexing script

### DIFF
--- a/dmscripts/index_to_search_service.py
+++ b/dmscripts/index_to_search_service.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+from multiprocessing.pool import ThreadPool
+
+import backoff
+import dmapiclient
+from six.moves import map
+
+from dmscripts.helpers import logging_helpers
+from dmscripts.helpers.logging_helpers import logging
+
+logger = logging_helpers.configure_logger({"dmapiclient": logging.WARNING})
+
+
+def print_progress(counter, start_time):
+    if counter % 100 == 0:
+        time_delta = datetime.utcnow() - start_time
+        logger.info("{counter} in {time} ({rps}/s)", extra={
+            'counter': counter, 'time': time_delta, 'rps': counter / time_delta.total_seconds()
+        })
+
+
+class IndexerBase(object):
+    def __init__(self, document_type, data_client, search_client, index):
+        self.document_type = document_type
+        self.index = index
+        self.search_client = search_client
+        self.data_client = data_client
+
+    def create_index(self, mapping):
+        logger.info("Creating {index} index", extra={'index': self.index})
+
+        try:
+            result = self.search_client.create_index(self.index, mapping=mapping)
+            logger.info("Index creation response: {response}", extra={'response': result})
+        except dmapiclient.HTTPError as e:
+            if 'already exists as alias' in str(e.message):
+                logger.info("Skipping index creation for alias {index}", extra={'index': self.index})
+            else:
+                raise
+
+    def request_items(self, frameworks):
+        raise NotImplementedError()
+
+    def __call__(self, item):
+        try:
+            self.index_item(item)
+            return True
+        except dmapiclient.APIError:
+            logger.exception("{id} not indexed", extra={'id': item.get('id')})
+            return False
+
+    def include_in_index(self, item):
+        raise NotImplementedError()
+
+    @backoff.on_exception(backoff.expo, dmapiclient.HTTPError, max_tries=5)
+    def index_item(self, item):
+        if self.include_in_index(item):
+            self.search_client.index(self.index, item['id'], item, self.document_type)
+        else:
+            self.search_client.delete(self.index, item['id'])
+
+
+class BriefIndexer(IndexerBase):
+    def request_items(self, frameworks):
+        # despite the name, `framework` takes a string containing a comma-separated list of framework slugs
+        return self.data_client.find_briefs_iter(framework=frameworks)
+
+    def include_in_index(self, item):
+        # Even draft briefs will be in the index, for now at least
+        return True
+
+
+class ServiceIndexer(IndexerBase):
+    def request_items(self, frameworks):
+        # despite the name, frameworks takes a string containing a comma-separated list of framework slugs
+        return self.data_client.find_services_iter(framework=frameworks)
+
+    def include_in_index(self, item):
+        return item['status'] == 'published'
+
+
+indexers = {
+    'briefs': BriefIndexer,
+    'services': ServiceIndexer,
+}
+
+
+def do_index(doc_type, search_api_url, search_api_access_token, data_api_url, data_api_access_token, mapping, serial,
+             index, frameworks):
+    logger.info("Search API URL: {search_api_url}", extra={'search_api_url': search_api_url})
+    logger.info("Data API URL: {data_api_url}", extra={'data_api_url': data_api_url})
+
+    if serial:
+        mapper = map
+    else:
+        pool = ThreadPool(10)
+        mapper = pool.imap_unordered
+
+    indexer = indexers[doc_type](
+        doc_type,
+        dmapiclient.DataAPIClient(data_api_url, data_api_access_token),
+        dmapiclient.SearchAPIClient(search_api_url, search_api_access_token),
+        index)
+    if mapping:
+        indexer.create_index(mapping=mapping)
+
+    counter = 0
+    start_time = datetime.utcnow()
+    status = True
+    items = indexer.request_items(frameworks)
+    for result in mapper(indexer, items):
+        counter += 1
+        status = status and result
+        print_progress(counter, start_time)
+
+    return status

--- a/scripts/index-to-search-service.py
+++ b/scripts/index-to-search-service.py
@@ -31,127 +31,12 @@ Examples:
 """
 
 import sys
-from datetime import datetime
-from multiprocessing.pool import ThreadPool
-
-import backoff
-import dmapiclient
 from docopt import docopt
-from six.moves import map
-
 
 sys.path.insert(0, '.')
+from dmscripts.index_to_search_service import do_index
 from dmscripts.helpers.auth_helpers import get_auth_token
-from dmscripts.helpers import logging_helpers
-from dmscripts.helpers.logging_helpers import logging
 from dmutils.env_helpers import get_api_endpoint_from_stage
-
-logger = logging_helpers.configure_logger({"dmapiclient": logging.WARNING})
-
-
-def print_progress(counter, start_time):
-    if counter % 100 == 0:
-        time_delta = datetime.utcnow() - start_time
-        logger.info("{counter} in {time} ({rps}/s)", extra={
-            'counter': counter, 'time': time_delta, 'rps': counter / time_delta.total_seconds()
-        })
-
-
-class IndexerBase(object):
-    def __init__(self, document_type, data_client, search_client, index):
-        self.document_type = document_type
-        self.index = index
-        self.search_client = search_client
-        self.data_client = data_client
-
-    def create_index(self, mapping):
-        logger.info("Creating {index} index", extra={'index': self.index})
-
-        try:
-            result = self.search_client.create_index(self.index, mapping=mapping)
-            logger.info("Index creation response: {response}", extra={'response': result})
-        except dmapiclient.HTTPError as e:
-            if 'already exists as alias' in str(e.message):
-                logger.info("Skipping index creation for alias {index}", extra={'index': self.index})
-            else:
-                raise
-
-    def request_items(self, frameworks):
-        raise NotImplementedError()
-
-    def __call__(self, item):
-        try:
-            self.index_item(item)
-            return True
-        except dmapiclient.APIError:
-            logger.exception("{id} not indexed", extra={'id': item.get('id')})
-            return False
-
-    def include_in_index(self, item):
-        raise NotImplementedError()
-
-    @backoff.on_exception(backoff.expo, dmapiclient.HTTPError, max_tries=5)
-    def index_item(self, item):
-        if self.include_in_index(item):
-            self.search_client.index(self.index, item['id'], item, self.document_type)
-        else:
-            self.search_client.delete(self.index, item['id'])
-
-
-class BriefIndexer(IndexerBase):
-    def request_items(self, frameworks):
-        # despite the name, `framework` takes a string containing a comma-separated list of framework slugs
-        return self.data_client.find_briefs_iter(framework=frameworks)
-
-    def include_in_index(self, item):
-        # Even draft briefs will be in the index, for now at least
-        return True
-
-
-class ServiceIndexer(IndexerBase):
-    def request_items(self, frameworks):
-        # despite the name, frameworks takes a string containing a comma-separated list of framework slugs
-        return self.data_client.find_services_iter(framework=frameworks)
-
-    def include_in_index(self, item):
-        return item['status'] == 'published'
-
-
-indexers = {
-    'briefs': BriefIndexer,
-    'services': ServiceIndexer,
-}
-
-
-def do_index(doc_type, search_api_url, search_api_access_token, data_api_url, data_api_access_token, mapping, serial,
-             index, frameworks):
-    logger.info("Search API URL: {search_api_url}", extra={'search_api_url': search_api_url})
-    logger.info("Data API URL: {data_api_url}", extra={'data_api_url': data_api_url})
-
-    if serial:
-        mapper = map
-    else:
-        pool = ThreadPool(10)
-        mapper = pool.imap_unordered
-
-    indexer = indexers[doc_type](
-        doc_type,
-        dmapiclient.DataAPIClient(data_api_url, data_api_access_token),
-        dmapiclient.SearchAPIClient(search_api_url, search_api_access_token),
-        index)
-    if mapping:
-        indexer.create_index(mapping=mapping)
-
-    counter = 0
-    start_time = datetime.utcnow()
-    status = True
-    items = indexer.request_items(frameworks)
-    for result in mapper(indexer, items):
-        counter += 1
-        status = status and result
-        print_progress(counter, start_time)
-
-    return status
 
 
 if __name__ == "__main__":

--- a/tests/test_index_to_search_service.py
+++ b/tests/test_index_to_search_service.py
@@ -1,0 +1,168 @@
+import mock
+import pytest
+
+from dmapiclient import HTTPError
+from dmscripts.index_to_search_service import (
+    do_index, BriefIndexer, ServiceIndexer
+
+)
+
+
+class TestIndexers:
+
+    def setup(self):
+        # Ensure we don't make any real API calls
+        self.data_api_client_patch = mock.patch(
+            'dmscripts.index_to_search_service.dmapiclient.DataAPIClient', autospec=True
+        )
+        self.data_api_client = self.data_api_client_patch.start()
+        self.search_api_client_patch = mock.patch(
+            'dmscripts.index_to_search_service.dmapiclient.SearchAPIClient', autospec=True
+        )
+        self.search_api_client = self.search_api_client_patch.start()
+
+    def teardown(self):
+        self.data_api_client_patch.stop()
+        self.search_api_client_patch.stop()
+
+    def test_brief_indexer_creates_index(self):
+        indexer = BriefIndexer(
+            'briefs', self.data_api_client.return_value, self.search_api_client.return_value, 'myIndex'
+        )
+        indexer.create_index('myMapping')
+
+    def test_brief_indexer_skips_create_if_index_already_exists(self):
+        self.search_api_client.return_value.create_index.side_effect = HTTPError(
+            message='myIndex already exists as alias'
+        )
+        indexer = BriefIndexer(
+            'briefs', self.data_api_client.return_value, self.search_api_client.return_value, 'myIndex'
+        )
+        indexer.create_index('myMapping')
+
+    def test_brief_indexer_create_index_raises_on_other_api_errors(self):
+        self.search_api_client.return_value.create_index.side_effect = HTTPError('disaster')
+        indexer = BriefIndexer(
+            'briefs', self.data_api_client.return_value, self.search_api_client.return_value, 'myIndex'
+        )
+        with pytest.raises(HTTPError) as e:
+            indexer.create_index('myMapping')
+            assert e.message == 'disaster'
+
+    def test_brief_indexer_request_items_calls_data_api_client_with_frameworks(self):
+        self.data_api_client.return_value.find_briefs_iter.return_value = ['brief1', 'brief2']
+        indexer = BriefIndexer(
+            'briefs', self.data_api_client.return_value, self.search_api_client.return_value, 'myIndex'
+        )
+        assert indexer.request_items('framework1,framework2') == ['brief1', 'brief2']
+        assert self.data_api_client.return_value.find_briefs_iter.call_args_list == [
+            mock.call(framework='framework1,framework2')
+        ]
+
+    def test_service_indexer_request_items_calls_data_api_client_with_frameworks(self):
+        self.data_api_client.return_value.find_services_iter.return_value = ['service1', 'service2']
+        indexer = ServiceIndexer(
+            'services', self.data_api_client.return_value, self.search_api_client.return_value, 'myIndex'
+        )
+        assert indexer.request_items('framework1,framework2') == ['service1', 'service2']
+        assert self.data_api_client.return_value.find_services_iter.call_args_list == [
+            mock.call(framework='framework1,framework2')
+        ]
+
+    def test_brief_indexer_index_items_calls_search_api_client(self):
+        self.data_api_client.return_value.find_briefs_iter.return_value = ['brief1', 'brief2']
+        indexer = BriefIndexer(
+            'briefs', self.data_api_client.return_value, self.search_api_client.return_value, 'myIndex'
+        )
+        indexer.index_item({'id': 'newBrief'})
+        assert self.search_api_client.return_value.index.call_args_list == [
+            mock.call('myIndex', 'newBrief', {'id': 'newBrief'}, 'briefs')
+        ]
+
+    def test_service_indexer_index_items_calls_search_api_index_for_published_services(self):
+        self.data_api_client.return_value.find_services_iter.return_value = ['service1', 'service2']
+        indexer = ServiceIndexer(
+            'services', self.data_api_client.return_value, self.search_api_client.return_value, 'myIndex'
+        )
+
+        indexer.index_item({'id': 'newService', 'status': 'published'})
+        assert self.search_api_client.return_value.index.call_args_list == [
+            mock.call('myIndex', 'newService', {'id': 'newService', 'status': 'published'}, 'services')
+        ]
+
+    def test_service_indexer_index_items_calls_search_api_delete_for_published_services(self):
+        self.data_api_client.return_value.find_services_iter.return_value = ['service1', 'service2']
+        indexer = ServiceIndexer(
+            'services', self.data_api_client.return_value, self.search_api_client.return_value, 'myIndex'
+        )
+
+        indexer.index_item({'id': 'newService', 'status': 'removed'})
+        assert self.search_api_client.return_value.delete.call_args_list == [
+            mock.call('myIndex', 'newService')
+        ]
+
+    @mock.patch.object(BriefIndexer, '__init__', autospec=True)
+    @mock.patch.object(BriefIndexer, 'index_item', autospec=True)
+    @mock.patch.object(BriefIndexer, 'request_items', autospec=True)
+    def test_do_index_creates_brief_indexer_class_and_indexes_items(self, request_items, index_item, indexer_init):
+        indexer_init.return_value = None
+        request_items.return_value = ['brief1', 'brief2']
+        do_index(
+            'briefs',
+            "http://search-api-url", "mySearchAPIToken",
+            "http://data-api-url", "myDataAPIToken",
+            mapping=False,
+            serial=True,  # don't run in parallel for testing
+            index="myIndex",
+            frameworks="framework1,framework2"
+        )
+
+        assert indexer_init.call_args_list == [
+            mock.call(
+                mock.ANY, 'briefs', self.data_api_client.return_value, self.search_api_client.return_value, 'myIndex'
+            )
+        ]
+        # Both API clients initialised when the BriefIndexer instance is created
+        assert self.data_api_client.call_args_list == [mock.call('http://data-api-url', 'myDataAPIToken')]
+        assert self.search_api_client.call_args_list == [mock.call('http://search-api-url', 'mySearchAPIToken')]
+
+        assert request_items.call_args_list == [
+            mock.call(mock.ANY, "framework1,framework2")
+        ]
+        assert index_item.call_args_list == [
+            mock.call(mock.ANY, 'brief1'),
+            mock.call(mock.ANY, 'brief2'),
+        ]
+
+    @mock.patch.object(ServiceIndexer, '__init__', autospec=True)
+    @mock.patch.object(ServiceIndexer, 'index_item', autospec=True)
+    @mock.patch.object(ServiceIndexer, 'request_items', autospec=True)
+    def test_do_index_creates_service_indexer_class_and_indexes_items(self, request_items, index_item, indexer_init):
+        indexer_init.return_value = None
+        request_items.return_value = ['service1', 'service2']
+        do_index(
+            'services',
+            "http://search-api-url", "mySearchAPIToken",
+            "http://data-api-url", "myDataAPIToken",
+            mapping=False,
+            serial=True,  # don't run in parallel for testing
+            index="myIndex",
+            frameworks="framework1,framework2"
+        )
+
+        assert indexer_init.call_args_list == [
+            mock.call(
+                mock.ANY, 'services', self.data_api_client.return_value, self.search_api_client.return_value, 'myIndex'
+            )
+        ]
+        # Both API clients initialised when the BriefIndexer instance is created
+        assert self.data_api_client.call_args_list == [mock.call('http://data-api-url', 'myDataAPIToken')]
+        assert self.search_api_client.call_args_list == [mock.call('http://search-api-url', 'mySearchAPIToken')]
+
+        assert request_items.call_args_list == [
+            mock.call(mock.ANY, "framework1,framework2")
+        ]
+        assert index_item.call_args_list == [
+            mock.call(mock.ANY, 'service1'),
+            mock.call(mock.ANY, 'service2'),
+        ]


### PR DESCRIPTION
Prep for https://trello.com/c/KzDlJAcH/125-prevent-indexing-script-using-wrong-mapping-file

Our main indexing script is untested 🙀. This PR should have no functional changes at all. I've run it locally for briefs and services and it seems fine, but not against Preview yet. Perhaps you, the reviewer, would like to give it a go...

- Moves logic out of top level script
- Adds tests for `do_index` (the main function) and the major class methods
- Some weird patching of the two API clients was needed as *I didn't want to change the code or the docopt stuff at all*. Normally in scripts we initialise the clients at the top level then pass the instance through to the script function, but here we initialise within the script function itself. So instead of just using a mock object as the client instance, we have to patch the class and use `data_api_client.return_value`. Hopefully this is only temporary as this script is going to get refactored to be like the others soon... right?