### PR TITLE
virus_scan_s3_bucket: handle 4xx errors from antivirus-api, counting them & continuing

### DIFF
--- a/scripts/virus-scan-s3-bucket.py
+++ b/scripts/virus-scan-s3-bucket.py
@@ -108,11 +108,16 @@ if __name__ == '__main__':
             raise
 
     logger.info(
-        "Total files found:\t%s\nTotal files passed:\t%s\nTotal files failed:\t%s\nTotal files already tagged:\t%s",
+        "Total files found:\t%s\n"
+        "Total files passed:\t%s\n"
+        "Total files failed:\t%s\n"
+        "Total files already tagged:\t%s"
+        "Total files errored:\t%s",
         counter.get("candidate", 0),
         counter.get("pass", 0),
         counter.get("fail", 0),
         counter.get("already_tagged", 0),
+        counter.get("error", 0),
     )
 
-    sys.exit(counter.get("fail", 0))
+    sys.exit(counter.get("fail", 0) + counter.get("error", 0))


### PR DESCRIPTION
https://trello.com/c/eI2PEVIY/202-create-jenkins-job-for-virus-scanning-catchup-script

Script counterpart to https://github.com/alphagov/digitalmarketplace-antivirus-api/pull/19