### PR TITLE
Antivirus scanning script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ virtualenv:
 	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
 
 .PHONY: requirements
-requirements: virtualenv requirements.txt
+requirements: virtualenv test-requirements requirements.txt
 	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
 
 .PHONY: requirements-dev
-requirements-dev: virtualenv requirements-dev.txt
+requirements-dev: virtualenv test-requirements requirements-dev.txt
 	${VIRTUALENV_ROOT}/bin/pip install -r requirements-dev.txt
 
 .PHONY: freeze-requirements

--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,9 @@ in (with args; {
     VIRTUAL_ENV_DISABLE_PROMPT = "1";
     SOURCE_DATE_EPOCH = "315532800";
 
+    # pip's builds will never be pure - allow gcc to include impure paths
+    NIX_ENFORCE_PURITY=0;
+
     # if we don't have this, we get unicode troubles in a --pure nix-shell
     LANG="en_GB.UTF-8";
 
@@ -48,7 +51,7 @@ in (with args; {
         ${pythonPackages.python}/bin/python -m venv $VIRTUALENV_ROOT
       fi
       source $VIRTUALENV_ROOT/bin/activate
-      pip install -r requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}.txt
+      make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
     '';
   }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
 })

--- a/dmscripts/virus_scan_s3_bucket.py
+++ b/dmscripts/virus_scan_s3_bucket.py
@@ -1,0 +1,53 @@
+from itertools import chain
+import logging
+
+
+logger = logging.getLogger("script")
+
+
+def virus_scan_bucket(s3_client, antivirus_api_client, bucket_name, prefix="", since=None, dry_run=True):
+    candidate_count, pass_count, fail_count, already_tagged_count = 0, 0, 0, 0
+
+    for version in chain.from_iterable(
+        page.get("Versions") or ()
+        for page in s3_client.get_paginator("list_object_versions").paginate(
+            Bucket=bucket_name,
+            Prefix=prefix,
+        )
+    ):
+        if since and version.get('LastModified') and version['LastModified'] < since:
+            logger.debug("Ignoring file from %s: %s", version["LastModified"], version["Key"])
+            continue
+
+        logger.info(
+            f"{'(Would be) ' if dry_run else ''}Requesting scan of key %s version %s (%s)",
+            version["Key"],
+            version["VersionId"],
+            version["LastModified"],
+        )
+        candidate_count += 1
+
+        if not dry_run:
+            result = antivirus_api_client.scan_and_tag_s3_object(
+                bucket_name,
+                version["Key"],
+                version["VersionId"],
+            )
+
+            if result["avStatusApplied"]:
+                if result.get("newAvStatus", {}).get("avStatus.result") == "pass":
+                    pass_count += 1
+                else:
+                    fail_count += 1
+                message = f"Marked with result {result.get('newAvStatus', {}).get('avStatus.result')}"
+            else:
+                already_tagged_count += 1
+                message = f"Unchanged: "
+                if result.get("existingAvStatus", {}).get("avStatus.result"):
+                    message += f"already marked as {result['existingAvStatus']['avStatus.result']!r}"
+                    if result.get("existingAvStatus", {}).get("avStatus.ts"):
+                        message += f" ({result['existingAvStatus']['avStatus.ts']})"
+
+            logger.info("%s: %s", version["VersionId"], message)
+
+    return candidate_count, pass_count, fail_count, already_tagged_count

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.6.0#egg=digitalmarketplace-utils==44.6.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.4.0#egg=digitalmarketplace-apiclient==19.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.6.0#egg=digitalmarketplace-apiclient==19.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
 awscli==1.14.31

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.6.0#egg=digitalmarketplace-utils==44.6.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.4.0#egg=digitalmarketplace-apiclient==19.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.6.0#egg=digitalmarketplace-apiclient==19.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
 awscli==1.14.31

