### PR TITLE
Avoid confusing initialisation of assess_draft_services for suppliers with an incomplete declaration

### DIFF
--- a/dmscripts/export_framework_results_reasons.py
+++ b/dmscripts/export_framework_results_reasons.py
@@ -24,7 +24,7 @@ def get_validation_errors(candidate, schema):
 
 def add_failed_questions(questions_numbers,
                          declaration_definite_pass_schema,
-                         declaration_baseline_schema
+                         declaration_discretionary_pass_schema
                          ):
     def inner(record):
         if record['declaration'].get('status') != 'complete':
@@ -34,8 +34,11 @@ def add_failed_questions(questions_numbers,
 
         all_failed_keys = get_validation_errors(record['declaration'], declaration_definite_pass_schema)
 
-        if declaration_baseline_schema:
-            baseline_only_failed_keys = get_validation_errors(record['declaration'], declaration_baseline_schema)
+        if declaration_discretionary_pass_schema:
+            baseline_only_failed_keys = get_validation_errors(
+                record['declaration'],
+                declaration_discretionary_pass_schema
+            )
         else:
             baseline_only_failed_keys = all_failed_keys
 
@@ -61,13 +64,13 @@ def find_suppliers_with_details(client,
                                 questions_numbers,
                                 framework_slug,
                                 declaration_definite_pass_schema,
-                                declaration_baseline_schema,
+                                declaration_discretionary_pass_schema,
                                 supplier_ids=None
                                 ):
     records = find_suppliers_with_details_and_draft_service_counts(client, framework_slug, supplier_ids)
     records = list(map(add_failed_questions(questions_numbers,
                                             declaration_definite_pass_schema,
-                                            declaration_baseline_schema), records))
+                                            declaration_discretionary_pass_schema), records))
 
     return records
 
@@ -178,7 +181,7 @@ def export_suppliers(
     content_loader,
     output_dir,
     declaration_definite_pass_schema,
-    declaration_baseline_schema=None,
+    declaration_discretionary_pass_schema=None,
     supplier_ids=None,
 ):
     if not os.path.exists(output_dir):
@@ -191,7 +194,7 @@ def export_suppliers(
         questions_numbers,
         framework_slug,
         declaration_definite_pass_schema,
-        declaration_baseline_schema,
+        declaration_discretionary_pass_schema,
         supplier_ids
     )
 

--- a/scripts/export-framework-results-reasons.py
+++ b/scripts/export-framework-results-reasons.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
     content_loader = ContentLoader(args['<content_path>'])
 
     declaration_definite_pass_schema = json.load(open(args["<declaration_schema_path>"], "r"))
-    declaration_baseline_schema = (declaration_definite_pass_schema.get("definitions") or {}).get("baseline")
+    declaration_discretionary_pass_schema = (declaration_definite_pass_schema.get("definitions") or {}).get("baseline")
 
     supplier_id_file = args['<supplier_id_file>']
     supplier_ids = get_supplier_ids_from_file(supplier_id_file)
@@ -50,6 +50,6 @@ if __name__ == '__main__':
         content_loader,
         args['<output_dir>'],
         declaration_definite_pass_schema,
-        declaration_baseline_schema,
+        declaration_discretionary_pass_schema,
         supplier_ids
     )

--- a/scripts/mark-definite-framework-results.py
+++ b/scripts/mark-definite-framework-results.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     declaration_definite_pass_schema = json.load(open(args["<declaration_definite_pass_schema_path>"], "r"))
 
