### PR TITLE
Fix bugs in ported email scripts

### DIFF
--- a/dmscripts/notify_buyers_when_requirements_close.py
+++ b/dmscripts/notify_buyers_when_requirements_close.py
@@ -35,7 +35,7 @@ def notify_users(email_api_key, stage, brief):
                 email_client.send_email(
                     email_address,
                     template_name_or_id=EMAIL_TEMPLATE_ID,
-                    template_personalisation={
+                    personalisation={
                         "brief_title": brief["title"],
                         "brief_responses_url": brief_responses_url,
                     },

--- a/dmscripts/notify_suppliers_of_new_questions_answers.py
+++ b/dmscripts/notify_suppliers_of_new_questions_answers.py
@@ -91,8 +91,8 @@ def send_supplier_emails(email_api_key, email_addresses, supplier_context, logge
     for email_address in email_addresses:
         email_client.send_email(
             template_name_or_id=EMAIL_TEMPLATE_ID,
-            email_address=email_address,
-            template_personalisation=get_template_personalisation(supplier_context),
+            to_email_address=email_address,
+            personalisation=get_template_personalisation(supplier_context),
         )
 
 

--- a/tests/test_notify_buyers_when_requirements_close.py
+++ b/tests/test_notify_buyers_when_requirements_close.py
@@ -42,7 +42,7 @@ def test_get_date_closed():
         check_date_closed(value, expected)
 
 
-@mock.patch('dmscripts.notify_buyers_when_requirements_close.DMNotifyClient.send_email')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.DMNotifyClient.send_email', autospec=True)
 def test_notify_users(send_email):
     notify_users(NOTIFY_API_KEY, 'preview', {
         'id': 100,
@@ -62,18 +62,20 @@ def test_notify_users(send_email):
 
     assert send_email.call_count == 2
     send_email.assert_any_call(
+        mock.ANY,  # self
         'a@example.com',
         template_name_or_id=mock.ANY,
-        template_personalisation={
+        personalisation={
             "brief_title": "My brief title",
             "brief_responses_url": brief_responses_url,
         },
         allow_resend=False,
     )
     send_email.assert_any_call(
+        mock.ANY,  # self
         'c@example.com',
         template_name_or_id=mock.ANY,
-        template_personalisation={
+        personalisation={
             "brief_title": "My brief title",
             "brief_responses_url": brief_responses_url,
         },
@@ -81,7 +83,7 @@ def test_notify_users(send_email):
     )
 
 
-@mock.patch('dmscripts.notify_buyers_when_requirements_close.DMNotifyClient.send_email')
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.DMNotifyClient.send_email', autospec=True)
 def test_notify_users_returns_false_on_error(send_email):
     send_email.side_effect = EmailError('Error')
     assert not notify_users(NOTIFY_API_KEY, 'preview', {

--- a/tests/test_notify_suppliers_of_new_questions_answers.py
+++ b/tests/test_notify_suppliers_of_new_questions_answers.py
@@ -264,7 +264,7 @@ def test_get_template_personalisation_renders_multiple_briefs():
     )
 
 
-@mock.patch(MODULE_UNDER_TEST + '.DMNotifyClient.send_email')
+@mock.patch(MODULE_UNDER_TEST + '.DMNotifyClient.send_email', autospec=True)
 def test_send_emails_calls_notify_api_client(send_email):
     logger = mock.Mock()
 
@@ -288,9 +288,10 @@ def test_send_emails_calls_notify_api_client(send_email):
 
     assert send_email.call_count == 2
     send_email.assert_any_call(
-        email_address="a@example.com",
+        mock.ANY,  # self
+        to_email_address="a@example.com",
         template_name_or_id=mock.ANY,
-        template_personalisation={
+        personalisation={
             "briefs": "https://www.digitalmarketplace.service.gov.uk/"
                       "digital-outcomes-and-specialists/opportunities/3?utm_id=20170419qa"
                       "\n"
@@ -299,9 +300,10 @@ def test_send_emails_calls_notify_api_client(send_email):
         }
     )
     send_email.assert_any_call(
-        email_address="a2@example.com",
+        mock.ANY,  # self
+        to_email_address="a2@example.com",
         template_name_or_id=mock.ANY,
-        template_personalisation={
+        personalisation={
             "briefs": "https://www.digitalmarketplace.service.gov.uk/"
                       "digital-outcomes-and-specialists/opportunities/3?utm_id=20170419qa"
                       "\n"


### PR DESCRIPTION
This PR fixes some careless mistakes on my behalf.

I've made sure now that the send_email is patched with autospec so that the proper call signature is checked by tests, and I also actually ran these on my machine this time, which I foolishly neglected to do last time.