--- a/tests/test_virus_scan_s3_bucket.py
+++ b/tests/test_virus_scan_s3_bucket.py
@@ -1,0 +1,221 @@
+from datetime import datetime
+from itertools import groupby
+
+import mock
+
+import boto3
+import pytest
+
+from dmapiclient import AntivirusAPIClient
+
+from dmscripts.virus_scan_s3_bucket import virus_scan_bucket
+
+
+class TestVirusScanBucket:
+    # a sequence of pairs of (boto "Versions" entry, scan_and_tag_s3_object response) corresponding to each
+    # "version" supposedly present in the bucket
+    versions_responses = (
+        (
+            {
+                "VersionId": "oo_.BepoodlLml",
+                "Key": "sandman/4321-billy-winks.pdf",
+                "LastModified": datetime(2012, 11, 10, 9, 8, 7),
+            },
+            {
+                "existingAvStatus": {},
+                "avStatusApplied": True,
+                "newAvStatus": {"avStatus.result": "pass"},
+            },
+        ),
+        (
+            {
+                "VersionId": "moB_eLplool.do",
+                "Key": "sandman/4321-billy-winks.pdf",
+                "LastModified": datetime(2012, 11, 10, 9, 8, 6),
+            },
+            {
+                "existingAvStatus": {
+                    "avStatus.result": "fail",
+                    "avStatus.ts": "2013-12-11T10:11:12.76543Z",
+                },
+                "avStatusApplied": False,
+                "newAvStatus": {"avStatus.result": "pass"},
+            },
+        ),
+        (
+            {
+                "VersionId": "ooBmo_pe.ldoLl",
+                "Key": "sandman/4321-billy-winks.pdf",
+                "LastModified": datetime(2012, 11, 10, 9, 8, 8),
+            },
+            {
+                "existingAvStatus": {},
+                "avStatusApplied": True,
+                "newAvStatus": {"avStatus.result": "fail"},
+            },
+        ),
+        (
+            {
+                "VersionId": "epmlLoBodo_ol.",
+                "Key": "sandman/1234-deedaw.pdf",
+                "LastModified": datetime(2012, 11, 10, 9, 8, 5),
+            },
+            {
+                "existingAvStatus": {},
+                "avStatusApplied": True,
+                "newAvStatus": {"avStatus.result": "pass"},
+            },
+        ),
+        (
+            {
+                "VersionId": "loleLoooBp_md.",
+                "Key": "sandman/1234-deedaw.pdf",
+                "LastModified": datetime(2012, 11, 10, 9, 8, 4),
+            },
+            {
+                "existingAvStatus": {"avStatus.irrelevant": "321"},
+                "avStatusApplied": True,
+                "newAvStatus": {"avStatus.result": "pass"},
+            },
+        ),
+        (
+            {
+                "VersionId": "molo.oB_oLdelp",
+                "Key": "sandman/4321-billy-winks.pdf",
+                "LastModified": datetime(2012, 11, 10, 9, 8, 9),
+            },
+            {
+                "existingAvStatus": {
+                    "avStatus.result": "pass",
+                    "avStatus.ts": "2013-12-11T10:09:08.76543Z",
+                },
+                "avStatusApplied": False,
+                "newAvStatus": None,
+            },
+        ),
+        (
+            {
+                "VersionId": "ldmoo_.pBeolLo",
+                "Key": "dribbling/bib.jpeg",
+                "LastModified": datetime(2012, 11, 10, 3, 0, 0),
+            },
+            {
+                "existingAvStatus": {},
+                "avStatusApplied": True,
+                "newAvStatus": {"avStatus.result": "pass"},
+            },
+        ),
+    )
+
+    def _get_mock_clients(self, versions_responses, versions_page_size):
+        # as nice as it would be to mock this at a higher level by using moto, at time of writing moto doesn't seem to
+        # support the paging interface used by virus_scan_bucket
+
+        # generate dict of responses for scan_and_tag_s3_object
+        scan_tag_responses = {
+            ("spade", version["Key"], version["VersionId"]): response
+            for version, response in versions_responses
+        }
+        av_api_client = mock.create_autospec(AntivirusAPIClient)
+        av_api_client.scan_and_tag_s3_object.side_effect = lambda b, k, v: scan_tag_responses[b, k, v]
+
+        # generate sequence of "pages" to be returned by list_object_versions paginator, chunked by versions_page_size
+        versions_pages = tuple(
+            {
+                "Versions": [version for i, (version, response) in versions_responses_chunk_iter],
+                # ...omitting various other keys which would be present IRL...
+            } for _, versions_responses_chunk_iter in groupby(
+                enumerate(versions_responses),
+                key=lambda i_vr: i_vr[0] // versions_page_size,
+            )
+        )
+        s3_client = mock.create_autospec(boto3.client("s3"), instance=True)
+        s3_client.get_paginator("").paginate.return_value = iter(versions_pages)
+        s3_client.reset_mock()
+
+        return av_api_client, s3_client
+
+    @pytest.mark.parametrize("versions_page_size", (2, 4, 100,))
+    @pytest.mark.parametrize("dry_run", (False, True,))
+    def test_unfiltered(self, versions_page_size, dry_run):
+        av_api_client, s3_client = self._get_mock_clients(self.versions_responses, versions_page_size)
+
+        retval = virus_scan_bucket(
+            s3_client,
+            av_api_client,
+            "spade",
+            prefix="",
+            since=None,
+            dry_run=dry_run,
+        )
+
+        assert av_api_client.mock_calls == [] if dry_run else [
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "oo_.BepoodlLml"),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "moB_eLplool.do"),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "ooBmo_pe.ldoLl"),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/1234-deedaw.pdf", "epmlLoBodo_ol."),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/1234-deedaw.pdf", "loleLoooBp_md."),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "molo.oB_oLdelp"),
+            mock.call.scan_and_tag_s3_object("spade", "dribbling/bib.jpeg", "ldmoo_.pBeolLo"),
+        ]
+        assert s3_client.mock_calls == [
+            mock.call.get_paginator("list_object_versions"),
+            mock.call.get_paginator().paginate(Bucket="spade", Prefix=""),
+        ]
+        assert retval == (7, 0, 0, 0,) if dry_run else (7, 4, 1, 2,)
+
+    @pytest.mark.parametrize("versions_page_size", (2, 4, 100,))
+    @pytest.mark.parametrize("dry_run", (False, True,))
+    def test_since_filtered(self, versions_page_size, dry_run):
+        av_api_client, s3_client = self._get_mock_clients(self.versions_responses, versions_page_size)
+
+        retval = virus_scan_bucket(
+            s3_client,
+            av_api_client,
+            "spade",
+            prefix="",
+            since=datetime(2012, 11, 10, 9, 8, 7),
+            dry_run=dry_run,
+        )
+
+        assert av_api_client.mock_calls == [] if dry_run else [
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "oo_.BepoodlLml"),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "ooBmo_pe.ldoLl"),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "molo.oB_oLdelp"),
+        ]
+        assert s3_client.mock_calls == [
+            mock.call.get_paginator("list_object_versions"),
+            mock.call.get_paginator().paginate(Bucket="spade", Prefix=""),
+        ]
+        assert retval == (3, 0, 0, 0,) if dry_run else (3, 1, 1, 1,)
+
+    @pytest.mark.parametrize("versions_page_size", (2, 4, 100,))
+    @pytest.mark.parametrize("dry_run", (False, True,))
+    def test_prefix_filtered(self, versions_page_size, dry_run):
+        av_api_client, s3_client = self._get_mock_clients(
+            tuple(v_r for v_r in self.versions_responses if v_r[0]["Key"].startswith("sand")),
+            versions_page_size,
+        )
+
+        retval = virus_scan_bucket(
+            s3_client,
+            av_api_client,
+            "spade",
+            prefix="sand",
+            since=None,
+            dry_run=dry_run,
+        )
+
+        assert av_api_client.mock_calls == [] if dry_run else [
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "oo_.BepoodlLml"),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "moB_eLplool.do"),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "ooBmo_pe.ldoLl"),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/1234-deedaw.pdf", "epmlLoBodo_ol."),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/1234-deedaw.pdf", "loleLoooBp_md."),
+            mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "molo.oB_oLdelp"),
+        ]
+        assert s3_client.mock_calls == [
+            mock.call.get_paginator("list_object_versions"),
+            mock.call.get_paginator().paginate(Bucket="spade", Prefix="sand"),
+        ]
+        assert retval == (6, 0, 0, 0,) if dry_run else (6, 3, 1, 2,)


