### PR TITLE
Revert ItsDangerous version bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ Flask-WTF==0.14.2
 future==0.16.0
 idna==2.7
 inflection==0.3.1
-ItsDangerous==1.0.0
+itsdangerous==0.24
 Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==2.0.18


### PR DESCRIPTION
ItsDangerous==1.0.0 was pulled from PyPI which makes this version of digitalmarketplace-scripts fail when `make requirements` is run.

As various parts of our infrastructure rely on scripts we need to revert to the last available version of ItsDangerous.

As of now there is a 1.1.0 version of ItsDangerous available, however for stability it is preferable to use the tried and tested version.