### PR TITLE
Add search for buyer with briefs to get-user script

### DIFF
--- a/dmscripts/get_user.py
+++ b/dmscripts/get_user.py
@@ -1,0 +1,38 @@
+
+import sys
+
+import dmapiclient
+
+sys.path.insert(0, '.')  # noqa
+from dmscripts.helpers.auth_helpers import get_auth_token, get_api_url
+from dmscripts.helpers.framework_helpers import get_full_framework_slug
+from dmscripts.helpers.user_helpers import (
+    get_random_buyer_with_brief,
+    get_supplier_id,
+    get_random_user,
+)
+
+
+def get_user(api_url, api_token, stage, role, framework, lot):
+    if not api_url:
+        api_url = get_api_url('api', stage)
+
+    api_token = api_token or get_auth_token('api', stage)
+    api_client = dmapiclient.DataAPIClient(api_url, api_token)
+
+    if role == 'supplier' and framework is not None:
+        framework = get_full_framework_slug(framework)
+        print('Framework: {}'.format(framework))
+        if lot is not None:
+            print('Lot: {}'.format(lot))
+        supplier_id = get_supplier_id(api_client, framework, lot)
+        print('Supplier id: {}'.format(supplier_id))
+        return get_random_user(api_client, None, supplier_id)
+    if role == "buyer" and framework is not None:
+        framework = get_full_framework_slug(framework)
+        print('Framework: {}'.format(framework))
+        if framework.startswith("digital-outcomes-and-specialists"):
+            print("Has requirements: True")
+            return get_random_buyer_with_brief(api_client, framework, lot)
+    else:
+        return get_random_user(api_client, role)

--- a/dmscripts/helpers/framework_helpers.py
+++ b/dmscripts/helpers/framework_helpers.py
@@ -1,6 +1,7 @@
 from collections import Counter
 from functools import partial
 from multiprocessing.pool import ThreadPool
+import re
 
 from dmapiclient import HTTPError
 
@@ -96,3 +97,18 @@ def add_draft_counts(client, framework_slug, record):
         for ds in client.find_draft_services_iter(record['supplier']['id'], framework=framework_slug)
     )
     return dict(record, counts=counts)
+
+
+def get_full_framework_slug(framework):
+    iteration = re.search('(\d+)', framework)
+    if framework.startswith('g'):
+        prefix = 'g-cloud'
+    elif framework.startswith('d'):
+        prefix = 'digital-outcomes-and-specialists'
+    else:
+        return framework
+
+    if iteration:
+        return "{}-{}".format(prefix, iteration.group(1))
+    else:
+        return prefix

--- a/dmscripts/helpers/user_helpers.py
+++ b/dmscripts/helpers/user_helpers.py
@@ -1,0 +1,47 @@
+
+import random
+
+
+def get_supplier_id(api_client, framework, lot):
+    services = [
+        s for s in api_client.find_services(framework=framework, lot=lot)['services']
+        if s['status'] in ['published']
+    ]
+
+    if not services:
+        raise RuntimeError(
+            "No live services found for '{}' framework{}".format(
+                framework,
+                " and '{}' lot".format(lot) if lot else "",
+            )
+        )
+
+    return random.choice(services)['supplierId']
+
+
+def get_random_buyer_with_brief(api_client, framework, lot):
+    briefs = api_client.find_briefs(
+        framework=framework,
+        lot=lot,
+        status="live,cancelled,unsuccessful,closed,awarded",
+        with_users=True,
+    )["briefs"]
+
+    if not briefs:
+        raise RuntimeError(
+            "No users with published briefs found for '{}' framework{}".format(
+                framework,
+                " and '{}' lot".format(lot) if lot else "",
+            )
+        )
+
+    brief = random.choice(briefs)
+
+    return random.choice(brief["users"])
+
+
+def get_random_user(api_client, role, supplier_id=None):
+    return random.choice([
+        u for u in api_client.find_users(role=role, supplier_id=supplier_id)['users']
+        if u['active'] and not u['locked']
+    ])

--- a/scripts/get-user.py
+++ b/scripts/get-user.py
@@ -59,6 +59,25 @@ def get_supplier_id(api_client, framework, lot):
     return random.choice(services)['supplierId']
 
 
+def get_random_buyer_with_brief(api_client, framework, lot):
+    briefs = api_client.find_briefs(
+        framework=framework,
+        lot=lot,
+        status="live,cancelled,unsuccessful,closed,awarded",
+        with_users=True,
+    )["briefs"]
+
+    if not briefs:
+        print("No users with published briefs found for '{}' framework{}".format(
+            framework, " and '{}' lot".format(lot) if lot else "")
+        )
+        sys.exit(1)
+
+    brief = random.choice(briefs)
+
+    return random.choice(brief["users"])
+
+
 def get_random_user(api_client, role, supplier_id=None):
     return random.choice([
         u for u in api_client.find_users(role=role, supplier_id=supplier_id)['users']
@@ -81,6 +100,12 @@ def get_user(api_url, api_token, stage, role, framework, lot):
         supplier_id = get_supplier_id(api_client, framework, lot)
         print('Supplier id: {}'.format(supplier_id))
         return get_random_user(api_client, None, supplier_id)
+    if role == "buyer" and framework is not None:
+        framework = get_full_framework_slug(framework)
+        print('Framework: {}'.format(framework))
+        if framework.startswith("digital-outcomes-and-specialists"):
+            print("Has requirements: True")
+            return get_random_buyer_with_brief(api_client, framework, lot)
     else:
         return get_random_user(api_client, role)
 


### PR DESCRIPTION
This commit adds a function to `scripts/get-user.py` that searches for a buyer with published briefs. I needed this to test a bit of functionality I was working on and thought it might be useful for other people.

I also took the opportunity to refactor the script, moving the logic out into modules.