### PR TITLE
Handle multiple email addresses in Notify suppliers of awarded briefs script

### DIFF
--- a/dmscripts/notify_suppliers_of_awarded_briefs.py
+++ b/dmscripts/notify_suppliers_of_awarded_briefs.py
@@ -58,8 +58,6 @@ def _build_and_send_emails(brief_responses, mail_client, stage, dry_run, templat
         # Although we don't officially support it, in some cases users
         # have multiple email addresses in their respondToEmailAddress field
         email_addresses = get_email_addresses(brief_response["respondToEmailAddress"])
-        if not email_addresses:
-            continue
 
         invalid_email_addresses = [a for a in email_addresses if not validate_email_address(a)]
         if invalid_email_addresses:
@@ -71,6 +69,18 @@ def _build_and_send_emails(brief_responses, mail_client, stage, dry_run, templat
                 }
             )
             failed_brief_responses.append(brief_response['id'])
+
+        for invalid_email_address in invalid_email_addresses:
+            email_addresses.remove(invalid_email_address)
+
+        if not email_addresses:
+            logger.error(
+                "No valid email address(es) for BriefResponse {brief_response_id} (Brief ID {brief_id})",
+                extra={
+                    "brief_id": brief_response['brief']['id'],
+                    "brief_response_id": brief_response['id'],
+                }
+            )
             continue
 
         brief_email_context = _create_context_for_brief(stage, brief_response['brief'])

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,11 +1,10 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.10.1
-git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
+Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@41.2.1#egg=digitalmarketplace-utils==41.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.2.0#egg=digitalmarketplace-utils==43.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.4.1#egg=digitalmarketplace-apiclient==16.4.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,10 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.10.1
-git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
+Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@41.2.1#egg=digitalmarketplace-utils==41.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.2.0#egg=digitalmarketplace-utils==43.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.4.1#egg=digitalmarketplace-apiclient==16.4.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
@@ -27,9 +26,10 @@ yq==2.4.1
 asn1crypto==0.24.0
 boto3==1.4.8
 botocore==1.8.35
-certifi==2018.4.16
+certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4
+click==6.7
 colorama==0.3.7
 contextlib2==0.4.0
 cryptography==2.3
@@ -48,7 +48,7 @@ mandrill==1.0.57
 Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
-numpy==1.15.0
+numpy==1.15.1
 odfpy==1.3.6
 pyasn1==0.4.4
 pycparser==2.18


### PR DESCRIPTION
In some cases users have multiple email addresses in their respondToEmailAddress field.

This causes errors in the "Notify suppliers of awarded briefs" script (see [this ticket](https://trello.com/c/DHDgBuns)).

This PR adds a limited ability to handle strings where there are multiple email addresses separated by a character such as `;` or `/`.

See alphagov/digitalmarketplace-utils#450 for more details on the helper functions used.

This PR only modifies the one script, as that is the only one I've seen having this error. We can extend it to other scripts with a little effort; unfortunately all the scripts seem to be written in slightly different ways without much reuse.

Additionally, I removed Flask-FeatureFlags from the requirements file as I upgraded to `dmutils 43.x.x`. I also upgraded Flask to the latest version as used in the frontend apps. I'm not clear on exactly why Flask is pinned in this repo, as it isn't used anywhere, but as @katstevens is away I've left it in until I can ask her about it (she added it in).