### PR TITLE
Check mapping dict for matching framework before creating index

### DIFF
--- a/dmscripts/index_to_search_service.py
+++ b/dmscripts/index_to_search_service.py
@@ -85,6 +85,24 @@ indexers = {
 }
 
 
+# Hardcoded for now as we are unlikely to add new frameworks in the near future
+FRAMEWORK_MAPPINGS = {
+    'g-cloud-9': 'services',
+    'g-cloud-10': 'services-g-cloud-10',
+    'digital-outcomes-and-specialists': 'briefs-digital-outcomes-and-specialists-2',
+    'digital-outcomes-and-specialists-2': 'briefs-digital-outcomes-and-specialists-2',
+    'digital-outcomes-and-specialists-3': 'briefs-digital-outcomes-and-specialists-2',
+}
+
+
+def search_mapping_matches_framework(mapping_name, frameworks):
+    # Check that the mapping has been generated from at least one of the frameworks given in
+    # the comma-separated list
+    if mapping_name:
+        return any(mapping_name == FRAMEWORK_MAPPINGS[fw] for fw in frameworks.split(','))
+    return False
+
+
 def do_index(doc_type, search_api_url, search_api_access_token, data_api_url, data_api_access_token, mapping, serial,
              index, frameworks):
     logger.info("Search API URL: {search_api_url}", extra={'search_api_url': search_api_url})
@@ -101,7 +119,7 @@ def do_index(doc_type, search_api_url, search_api_access_token, data_api_url, da
         dmapiclient.DataAPIClient(data_api_url, data_api_access_token),
         dmapiclient.SearchAPIClient(search_api_url, search_api_access_token),
         index)
-    if mapping:
+    if search_mapping_matches_framework(mapping, frameworks):
         indexer.create_index(mapping=mapping)
 
     counter = 0

--- a/dmscripts/index_to_search_service.py
+++ b/dmscripts/index_to_search_service.py
@@ -98,9 +98,9 @@ FRAMEWORK_MAPPINGS = {
 def search_mapping_matches_framework(mapping_name, frameworks):
     # Check that the mapping has been generated from at least one of the frameworks given in
     # the comma-separated list
-    if mapping_name:
-        return any(mapping_name == FRAMEWORK_MAPPINGS[fw] for fw in frameworks.split(','))
-    return False
+    if any(mapping_name == FRAMEWORK_MAPPINGS[fw] for fw in frameworks.split(',')):
+        return True
+    raise ValueError("Incorrect mapping '{}' for the supplied framework(s): {}".format(mapping_name, frameworks))
 
 
 def do_index(doc_type, search_api_url, search_api_access_token, data_api_url, data_api_access_token, mapping, serial,
@@ -119,7 +119,7 @@ def do_index(doc_type, search_api_url, search_api_access_token, data_api_url, da
         dmapiclient.DataAPIClient(data_api_url, data_api_access_token),
         dmapiclient.SearchAPIClient(search_api_url, search_api_access_token),
         index)
-    if search_mapping_matches_framework(mapping, frameworks):
+    if mapping and search_mapping_matches_framework(mapping, frameworks):
         indexer.create_index(mapping=mapping)
 
     counter = 0

--- a/tests/test_index_to_search_service.py
+++ b/tests/test_index_to_search_service.py
@@ -166,3 +166,35 @@ class TestIndexers:
             mock.call(mock.ANY, 'service1'),
             mock.call(mock.ANY, 'service2'),
         ]
+
+    @mock.patch.object(ServiceIndexer, 'create_index', autospec=True)
+    def test_do_index_creates_new_index_from_services_mapping(self, create_index):
+        do_index(
+            'services',
+            "http://search-api-url", "mySearchAPIToken",
+            "http://data-api-url", "myDataAPIToken",
+            mapping='services-g-cloud-10',
+            serial=True,  # don't run in parallel for testing
+            index="my-new-g-cloud-10-index",
+            frameworks="g-cloud-10"
+        )
+
+        assert create_index.call_args_list == [
+            mock.call(mock.ANY, mapping='services-g-cloud-10')
+        ]
+
+    @mock.patch.object(BriefIndexer, 'create_index', autospec=True)
+    def test_do_index_creates_new_index_from_briefs_mapping(self, create_index):
+        do_index(
+            'briefs',
+            "http://search-api-url", "mySearchAPIToken",
+            "http://data-api-url", "myDataAPIToken",
+            mapping='briefs-digital-outcomes-and-specialists-2',
+            serial=True,  # don't run in parallel for testing
+            index="my-new-dos-index",
+            frameworks="digital-outcomes-and-specialists,digital-outcomes-and-specialists-2"
+        )
+
+        assert create_index.call_args_list == [
+            mock.call(mock.ANY, mapping='briefs-digital-outcomes-and-specialists-2')
+        ]

--- a/tests/test_index_to_search_service.py
+++ b/tests/test_index_to_search_service.py
@@ -198,3 +198,20 @@ class TestIndexers:
         assert create_index.call_args_list == [
             mock.call(mock.ANY, mapping='briefs-digital-outcomes-and-specialists-2')
         ]
+
+    @mock.patch.object(ServiceIndexer, 'create_index', autospec=True)
+    def test_incorrect_mapping_for_framework_raises_error(self, create_index):
+        with pytest.raises(ValueError) as e:
+            do_index(
+                'services',
+                "http://search-api-url", "mySearchAPIToken",
+                "http://data-api-url", "myDataAPIToken",
+                mapping='services',
+                serial=True,  # don't run in parallel for testing
+                index="my-new-g-cloud-10-index",
+                frameworks="g-cloud-10"
+            )
+
+        assert str(e.value) == "Incorrect mapping 'services' for the supplied framework(s): g-cloud-10"
+
+        assert create_index.call_args_list == []


### PR DESCRIPTION
Trello: https://trello.com/c/KzDlJAcH/125-prevent-indexing-script-using-wrong-mapping-file

The aim: to sanity check that we're using the right mapping file when creating an index for a framework.

The problem: as the index doesn't exist yet, we don't 'know' what mapping to use. 

The compromise: given we are unlikely to support frameworks other than G-Cloud/DOS in the near future, we can hardcode a dictionary of frameworks and their mappings for now. We can manually look at the Search API's `/g-cloud-10` or `/briefs-digital-outcomes-and-specialists` endpoints (see https://github.com/alphagov/digitalmarketplace-search-api/pull/163) to sanity check what mapping was used to create those indexes.