### PR TITLE
Pin itsdangerous to version 0.24

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,6 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 Flask==1.0.2
+itsdangerous==0.24
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.6.0#egg=digitalmarketplace-utils==44.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # with package version changes made in requirements-app.txt
 
 Flask==1.0.2
+itsdangerous==0.24
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.6.0#egg=digitalmarketplace-utils==44.6.0
@@ -36,10 +37,9 @@ docutils==0.14
 Flask-Login==0.4.1
 Flask-Script==2.0.6
 Flask-WTF==0.14.2
-future==0.16.0
+future==0.17.0
 idna==2.7
 inflection==0.3.1
-itsdangerous==0.24
 Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==2.0.18
@@ -53,7 +53,7 @@ odfpy==1.3.6
 pyasn1==0.4.4
 pycparser==2.19
 PyJWT==1.6.4
-pytz==2018.6
+pytz==2018.7
 PyYAML==3.13
 requests==2.20.0
 rsa==3.4.2


### PR DESCRIPTION
Pallets recently released and then pulled version 1.0.0 of the library itsdangerous, which is a requirement of Flask. See [this Trello card](https://trello.com/b/NnlGJoWD) for details.

We've decided that this time we want to wait a bit before commiting to the new version, so this commit pins this app to the old 0.24 version