### PR TITLE
Export suppliers/users to CSV scripts

### DIFF
--- a/dmscripts/generate_supplier_user_csv.py
+++ b/dmscripts/generate_supplier_user_csv.py
@@ -1,0 +1,154 @@
+import csv
+from dmutils.s3 import S3ResponseError
+
+from dmscripts.models.writecsv import csv_path
+
+
+def generate_supplier_csv(framework_slug, data_api_client, logger):
+    framework = data_api_client.get_framework(framework_slug).get("frameworks")
+
+    supplier_rows = data_api_client.export_suppliers(framework_slug).get('suppliers', [])
+    if not supplier_rows:
+        logger.info('No supplier data found for framework {}'.format(framework_slug))
+        return [], [], None
+
+    supplier_and_framework_headers = [
+        "supplier_id",
+        "supplier_name",
+        "supplier_organisation_size",
+        "duns_number",
+        "companies_house_number",
+        "registered_name",
+        "declaration_status",
+        "application_status",
+        "application_result",
+        "framework_agreement",
+        "variations_agreed",
+    ]
+    service_count_headers = [lot['slug'] for lot in framework['lots']]
+    contact_info_headers = [
+        'contact_name',
+        'contact_email',
+        'contact_phone_number',
+        'address_first_line',
+        'address_city',
+        'address_postcode',
+        'address_country',
+    ]
+
+    filename = "official-details-for-suppliers-{}".format(framework_slug)
+
+    supplier_headers = supplier_and_framework_headers + ["total_number_of_services"] + \
+        ["service-count-{}".format(h) for h in service_count_headers] + contact_info_headers
+
+    formatted_rows = []
+    for row in supplier_rows:
+        # Include an extra column with the total number of services across all lots
+        service_counts = [row['published_services_count'][heading] for heading in service_count_headers]
+        total_number_of_services = sum(service_counts)
+
+        formatted_rows.append(
+            [row[heading] for heading in supplier_and_framework_headers] +
+            [total_number_of_services] +
+            service_counts +
+            [row['contact_information'][heading] for heading in contact_info_headers]
+        )
+
+    return supplier_headers, formatted_rows, filename
+
+
+def generate_user_csv(framework_slug, data_api_client, user_research_opted_in, logger):
+    """
+    Call API endpoint
+    Get CSV headers and rows
+    """
+    user_headers = [
+        "email address",
+        "user_name",
+        "supplier_id",
+        "declaration_status",
+        "application_status",
+        "application_result",
+        "framework_agreement",
+        "variations_agreed",
+        "published_service_count"
+    ]
+    user_rows = data_api_client.export_users(framework_slug).get('users', [])
+    if not user_rows:
+        logger.info('No user data found for framework {}'.format(framework_slug))
+        return [], [], None
+
+    if user_research_opted_in:
+        filename = "user-research-suppliers-on-{}".format(framework_slug)
+    else:
+        filename = "all-email-accounts-for-suppliers-{}".format(framework_slug)
+
+    formatted_rows = []
+    for row in user_rows:
+        if user_research_opted_in:
+            if row['user_research_opted_in']:
+                formatted_rows.append([row[heading] for heading in user_headers])
+        else:
+            formatted_rows.append([row[heading] for heading in user_headers])
+
+    return user_headers, formatted_rows, filename
+
+
+def upload_to_s3(file_path, framework_slug, download_filename, bucket, dry_run, logger):
+    # e.g. in the 'digitalmarketplace-reports-preview-preview' bucket, the
+    # path would be 'g-cloud-10/official-details-for-suppliers-g-cloud-10.csv'
+
+    try:
+        if dry_run:
+            logger.info("[Dry-run] UPLOAD: '{}' to '{}'".format(file_path, download_filename))
+        else:
+            # Upload file - need to open in binary mode as it's not plain text
+            with open(file_path, 'rb') as source_file:
+                # S3 bucket already logging external request
+                bucket.save(
+                    "{}/{}".format(framework_slug, download_filename),
+                    source_file,
+                    acl='private',
+                    download_filename=download_filename
+                )
+                logger.info("UPLOADED: '{}' to '{}'".format(file_path, download_filename))
+
+    # Catch and re-raise these exceptions for logging
+    except (OSError, IOError) as e:
+        logger.error("Error reading file '{}': {}".format(file_path, e.message))
+        raise
+    except S3ResponseError as e:
+        logger.error("Error uploading '{}' to '{}': {}".format(file_path, download_filename, str(e)))
+        raise
+
+
+def _build_csv(file_path, headers, rows):
+    with open(file_path, 'w') as csv_file:
+        writer = csv.writer(csv_file, delimiter=',', quotechar='"')
+        writer.writerow(headers)
+        for row in rows:
+            writer.writerow(row)
+
+
+def generate_csv_and_upload_to_s3(
+    bucket, framework_slug, report_type, output_dir, data_api_client,
+    dry_run=False, user_research_opted_in=False, logger=None
+):
+    # Fetch data from API
+    if report_type == 'users':
+        headers, rows, download_filename = generate_user_csv(
+            framework_slug, data_api_client, user_research_opted_in=user_research_opted_in, logger=logger
+        )
+
+    else:
+        headers, rows, download_filename = generate_supplier_csv(framework_slug, data_api_client, logger=logger)
+
+    if not rows:
+        return False
+
+    # Save CSV to output dir and upload to S3
+    file_path = csv_path(output_dir, download_filename)
+    _build_csv(file_path, headers, rows)
+    upload_to_s3(file_path, framework_slug, "{}.csv".format(download_filename), bucket, dry_run=dry_run, logger=logger)
+
+    return True