### PR DESCRIPTION
https://trello.com/c/aWnL8fAa/192-antivirus-create-catch-up-bulk-scan-script

This ports the script `virus-scan-s3-bucket.py` to use the antivirus api for actual scanning of objects. It will allow us to scan & tag all existing files on a bucket and will also be good to use as a "catch up" script which runs periodically and scans any file versions which missed SNS-triggered scanning for some reason.

There are a number of things that should(/could?) be done to this before we say it's done:

 - Add tests, obviously. This may need some preparatory work as the test will presumably use `moto` which isn't yet a dependency of this repo. And because this will be the third place I'd be copypasta-ing basically the same `moto`-based pytest fixtures, it feels like time to stick them together - possibly in `-test-utils`?
- Multithread the loop. Not particularly hard - we have multiple `antivirus-api` instances and multiple webserver and `clamd` processes per instances - the service should be able to handle a number of requests in parallel with no problem and this should reduce the execution time when performing batch scans. Maybe I should run a timing test to give people a better picture how "slow" a full-bucket scan could be. Incidentally, this is why I designed the log messages in a way that would make sense if the request and response for each file got interleaved with another...
- Options like "force re-scan"? This would also require additions to the api endpoint, but I definitely foresee us needing to do this at some point in the future.
 - Actually run this on production to reassure ourselves we're not already hosting any nasties.

Thoughts on what order they'd like these done in?