### PR TITLE
Update scripts that manage and send DOS3 opportunity emails

### DIFF
--- a/scripts/send-dos-opportunities-email.py
+++ b/scripts/send-dos-opportunities-email.py
@@ -26,12 +26,13 @@ Description:
     failed.
 
 Usage:
-    send-dos-opportunities-email.py <stage> <mailchimp_username> <mailchimp_api_key>
+    send-dos-opportunities-email.py <stage> <mailchimp_username> <mailchimp_api_key> <framework_slug>
         [--number_of_days=<number_of_days>] [--list_id=<list_id>] [--lot_slug=<lot_slug>]
 
 Example:
     send-dos-opportunities-email.py
-        preview user@gds.gov.uk 7483crh87h34c3 --number_of_days=3 --list_id=988972hse --lot_slug=digital-outcomes
+        preview user@gds.gov.uk 7483crh87h34c3 digital-outcomes-and-specialists-3
+        --number_of_days=3 --list_id=988972hse --lot_slug=digital-outcomes
 """
 
 import sys
@@ -52,27 +53,39 @@ from dmutils.env_helpers import get_api_endpoint_from_stage
 logger = logging_helpers.configure_logger()
 
 
-lots = [
-    {
-        "lot_slug": "digital-specialists",
-        "lot_name": "Digital specialists",
-        "list_id": "30ba9fdf39"
+list_ids = {
+    'digital-outcomes-and-specialists-2': {
+        'digital-specialists': "30ba9fdf39",
+        'digital-outcomes': "97952fee38",
+        'user-research-participants': "e6b93a3bce",
     },
-    {
-        "lot_slug": "digital-outcomes",
-        "lot_name": "Digital outcomes",
-        "list_id": "97952fee38"
-    },
-    {
-        "lot_slug": "user-research-participants",
-        "lot_name": "User research participants",
-        "list_id": "e6b93a3bce"
+    'digital-outcomes-and-specialists-3': {
+        'digital-specialists': "bee802d641",
+        'digital-outcomes': "5c92c78a78",
+        'user-research-participants': "34ebe0bffa",
     }
-]
-
+}
 
 if __name__ == "__main__":
     arguments = docopt(__doc__)
+    framework_slug = arguments['<framework_slug>']
+    lots = [
+        {
+            "lot_slug": "digital-specialists",
+            "lot_name": "Digital specialists",
+            "list_id": list_ids[framework_slug]['digital-specialists']
+        },
+        {
+            "lot_slug": "digital-outcomes",
+            "lot_name": "Digital outcomes",
+            "list_id": list_ids[framework_slug]['digital-outcomes']
+        },
+        {
+            "lot_slug": "user-research-participants",
+            "lot_name": "User research participants",
+            "list_id": list_ids[framework_slug]['user-research-participants']
+        }
+    ]
 
     # Override number of days
     if arguments.get("--number_of_days"):
@@ -111,7 +124,8 @@ if __name__ == "__main__":
             data_api_client=data_api_client,
             mailchimp_client=dm_mailchimp_client,
             lot_data=lot_data,
-            number_of_days=number_of_days
+            number_of_days=number_of_days,
+            framework_slug=framework_slug,
         )
         if not ok:
             sys.exit(1)

--- a/scripts/upload-dos-opportunities-email-list.py
+++ b/scripts/upload-dos-opportunities-email-list.py
@@ -15,10 +15,10 @@ Description:
     that we have setup on mailchimp.
 
 Usage:
-    upload-dos-opportunities-email-list.py <stage> <mailchimp_username> <mailchimp_api_key>
+    upload-dos-opportunities-email-list.py <stage> <mailchimp_username> <mailchimp_api_key> <framework_slug>
 
 Example:
-    upload-dos-opportunities-email-list.py preview user@gds.gov.uk 7483crh87h34c3
+    upload-dos-opportunities-email-list.py preview user@gds.gov.uk 7483crh87h34c3 digital-outcomes-and-specialists-3
 
 """
 
@@ -35,33 +35,36 @@ from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
+LOT_SLUGS = ('digital-specialists', 'digital-outcomes', 'user-research-participants')
 
 logger = logging_helpers.configure_logger({'dmapiclient': logging.INFO})
 
 
 if __name__ == '__main__':
     arguments = docopt(__doc__)
+    framework_slug = arguments['<framework_slug>']
+    stage = arguments['<stage>']
+
+    list_ids = {
+        'digital-outcomes-and-specialists-2': {
+            'digital-specialists': "30ba9fdf39" if stage == "production" else "07c21f0451",
+            'digital-outcomes': "97952fee38" if stage == "production" else "f0077c516d",
+            'user-research-participants': "e6b93a3bce" if stage == "production" else "d35601203b",
+        },
+        'digital-outcomes-and-specialists-3': {
+            'digital-specialists': "bee802d641" if stage == "production" else "07c21f0451",
+            'digital-outcomes': "5c92c78a78" if stage == "production" else "f0077c516d",
+            'user-research-participants': "34ebe0bffa" if stage == "production" else "d35601203b",
+        }
+    }
 
     lots = [
-        {
-            "lot_slug": "digital-specialists",
-            "list_id": "30ba9fdf39" if arguments['<stage>'] == "production" else "07c21f0451",
-            "framework_slug": "digital-outcomes-and-specialists-2"
-        },
-        {
-            "lot_slug": "digital-outcomes",
-            "list_id": "97952fee38" if arguments['<stage>'] == "production" else "f0077c516d",
-            "framework_slug": "digital-outcomes-and-specialists-2"
-        },
-        {
-            "lot_slug": "user-research-participants",
-            "list_id": "e6b93a3bce" if arguments['<stage>'] == "production" else "d35601203b",
-            "framework_slug": "digital-outcomes-and-specialists-2"
-        }
+        {'lot_slug': lot_slug, 'list_id': list_ids[framework_slug][lot_slug], 'framework_slug': framework_slug}
+        for lot_slug in LOT_SLUGS
     ]
 
-    api_url = get_api_endpoint_from_stage(arguments['<stage>'])
-    data_api_client = DataAPIClient(api_url, get_auth_token('api', arguments['<stage>']))
+    api_url = get_api_endpoint_from_stage(stage)
+    data_api_client = DataAPIClient(api_url, get_auth_token('api', stage))
     dm_mailchimp_client = DMMailChimpClient(
         arguments['<mailchimp_username>'],
         arguments['<mailchimp_api_key>'],


### PR DESCRIPTION
For [this trello ticket](https://trello.com/c/y3Rv3kGC).

This will require updates to the Jenkins jobs which run these scripts. Coming next.

### Add DOS3 list IDs to upload_dos_opportunities_email_list  …
We're going to need a new list for DOS3 suppliers. Being able to select
framework specific list ids will make the transition from dos2 to dos3
much easier.

The list IDs for DOS3 have already been created in Mailchimp.

### Add DOS3 mailchimp list IDs to email sending script  …
And pass framework_slug to main.

We need to send separate emails to separate lists based on which DOS
opportunities are available.