--- a/scripts/generate-supplier-user-csv.py
+++ b/scripts/generate-supplier-user-csv.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+"""
+PREREQUISITE: You'll need AWS credentials set up for the environment that you're uploading to:
+              Save your aws_access_key_id and aws_secret_access_key in ~/.aws/credentials
+              If you have more than one set of credentials in there then be sure to set your AWS_PROFILE environment
+              variable to reference the right credentials before running the script.
+              Alternatively, if this script is being run from Jenkins, do not provide any credentials and boto will use
+              the Jenkins IAM role. It should have the required permissions for the bucket.
+
+This will:
+ * call the export_<suppliers|users>_for_framework endpoint from the API
+ * create a CSV file from the results and save to saved to `<output-dir>/<filename>.csv` (see get-model-data.py)
+ * upload the file to the S3 admin reports bucket for <stage> with the file path:
+    <framework_slug>/official-details-for-suppliers-<framework_slug>.csv OR
+    <framework_slug>/user-research-suppliers-on-<framework_slug>.csv OR
+    <framework_slug>/all-email-accounts-for-suppliers-<framework_slug>.csv
+
+     e.g.
+     g-cloud-10/user-research-suppliers-on-g-cloud-10.csv
+
+Usage: scripts/generate-supplier-user-csv.py <stage> <report_type> <framework_slug> [options]
+
+Options:
+    --dry-run                       Don't actually do anything
+    --user-research-opted-in        Only include users who have opted in to user research
+    --output-dir=<output_dir>       Location to store CSV file [default: data]
+
+"""
+import os
+import sys
+sys.path.insert(0, '.')
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.bulk_upload_documents import get_bucket_name
+from dmscripts.generate_supplier_user_csv import generate_csv_and_upload_to_s3
+from dmscripts.helpers import logging_helpers
+from dmscripts.helpers.logging_helpers import logging
+from dmutils.env_helpers import get_api_endpoint_from_stage
+
+from docopt import docopt
+from dmapiclient import DataAPIClient
+
+from dmutils.s3 import S3
+
+
+logger = logging_helpers.configure_logger({
+    'dmapiclient.base': logging.WARNING,
+})
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    stage = arguments['<stage>']
+    data_api_client = DataAPIClient(get_api_endpoint_from_stage(stage), get_auth_token('api', stage))
+    report_type = arguments['<report_type>']
+    framework_slug = arguments['<framework_slug>']
+    output_dir = arguments['--output-dir']
+    user_research_opted_in = arguments['--user-research-opted-in'] or None
+    dry_run = arguments['--dry-run']
+
+    if report_type not in ['users', 'suppliers']:
+        logger.error('Please specify users or suppliers to be exported.')
+        sys.exit(1)
+
+    if not os.path.exists(output_dir):
+        logger.info("Creating {} directory".format(output_dir))
+        os.makedirs(output_dir)
+
+    if dry_run:
+        bucket = None
+    else:
+        if stage == 'local':
+            bucket = S3('digitalmarketplace-dev-uploads')
+        else:
+            # e.g. preview would give 'digitalmarketplace-reports-preview-preview'
+            bucket = S3(get_bucket_name(stage, "reports"))
+
+    ok = generate_csv_and_upload_to_s3(
+        bucket,
+        framework_slug,
+        report_type,
+        output_dir,
+        data_api_client,
+        dry_run=dry_run,
+        user_research_opted_in=user_research_opted_in,
+        logger=logger,
+    )
+
+    if not ok:
+        sys.exit(1)

