### PR TITLE
Include reports folder in S3 upload path

### DIFF
--- a/dmscripts/generate_supplier_user_csv.py
+++ b/dmscripts/generate_supplier_user_csv.py
@@ -106,7 +106,7 @@ def upload_to_s3(file_path, framework_slug, download_filename, bucket, dry_run, 
             with open(file_path, 'rb') as source_file:
                 # S3 bucket already logging external request
                 bucket.save(
-                    "{}/{}".format(framework_slug, download_filename),
+                    "{}/reports/{}".format(framework_slug, download_filename),
                     source_file,
                     acl='private',
                     download_filename=download_filename

--- a/tests/test_generate_supplier_user_csv.py
+++ b/tests/test_generate_supplier_user_csv.py
@@ -181,7 +181,7 @@ def test_upload_to_s3_uploads_or_logs_for_dry_run(dry_run):
     else:
         assert bucket.save.call_args_list == [
             mock.call(
-                "g-cloud-10/supplier-users-g-cloud-10.csv",
+                "g-cloud-10/reports/supplier-users-g-cloud-10.csv",
                 mock.ANY,  # file object
                 acl='private',
                 download_filename='supplier-users-g-cloud-10.csv'


### PR DESCRIPTION
Trello: https://trello.com/c/FtV7sVMU/138-admin-download-all-suppliers-for-framework-endpoint-locks-up-an-api-process

In order to serve the S3 file in the admin (via the `DM_ASSETS_URL`), the router needs to proxy the url to the correct bucket. To do that, it uses a regex to match the path supplied (see https://github.com/alphagov/digitalmarketplace-router/pull/30/files). The other asset buckets include their type in the path structure to assist with this (e.g. `/g-cloud-10/communications/filename.csv`), and the reports bucket should do the same.

TL;DR - this PR sticks a `.../reports/...` in the CSV upload path.

Tested against preview already, works as expected.