### PR TITLE
digitalmarketplace-apiclient dependency: bump to v19.7.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.6.0#egg=digitalmarketplace-utils==44.6.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.6.0#egg=digitalmarketplace-apiclient==19.6.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digitalmarketplace-apiclient==19.7.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
 awscli==1.14.31

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.6.0#egg=digitalmarketplace-utils==44.6.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.6.0#egg=digitalmarketplace-apiclient==19.6.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digitalmarketplace-apiclient==19.7.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.8.0#egg=digitalmarketplace-content-loader==2.8.0
 
 awscli==1.14.31
@@ -26,7 +26,7 @@ yq==2.4.1
 asn1crypto==0.24.0
 boto3==1.7.83
 botocore==1.10.84
-certifi==2018.8.24
+certifi==2018.10.15
 cffi==1.11.5
 chardet==3.0.4
 Click==7.0

--- a/scripts/virus-scan-s3-bucket.py
+++ b/scripts/virus-scan-s3-bucket.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
         counter.get("candidate", 0),
         counter.get("pass", 0),
         counter.get("fail", 0),
-        counter.get("already_passed", 0),
+        counter.get("already_tagged", 0),
     )
 
     sys.exit(counter.get("fail", 0))


### PR DESCRIPTION
https://trello.com/c/ZSg7FK5s/201-switch-av-api-scanandtags3object-endpoint-to-put-was-apiclient-sort-out-timeouts-retrying-once-for-all

This causes the `virus-scan-s3-bucket.py` script to use `PUT` requests which should add reliability.