--- a/tests/test_generate_supplier_user_csv.py
+++ b/tests/test_generate_supplier_user_csv.py
@@ -1,0 +1,236 @@
+import builtins
+import mock
+import pytest
+
+from dmscripts.generate_supplier_user_csv import (
+    generate_csv_and_upload_to_s3, generate_supplier_csv, generate_user_csv, upload_to_s3
+)
+
+
+def test_generate_supplier_csv_calls_api_and_returns_csv():
+    data_api_client = mock.Mock()
+    data_api_client.export_suppliers.return_value = {
+        'suppliers': [
+            {
+                'supplier_id': 1,
+                'application_result': 'no result',
+                'application_status': 'no_application',
+                'declaration_status': 'unstarted',
+                'framework_agreement': False,
+                'supplier_name': "Supplier 1",
+                'supplier_organisation_size': "small",
+                'duns_number': "100000001",
+                'registered_name': 'Registered Supplier Name 1',
+                'companies_house_number': None,
+                "published_services_count": {
+                    "cloud-hosting": 2
+                },
+                "contact_information": {
+                    'contact_name': 'Contact for Supplier 1',
+                    'contact_email': 'hello@example.com',
+                    'contact_phone_number': None,
+                    'address_first_line': '7 Gem Lane',
+                    'address_city': 'Cantelot',
+                    'address_postcode': 'SW1A 1AA',
+                    'address_country': 'country:GB',
+                },
+                'variations_agreed': '',
+            }
+        ]
+    }
+    data_api_client.get_framework.return_value = {
+        'frameworks': {
+            'lots': [
+                {"id": 1, "slug": "cloud-hosting"},
+            ]
+        }
+    }
+    logger = mock.Mock()
+
+    headers, rows, filename = generate_supplier_csv('g-cloud-10', data_api_client, logger)
+
+    assert filename == 'official-details-for-suppliers-g-cloud-10'
+    assert headers == [
+        "supplier_id",
+        "supplier_name",
+        "supplier_organisation_size",
+        "duns_number",
+        "companies_house_number",
+        "registered_name",
+        "declaration_status",
+        "application_status",
+        "application_result",
+        "framework_agreement",
+        "variations_agreed",
+        "total_number_of_services",
+        'service-count-cloud-hosting',
+        'contact_name',
+        'contact_email',
+        'contact_phone_number',
+        'address_first_line',
+        'address_city',
+        'address_postcode',
+        'address_country'
+    ]
+    assert rows[0] == [
+        1, 'Supplier 1', 'small', '100000001', None, 'Registered Supplier Name 1',
+        'unstarted', 'no_application', 'no result', False, '', 2, 2,
+        'Contact for Supplier 1', 'hello@example.com',
+        None, '7 Gem Lane', 'Cantelot', 'SW1A 1AA', 'country:GB'
+    ]
+
+    assert data_api_client.get_framework.call_args_list == [mock.call('g-cloud-10')]
+    assert data_api_client.export_suppliers.call_args_list == [mock.call('g-cloud-10')]
+
+
+@pytest.mark.parametrize('user_research_opted_in, expected_filename', [
+    (True, 'user-research-suppliers-on-g-cloud-10'),
+    (False, 'all-email-accounts-for-suppliers-g-cloud-10')
+])
+def test_generate_user_csv_calls_api_and_returns_csv(user_research_opted_in, expected_filename):
+    data_api_client = mock.Mock()
+    logger = mock.Mock()
+
+    data_api_client.export_users.return_value = {
+        'users': [
+            {
+                "application_result": "pass",
+                "application_status": "no_application",
+                "declaration_status": "unstarted",
+                "email address": "1234@example.com",
+                "framework_agreement": True,
+                "published_service_count": 4,
+                "supplier_id": 1234,
+                "user_name": "Test user 1",
+                "user_research_opted_in": True,
+                "variations_agreed": ""
+            },
+            {
+                "application_result": "pass",
+                "application_status": "no_application",
+                "declaration_status": "unstarted",
+                "email address": "5678@example.com",
+                "framework_agreement": True,
+                "published_service_count": 3,
+                "supplier_id": 5678,
+                "user_name": "Test user 2",
+                "user_research_opted_in": False,
+                "variations_agreed": ""
+            }
+        ]
+    }
+    headers, rows, filename = generate_user_csv('g-cloud-10', data_api_client, user_research_opted_in, logger)
+
+    assert filename == expected_filename
+    assert headers == [
+        "email address",
+        "user_name",
+        "supplier_id",
+        "declaration_status",
+        "application_status",
+        "application_result",
+        "framework_agreement",
+        "variations_agreed",
+        "published_service_count"
+    ]
+    assert rows[0] == [
+        '1234@example.com',
+        'Test user 1',
+        1234,
+        'unstarted',
+        'no_application',
+        'pass',
+        True,
+        '',
+        4
+    ]
+    if not user_research_opted_in:
+        # Additional row included
+        assert rows[1] == [
+            '5678@example.com',
+            'Test user 2',
+            5678,
+            'unstarted',
+            'no_application',
+            'pass',
+            True,
+            '',
+            3
+        ]
+
+    assert data_api_client.export_users.call_args_list == [mock.call('g-cloud-10')]
+
+
+@pytest.mark.parametrize('dry_run', [False, True])
+def test_upload_to_s3_uploads_or_logs_for_dry_run(dry_run):
+    bucket = mock.Mock()
+    logger = mock.Mock()
+
+    with mock.patch.object(builtins, 'open', mock.mock_open(read_data='some csv rows')):
+        upload_to_s3(
+            'data/suppliers-export.csv', 'g-cloud-10', 'supplier-users-g-cloud-10.csv', bucket, dry_run, logger
+        )
+
+    if dry_run:
+        assert bucket.save.call_args_list == []
+        assert logger.info.call_args_list == [
+            mock.call(
+                "[Dry-run] UPLOAD: 'data/suppliers-export.csv' to 'supplier-users-g-cloud-10.csv'"
+            )
+        ]
+    else:
+        assert bucket.save.call_args_list == [
+            mock.call(
+                "g-cloud-10/supplier-users-g-cloud-10.csv",
+                mock.ANY,  # file object
+                acl='private',
+                download_filename='supplier-users-g-cloud-10.csv'
+            )
+        ]
+        assert logger.info.call_args_list == [
+            mock.call(
+                "UPLOADED: 'data/suppliers-export.csv' to 'supplier-users-g-cloud-10.csv'"
+            )
+        ]
+
+
+@mock.patch('dmscripts.generate_supplier_user_csv._build_csv')
+@mock.patch('dmscripts.generate_supplier_user_csv.generate_supplier_csv')
+@mock.patch('dmscripts.generate_supplier_user_csv.upload_to_s3')
+def test_generate_supplier_csv_generates_csv_and_uploads_to_s3(upload_to_s3, generate_supplier_csv, build_csv):
+    bucket, data_api_client = mock.Mock(), mock.Mock()
+    generate_supplier_csv.return_value = ['header1', 'header2'], ['row1', 'row2'], 'filename'
+
+    generate_csv_and_upload_to_s3(
+        bucket, 'g-cloud-10', 'suppliers', 'data', data_api_client, logger='logger'
+    )
+
+    assert generate_supplier_csv.call_args_list == [
+        mock.call('g-cloud-10', data_api_client, logger='logger')
+    ]
+    assert upload_to_s3.call_args_list == [
+        mock.call(
+            'data/filename.csv', 'g-cloud-10', 'filename.csv', bucket, dry_run=False, logger='logger'
+        )
+    ]
+
+
+@mock.patch('dmscripts.generate_supplier_user_csv._build_csv')
+@mock.patch('dmscripts.generate_supplier_user_csv.generate_user_csv')
+@mock.patch('dmscripts.generate_supplier_user_csv.upload_to_s3')
+def test_generate_user_csv_generates_csv_and_uploads_to_s3(upload_to_s3, generate_user_csv, build_csv):
+    bucket, data_api_client = mock.Mock(), mock.Mock()
+    generate_user_csv.return_value = ['header1', 'header2'], ['row1', 'row2'], 'filename'
+
+    generate_csv_and_upload_to_s3(
+        bucket, 'g-cloud-10', 'users', 'data', data_api_client, logger='logger'
+    )
+
+    assert generate_user_csv.call_args_list == [
+        mock.call('g-cloud-10', data_api_client, user_research_opted_in=False, logger='logger')
+    ]
+    assert upload_to_s3.call_args_list == [
+        mock.call(
+            'data/filename.csv', 'g-cloud-10', 'filename.csv', bucket, dry_run=False, logger='logger'
+        )
+    ]


