### PR TITLE
Add support for space as separator of multiple email addresses

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,7 @@
 Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@43.2.0#egg=digitalmarketplace-utils==43.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.4.0#egg=digitalmarketplace-utils==43.4.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.4.1#egg=digitalmarketplace-apiclient==16.4.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@43.2.0#egg=digitalmarketplace-utils==43.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.4.0#egg=digitalmarketplace-utils==43.4.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.4.1#egg=digitalmarketplace-apiclient==16.4.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
@@ -24,8 +24,8 @@ yq==2.4.1
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
-boto3==1.4.8
-botocore==1.8.35
+boto3==1.7.83
+botocore==1.10.84
 certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4


### PR DESCRIPTION
dmutils 43.4.0 uses space as an email separator by default