### PR TITLE
Update apiclient (16.x.x -> 19.x.x)

### DIFF
--- a/dmscripts/index_to_search_service.py
+++ b/dmscripts/index_to_search_service.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from multiprocessing.pool import ThreadPool
 
-import backoff
 import dmapiclient
 from six.moves import map
 
@@ -52,7 +51,6 @@ class IndexerBase(object):
     def include_in_index(self, item):
         raise NotImplementedError()
 
-    @backoff.on_exception(backoff.expo, dmapiclient.HTTPError, max_tries=5)
     def index_item(self, item):
         if self.include_in_index(item):
             self.search_client.index(self.index, item['id'], item, self.document_type)

--- a/dmscripts/send_stats_to_performance_platform.py
+++ b/dmscripts/send_stats_to_performance_platform.py
@@ -1,9 +1,7 @@
-import backoff
 import base64
 import requests
 
 from datetime import datetime, timedelta
-import dmapiclient
 
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
@@ -160,7 +158,6 @@ def send_by_lot_stats(stats, timestamp_string, period, framework, pp_bearer, pp_
     return send_data(data, PERFORMANCE_PLATFORM_URL_TEMPLATES[period]['lot'].format(pp_service=pp_service), pp_bearer)
 
 
-@backoff.on_exception(backoff.expo, dmapiclient.HTTPError, max_tries=5)
 def send_framework_stats(data_api_client, framework_slug, period, pp_bearer, pp_service):
     stats = data_api_client.get_framework_stats(framework_slug)
     framework = data_api_client.get_framework(framework_slug)['frameworks']

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@43.4.0#egg=digitalmarketplace-utils==43.4.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.4.1#egg=digitalmarketplace-apiclient==16.4.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.4.0#egg=digitalmarketplace-apiclient==19.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
 awscli==1.14.31

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@43.4.0#egg=digitalmarketplace-utils==43.4.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.4.1#egg=digitalmarketplace-apiclient==16.4.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.4.0#egg=digitalmarketplace-apiclient==19.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
 awscli==1.14.31
@@ -55,11 +55,11 @@ pycparser==2.18
 PyJWT==1.6.4
 pytz==2015.4
 PyYAML==3.11
-requests==2.18.4
+requests==2.19.1
 rsa==3.4.2
 s3transfer==0.1.13
 six==1.11.0
-urllib3==1.22
+urllib3==1.23
 Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.2.1

--- a/scripts/oneoff/acknowledge_publish_draft_service_updates.py
+++ b/scripts/oneoff/acknowledge_publish_draft_service_updates.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python
 
 import argparse
-import backoff
 import multiprocessing as mp
 from multiprocessing.pool import ThreadPool
 import sys
 
-from dmapiclient import HTTPError
 from dmapiclient.audit import AuditTypes
 from dmapiclient.data import DataAPIClient
 
@@ -18,7 +16,6 @@ from dmscripts.helpers.auth_helpers import get_api_url, get_auth_token
 ACKNOWLEDGE_USER = 'scripts/oneoff/acknowledge_publish_draft_service_updates.py'
 
 
-@backoff.on_exception(backoff.expo, HTTPError, max_tries=5)
 def acknowledge_update(audit_event):
     response = data.acknowledge_audit_event(audit_event['id'], user=ACKNOWLEDGE_USER)['auditEvents']
     print(f'Acknowledged {audit_event["id"]} on service id #{audit_event["data"]["serviceId"]} by '

--- a/scripts/oneoff/rename-supplier-registered-country.py
+++ b/scripts/oneoff/rename-supplier-registered-country.py
@@ -13,22 +13,13 @@ Usage:
 import sys
 sys.path.insert(0, '.')
 
-import backoff
-import requests
 from docopt import docopt
 from dmapiclient import DataAPIClient, HTTPError
-from dmapiclient.errors import HTTPTemporaryError
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
 OLD_COUNTRY = "gb"
 NEW_COUNTRY = "country:GB"
-
-_backoff_wrap = backoff.on_exception(
-    backoff.expo,
-    (HTTPError, HTTPTemporaryError, requests.exceptions.ConnectionError, RuntimeError),
-    max_tries=5,
-)
 
 
 def rename_country(client, dry_run):
@@ -38,13 +29,11 @@ def rename_country(client, dry_run):
         if supplier.get('registrationCountry') == OLD_COUNTRY:
             if not dry_run:
                 try:
-                    _backoff_wrap(
-                        lambda: client.update_supplier(
-                            supplier['id'],
-                            {'registrationCountry': NEW_COUNTRY},
-                            'rename supplier registered country script',
-                        )
-                    )()
+                    client.update_supplier(
+                        supplier['id'],
+                        {'registrationCountry': NEW_COUNTRY},
+                        'rename supplier registered country script',
+                    )
                     success_counter += 1
                 except HTTPError as e:
                     print("Error updating supplier {}: {}".format(supplier['id'], e.message))

--- a/scripts/publish-g-cloud-draft-services.py
+++ b/scripts/publish-g-cloud-draft-services.py
@@ -124,7 +124,6 @@ def copy_draft_documents(client, copy_document, draft_service, framework_slug, d
         print("    > document URLs updated")
 
 
-@backoff.on_exception(backoff.expo, dmapiclient.HTTPError, max_tries=5)
 def make_draft_service_live(client, copy_document, draft_service, framework_slug, dry_run,
                             continue_if_published=False):
     print("  > Migrating draft {}".format(draft_service['id']))

--- a/scripts/snapshot-framework-stats.py
+++ b/scripts/snapshot-framework-stats.py
@@ -6,7 +6,6 @@ Example:
     ./snapshot_framework_stats.py g-cloud-7 dev
 """
 
-import backoff
 from docopt import docopt
 import logging
 import sys
@@ -23,7 +22,6 @@ logger = logging.getLogger('script')
 logging.basicConfig(level=logging.INFO)
 
 
-@backoff.on_exception(backoff.expo, dmapiclient.HTTPError, max_tries=5)
 def get_stats(data_client, framework_slug):
     return data_client.get_framework_stats(framework_slug)
 

--- a/tests/helpers/test_framework_helpers.py
+++ b/tests/helpers/test_framework_helpers.py
@@ -47,9 +47,9 @@ def test_set_framework_result_calls_with_correct_arguments(mock_data_client):
 def test_set_framework_result_returns_error_message_if_update_fails(mock_data_client):
     mock_data_client.set_framework_result.side_effect = [HTTPError(), HTTPError(Mock(status_code=400))]
     assert framework_helpers.set_framework_result(mock_data_client, 'g-whizz-6', 123456, True, 'user') == \
-        "  Error inserting result for 123456 (True): Request failed (status: 503)"
+        "  Error inserting result for 123456 (True): Unknown request failure in dmapiclient (status: 503)"
     assert framework_helpers.set_framework_result(mock_data_client, 'digital-stuff', 567890, False, 'script-user') == \
-        "  Error inserting result for 567890 (False): Request failed (status: 400)"
+        "  Error inserting result for 567890 (False): Unknown request failure in dmapiclient (status: 400)"
 
 
 def test_has_supplier_submitted_services_with_no_submitted_services(mock_data_client):

--- a/tests/test_insert_framework_results.py
+++ b/tests/test_insert_framework_results.py
@@ -54,4 +54,4 @@ def test_http_error_handling(mock_data_client):
     mock_data_client.get_supplier.return_value = {'suppliers': {'name': 'Supplier Name'}}
 
     result = insert_result(mock_data_client, 123456, "Supplier Name", 'g-cloud-7', True, 'user')
-    assert result == 'Error inserting result for 123456 (True): Request failed (status: 503)\n'
+    assert result == 'Error inserting result for 123456 (True): Unknown request failure in dmapiclient (status: 503)\n'


### PR DESCRIPTION
I had an issue the other day where I couldn't use one of the new API features in the `api-clients-shell` environment, because the apiclient in scripts was outdated. This PR updates the apiclient version specified in the requirements file. 

There was one breaking change that I did fix, and another that I didn't, as it only affected some one-off scripts that seemed not very important.