-    declaration_baseline_schema = \
+    declaration_discretionary_pass_schema = \
         (declaration_definite_pass_schema.get("definitions") or {}).get("baseline")
 
     service_schema = json.load(
@@ -76,7 +76,7 @@ if __name__ == "__main__":
         updated_by,
         args["<framework_slug>"],
         declaration_definite_pass_schema,
-        declaration_baseline_schema=declaration_baseline_schema,
+        declaration_discretionary_pass_schema=declaration_discretionary_pass_schema,
         service_schema=service_schema,
         reassess_passed=args["--reassess-passed-sf"],
         reassess_failed=args["--reassess-failed-sf"],

--- a/tests/test_mark_definite_framework_results.py
+++ b/tests/test_mark_definite_framework_results.py
@@ -38,21 +38,27 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
     @pytest.mark.parametrize(
         # we can very easily parametrize this into the 16 possible combinations of these flags - the results for the
         # first three flags should be identical and it's very easy to flip some of the assertions for the dry_run mode
-        "reassess_passed,reassess_failed,reassess_failed_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
-    def test_with_ds_schema(self, reassess_passed, reassess_failed, reassess_failed_ds, dry_run,):
+    def test_with_ds_schema(
+            self,
+            reassess_passed_suppliers,
+            reassess_failed_suppliers,
+            reassess_failed_suppliers_ds,
+            dry_run,
+    ):
         mark_definite_framework_results(
             self.mock_data_client,
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=reassess_passed,
-            reassess_failed=reassess_failed,
-            reassess_failed_draft_services=reassess_failed_ds,
+            reassess_passed_suppliers=reassess_passed_suppliers,
+            reassess_failed_suppliers=reassess_failed_suppliers,
+            reassess_failed_draft_services=reassess_failed_suppliers_ds,
         )
 
         expected_sf_actions = {
@@ -73,21 +79,27 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed,reassess_failed,reassess_failed_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
-    def test_without_ds_schema(self, reassess_passed, reassess_failed, reassess_failed_ds, dry_run,):
+    def test_without_ds_schema(
+            self,
+            reassess_passed_suppliers,
+            reassess_failed_suppliers,
+            reassess_failed_suppliers_ds,
+            dry_run,
+    ):
         mark_definite_framework_results(
             self.mock_data_client,
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=None,
             dry_run=dry_run,
-            reassess_passed=reassess_passed,
-            reassess_failed=reassess_failed,
-            reassess_failed_draft_services=reassess_failed_ds,
+            reassess_passed_suppliers=reassess_passed_suppliers,
+            reassess_failed_suppliers=reassess_failed_suppliers,
+            reassess_failed_draft_services=reassess_failed_suppliers_ds,
         )
 
         expected_sf_actions = {
@@ -104,14 +116,14 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed,reassess_failed,reassess_failed_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
     def test_no_baseline_schema(
         self,
-        reassess_passed,
-        reassess_failed,
-        reassess_failed_ds,
+        reassess_passed_suppliers,
+        reassess_failed_suppliers,
+        reassess_failed_suppliers_ds,
         dry_run,
     ):
         mark_definite_framework_results(
@@ -119,12 +131,12 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=None,
+            declaration_discretionary_pass_schema=None,
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=reassess_passed,
-            reassess_failed=reassess_failed,
-            reassess_failed_draft_services=reassess_failed_ds,
+            reassess_passed_suppliers=reassess_passed_suppliers,
+            reassess_failed_suppliers=reassess_failed_suppliers,
+            reassess_failed_draft_services=reassess_failed_suppliers_ds,
         )
 
         expected_sf_actions = {
@@ -144,14 +156,14 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed,reassess_failed,reassess_failed_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
     def test_neither_optional_schema(
         self,
-        reassess_passed,
-        reassess_failed,
-        reassess_failed_ds,
+        reassess_passed_suppliers,
+        reassess_failed_suppliers,
+        reassess_failed_suppliers_ds,
         dry_run,
     ):
         mark_definite_framework_results(
@@ -159,12 +171,12 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=None,
+            declaration_discretionary_pass_schema=None,
             service_schema=None,
             dry_run=dry_run,
-            reassess_passed=reassess_passed,
-            reassess_failed=reassess_failed,
-            reassess_failed_draft_services=reassess_failed_ds,
+            reassess_passed_suppliers=reassess_passed_suppliers,
+            reassess_failed_suppliers=reassess_failed_suppliers,
+            reassess_failed_draft_services=reassess_failed_suppliers_ds,
         )
 
         expected_sf_actions = {
@@ -188,11 +200,11 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=False,
-            reassess_failed=False,
+            reassess_passed_suppliers=False,
+            reassess_failed_suppliers=False,
             reassess_failed_draft_services=False,
         )
 
@@ -209,17 +221,17 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
     @pytest.mark.parametrize("dry_run", (False, True,),)
-    def test_reassess_failed(self, dry_run,):
+    def test_reassess_failed_suppliers(self, dry_run,):
         mark_definite_framework_results(
             self.mock_data_client,
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=False,
-            reassess_failed=True,
+            reassess_passed_suppliers=False,
+            reassess_failed_suppliers=True,
             reassess_failed_draft_services=False,
         )
 
@@ -237,17 +249,17 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
     @pytest.mark.parametrize("dry_run", (False, True,),)
-    def test_reassess_passed(self, dry_run,):
+    def test_reassess_passed_suppliers(self, dry_run,):
         mark_definite_framework_results(
             self.mock_data_client,
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=True,
-            reassess_failed=False,
+            reassess_passed_suppliers=True,
+            reassess_failed_suppliers=False,
             reassess_failed_draft_services=False,
         )
 
@@ -272,11 +284,11 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=True,
-            reassess_failed=True,
+            reassess_passed_suppliers=True,
+            reassess_failed_suppliers=True,
             reassess_failed_draft_services=True,
         )
 
@@ -304,11 +316,11 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=None,
             dry_run=dry_run,
-            reassess_passed=True,
-            reassess_failed=True,
+            reassess_passed_suppliers=True,
+            reassess_failed_suppliers=True,
             reassess_failed_draft_services=True,
         )
 


### PR DESCRIPTION
Needed to check how this worked and decided to add some comments/ do a bit of a refactor.
We don't need to assess_draft_services if the supplier hasn't completed their declaration. 