### PR TITLE
Use utils api endpoint helper

### DIFF
--- a/dmscripts/get_user.py
+++ b/dmscripts/get_user.py
@@ -1,10 +1,10 @@
 
 import sys
-
 import dmapiclient
 
 sys.path.insert(0, '.')  # noqa
-from dmscripts.helpers.auth_helpers import get_auth_token, get_api_url
+from dmutils.env_helpers import get_api_endpoint_from_stage
+from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.framework_helpers import get_full_framework_slug
 from dmscripts.helpers.user_helpers import (
     get_random_buyer_with_brief,
@@ -15,7 +15,7 @@ from dmscripts.helpers.user_helpers import (
 
 def get_user(api_url, api_token, stage, role, framework, lot):
     if not api_url:
-        api_url = get_api_url('api', stage)
+        api_url = get_api_endpoint_from_stage(stage)
 
     api_token = api_token or get_auth_token('api', stage)
     api_client = dmapiclient.DataAPIClient(api_url, api_token)

--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -26,14 +26,3 @@ def get_auth_token(api, stage):
         auth_token = next(token for token in auth_tokens if token.startswith(token_prefix))
 
     return auth_token
-
-
-def get_api_url(api, stage):
-    if stage in DEV_ALIASES:
-        url = 'http://localhost:{}'.format(5001 if api == 'search-api' else 5000)
-    elif stage == 'production':
-        url = 'https://{}.digitalmarketplace.service.gov.uk'
-    else:
-        url = 'https://{{}}.{}.marketplace.team'.format(stage)
-
-    return url.format(api)

--- a/scripts/api-clients-shell.py
+++ b/scripts/api-clients-shell.py
@@ -25,7 +25,8 @@ import sys
 from dmapiclient import DataAPIClient, SearchAPIClient
 
 sys.path.insert(0, '.')
-from dmscripts.helpers.auth_helpers import get_auth_token, get_api_url
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmutils.env_helpers import get_api_endpoint_from_stage
 
 
 def clients_in_shell(stage, api_url, api_token, search_api_url, search_api_token):
@@ -34,8 +35,8 @@ def clients_in_shell(stage, api_url, api_token, search_api_url, search_api_token
     search_api_token = search_api_token or get_auth_token('search_api', stage)
 
     print('Creating clients...')
-    data = DataAPIClient(api_url or get_api_url('api', stage), api_token)  # noqa
-    search = SearchAPIClient(search_api_url or get_api_url('search-api', stage), search_api_token)  # noqa
+    data = DataAPIClient(api_url or get_api_endpoint_from_stage(stage), api_token)  # noqa
+    search = SearchAPIClient(search_api_url or get_api_endpoint_from_stage(stage, app='search-api'), search_api_token)  # noqa
 
     print('Dropping into shell...')
     IPython.embed()

--- a/scripts/clients.py
+++ b/scripts/clients.py
@@ -19,7 +19,8 @@ import sys
 from dmapiclient import DataAPIClient, SearchAPIClient
 
 sys.path.insert(0, '.')
-from dmscripts.helpers.auth_helpers import get_auth_token, get_api_url
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmutils.env_helpers import get_api_endpoint_from_stage
 
 
 def clients_in_shell(stage):
@@ -32,8 +33,8 @@ def clients_in_shell(stage):
         search_api_token = get_auth_token('search_api', stage)
 
     print('Creating clients...')
-    data = DataAPIClient(get_api_url('api', stage), api_token)  # noqa
-    search = SearchAPIClient(get_api_url('search-api', stage), search_api_token)  # noqa
+    data = DataAPIClient(get_api_endpoint_from_stage(stage), api_token)  # noqa
+    search = SearchAPIClient(get_api_endpoint_from_stage(stage, app='search-api'), search_api_token)  # noqa
 
     print('Dropping into shell...')
     IPython.embed()

--- a/scripts/oneoff/acknowledge_publish_draft_service_updates.py
+++ b/scripts/oneoff/acknowledge_publish_draft_service_updates.py
@@ -10,7 +10,8 @@ from dmapiclient.data import DataAPIClient
 
 sys.path.insert(0, '.')
 
-from dmscripts.helpers.auth_helpers import get_api_url, get_auth_token
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmutils.env_helpers import get_api_endpoint_from_stage
 
 
 ACKNOWLEDGE_USER = 'scripts/oneoff/acknowledge_publish_draft_service_updates.py'
@@ -30,7 +31,7 @@ if __name__ == '__main__':
                                                '(YYYY-MM-DD).')
     args = parser.parse_args()
 
-    data = DataAPIClient(get_api_url('api', args.stage), get_auth_token('api', args.stage))
+    data = DataAPIClient(get_api_endpoint_from_stage(args.stage), get_auth_token('api', args.stage))
 
     audit_events = data.find_audit_events_iter(audit_type=AuditTypes.update_service,
                                                user='Moving documents to live bucket',

--- a/scripts/oneoff/inject-framework-dates.py
+++ b/scripts/oneoff/inject-framework-dates.py
@@ -15,7 +15,8 @@ import argparse
 sys.path.insert(0, '.')
 
 from dmapiclient import DataAPIClient
-from dmscripts.helpers.auth_helpers import get_auth_token, get_api_url
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmutils.env_helpers import get_api_endpoint_from_stage
 
 # Dates taken from https://github.com/alphagov/digitalmarketplace-frameworks/blob
 # /e1f8e5c4a1a98d817e1bc9ff90ace85c1a0762c6/frameworks/<framework>/messages/dates.yml
@@ -110,7 +111,7 @@ FRAMEWORKS_AND_DATES = {
 
 def inject_framework_dates(stage):
     data_api_token = get_auth_token('api', stage) if stage != 'development' else 'myToken'
-    data_api_client = DataAPIClient(get_api_url('api', stage), data_api_token)
+    data_api_client = DataAPIClient(get_api_endpoint_from_stage(stage), data_api_token)
 
     for framework_slug, framework_data in FRAMEWORKS_AND_DATES.items():
         print(f'Injecting dates for {framework_slug}: {framework_data}')

--- a/scripts/oneoff/reset-supplier-declaration.py
+++ b/scripts/oneoff/reset-supplier-declaration.py
@@ -20,12 +20,13 @@ sys.path.insert(0, '.')
 
 from dmapiclient import DataAPIClient
 from dmapiclient.errors import HTTPError
-from dmscripts.helpers.auth_helpers import get_auth_token, get_api_url
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmutils.env_helpers import get_api_endpoint_from_stage
 
 
 def reset_supplier_declaration(stage, framework_slug, reason, email, supplier_id):
     data_api_token = get_auth_token('api', stage) if stage != 'development' else 'myToken'
-    data_api_client = DataAPIClient(get_api_url('api', stage), data_api_token)
+    data_api_client = DataAPIClient(get_api_endpoint_from_stage(stage), data_api_token)
 
     if email:
         user = data_api_client.get_user(email_address=email)


### PR DESCRIPTION
See https://github.com/alphagov/digitalmarketplace-scripts/issues/257

(I've had this Issue tab open in my browser for months and it's starting to annoy me - just this and one more branch to tick off, then we can close it)

- Utils has a function to construct API urls for each stage (including local/dev). See https://github.com/alphagov/digitalmarketplace-utils/blob/master/dmutils/env_helpers.py
- Scripts certainly doesn't need its own function to do this
- Most of the scripts already use the utils function; this PR cleans up the remaining scripts and deletes the function