### PR TITLE
virus_scan_s3_bucket: don't try to be so clever in counting

### DIFF
--- a/scripts/virus-scan-s3-bucket.py
+++ b/scripts/virus-scan-s3-bucket.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 
     with ThreadPoolExecutor(max_workers=args.concurrency) if args.concurrency else nullcontext() as executor:
         map_callable = map if executor is None else executor.map
-        candidate_count, pass_count, fail_count, already_tagged_count = virus_scan_bucket(
+        counter = virus_scan_bucket(
             s3_client=boto3.client("s3", region_name="eu-west-1"),  # actual region specified here doesn't matter
             antivirus_api_client=av_api_client,
             bucket_name=args.bucket,
@@ -103,10 +103,10 @@ if __name__ == '__main__':
 
     logger.info(
         "Total files found:\t%s\nTotal files passed:\t%s\nTotal files failed:\t%s\nTotal files already tagged:\t%s",
-        candidate_count,
-        pass_count,
-        fail_count,
-        already_tagged_count,
+        counter.get("candidate", 0),
+        counter.get("pass", 0),
+        counter.get("fail", 0),
+        counter.get("already_passed", 0),
     )
 
-    sys.exit(fail_count)
+    sys.exit(counter.get("fail", 0))

--- a/tests/test_virus_scan_s3_bucket.py
+++ b/tests/test_virus_scan_s3_bucket.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import datetime
@@ -167,7 +168,7 @@ class TestVirusScanBucket:
 
         if dry_run:
             assert av_api_client.mock_calls == []
-            assert retval == (7, 0, 0, 0,)
+            assert retval == Counter({"candidate": 7})
         else:
             # taking string representations because call()s are not sortable and we want to disregard order
             assert sorted(str(c) for c in av_api_client.mock_calls) == sorted(str(c) for c in (
@@ -179,7 +180,12 @@ class TestVirusScanBucket:
                 mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "molo.oB_oLdelp"),
                 mock.call.scan_and_tag_s3_object("spade", "dribbling/bib.jpeg", "ldmoo_.pBeolLo"),
             ))
-            assert retval == (7, 4, 1, 2,)
+            assert retval == Counter({
+                "candidate": 7,
+                "pass": 4,
+                "fail": 1,
+                "already_tagged": 2,
+            })
 
     @pytest.mark.parametrize("concurrency", (0, 1, 3,))
     @pytest.mark.parametrize("versions_page_size", (2, 4, 100,))
@@ -206,7 +212,7 @@ class TestVirusScanBucket:
 
         if dry_run:
             assert av_api_client.mock_calls == []
-            assert retval == (3, 0, 0, 0,)
+            assert retval == Counter({"candidate": 3})
         else:
             # taking string representations because call()s are not sortable and we want to disregard order
             assert sorted(str(c) for c in av_api_client.mock_calls) == sorted(str(c) for c in (
@@ -214,7 +220,12 @@ class TestVirusScanBucket:
                 mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "ooBmo_pe.ldoLl"),
                 mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "molo.oB_oLdelp"),
             ))
-            assert retval == (3, 1, 1, 1,)
+            assert retval == Counter({
+                "candidate": 3,
+                "pass": 1,
+                "fail": 1,
+                "already_tagged": 1,
+            })
 
     @pytest.mark.parametrize("concurrency", (0, 1, 3,))
     @pytest.mark.parametrize("versions_page_size", (2, 4, 100,))
@@ -244,7 +255,7 @@ class TestVirusScanBucket:
 
         if dry_run:
             assert av_api_client.mock_calls == []
-            assert retval == (6, 0, 0, 0,)
+            assert retval == Counter({"candidate": 6})
         else:
             # taking string representations because call()s are not sortable and we want to disregard order
             assert sorted(str(c) for c in av_api_client.mock_calls) == sorted(str(c) for c in (
@@ -255,4 +266,9 @@ class TestVirusScanBucket:
                 mock.call.scan_and_tag_s3_object("spade", "sandman/1234-deedaw.pdf", "loleLoooBp_md."),
                 mock.call.scan_and_tag_s3_object("spade", "sandman/4321-billy-winks.pdf", "molo.oB_oLdelp"),
             ))
-            assert retval == (6, 3, 1, 2,)
+            assert retval == Counter({
+                "candidate": 6,
+                "pass": 3,
+                "fail": 1,
+                "already_tagged": 2,
+            })


### PR DESCRIPTION
https://trello.com/c/aWnL8fAa/192-antivirus-create-catch-up-bulk-scan-script

@lfdebrux alerted me that integer increment in python is indeed *not* atomic. So instead don't try to be such a smartass in the file counting and instead pass the counts in the map function results and accumulate in the loop...