### PR DESCRIPTION
Trello: https://trello.com/c/FtV7sVMU/138-admin-download-all-suppliers-for-framework-endpoint-locks-up-an-api-process

Fetches supplier/user data from the API, creates a CSV (saving to a local `data` folder by default, as per the `get-model-export.py` script) then uploads that file to S3. 

There are 3 different CSV files that could be generated by this script:

1. Official supplier details for a framework
2. Supplier user contact details for a framework (all active users)
3. Supplier user contact details for a framework (user research opted-in only)

Examples:

```
./scripts/generate-supplier-user-csv.py preview suppliers g-cloud-10
./scripts/generate-supplier-user-csv.py preview users g-cloud-10 --dry-run
./scripts/generate-supplier-user-csv.py preview users g-cloud-10 --user-research-opted-in
```

The code for the API calls and report generation is adapted from the Admin FE views (the CSV generation is simplified, as we don't have to return it as a streamed response): 
https://github.com/alphagov/digitalmarketplace-admin-frontend/blob/master/app/main/views/users.py#L74
https://github.com/alphagov/digitalmarketplace-admin-frontend/blob/master/app/main/views/users.py#L119

The code for the script initialisation and the S3 upload is adapted from `scripts/upload-counterpart-agreements.py`.

Ready for review, however the new buckets still need to be created.
