### PR TITLE
Delete unsuccessful suppliers declarations

### DIFF
--- a/dmscripts/data_retention_remove_supplier_declarations.py
+++ b/dmscripts/data_retention_remove_supplier_declarations.py
@@ -8,3 +8,13 @@ def remove_supplier_data(data_api_client, logger, dry_run: bool):
         dry_run=dry_run
     )
     supplier_frameworks.remove_supplier_declaration_for_expired_frameworks()
+
+
+def remove_unsuccessful_supplier_declarations(data_api_client, logger, dry_run: bool, framework_slug: str):
+    supplier_frameworks_methods = SupplierFrameworkDeclarations(
+        api_client=data_api_client,
+        logger=logger,
+        dry_run=dry_run,
+        framework_slug=framework_slug
+    )
+    supplier_frameworks_methods.remove_declaration_from_failed_applicants()

--- a/dmscripts/data_retention_remove_supplier_declarations.py
+++ b/dmscripts/data_retention_remove_supplier_declarations.py
@@ -1,7 +1,7 @@
 from dmscripts.helpers.supplier_data_helpers import SupplierFrameworkDeclarations
 
 
-def remove_supplier_data(data_api_client, logger, dry_run: bool):
+def remove_supplier_data(data_api_client, logger, dry_run):
     supplier_frameworks = SupplierFrameworkDeclarations(
         api_client=data_api_client,
         logger=logger,
@@ -10,7 +10,7 @@ def remove_supplier_data(data_api_client, logger, dry_run: bool):
     supplier_frameworks.remove_supplier_declaration_for_expired_frameworks()
 
 
-def remove_unsuccessful_supplier_declarations(data_api_client, logger, dry_run: bool, framework_slug: str):
+def remove_unsuccessful_supplier_declarations(data_api_client, logger, dry_run, framework_slug):
     supplier_frameworks_methods = SupplierFrameworkDeclarations(
         api_client=data_api_client,
         logger=logger,

--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -206,7 +206,7 @@ class SupplierFrameworkDeclarations:
         """
         failed_supplier_ids = self.suppliers_application_failed_to_framework()
         for supplier_id in failed_supplier_ids:
-            self.remove_declaration(supplier_id)
+            self.remove_declaration(supplier_id, self.framework_slug)
 
     def _frameworks_older_than_date(self, date_closed):
         """

--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -232,7 +232,7 @@ class SupplierFrameworkDeclarations:
         for framework in old_frameworks:
             suppliers_with_declarations_to_clear = self.api_client.find_framework_suppliers_iter(
                 framework_slug=framework
-            )['supplierFrameworks']
+            )
             for supplier in suppliers_with_declarations_to_clear:
                 self.logger.info(
                     f"Declaration of supplier {supplier['supplierId']} "

--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -160,7 +160,7 @@ class SupplierFrameworkDeclarations:
     Methods for manipulating supplier declarations
     """
 
-    def __init__(self, api_client, logger, framework_slug: str=None, dry_run: bool=True):
+    def __init__(self, api_client, logger, framework_slug, dry_run):
         self.api_client = api_client
         self.framework_slug = framework_slug
         self.dry_run = dry_run
@@ -179,7 +179,7 @@ class SupplierFrameworkDeclarations:
             if framework_supplier['onFramework'] is not True
         ]
 
-    def remove_declaration(self, supplier_id: int, framework_slug: str):
+    def remove_declaration(self, supplier_id, framework_slug):
         """
         This method accesses an endpoint and removes the declaration of the associated SupplierFramework. It returns
         either the response object from the endpoint, or throws an exception

--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -195,6 +195,10 @@ class SupplierFrameworkDeclarations:
                              supplier_id, framework_slug
                              )
         else:
+            self.logger.info(
+                f"Declaration of supplier {supplier_id} "
+                f"that applied to framework {framework_slug} removed"
+            )
             return self.api_client.remove_supplier_declaration(supplier_id, framework_slug, 'user')
 
     def remove_declaration_from_failed_applicants(self):
@@ -234,10 +238,6 @@ class SupplierFrameworkDeclarations:
                 framework_slug=framework
             )
             for supplier in suppliers_with_declarations_to_clear:
-                self.logger.info(
-                    f"Declaration of supplier {supplier['supplierId']} "
-                    f"that applied to framework {framework} removed"
-                )
                 self.remove_declaration(supplier['supplierId'], framework_slug=framework)
         self.logger.info("All declarations older than three years have been cleared")
 

--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -160,13 +160,12 @@ class SupplierFrameworkDeclarations:
     Methods for manipulating supplier declarations
     """
 
-    def __init__(self, api_client, logger, framework_slug, dry_run):
+    def __init__(self, api_client, logger, dry_run):
         self.api_client = api_client
-        self.framework_slug = framework_slug
         self.dry_run = dry_run
         self.logger = logger
 
-    def suppliers_application_failed_to_framework(self):
+    def suppliers_application_failed_to_framework(self, framework_slug):
         """
         This functions calls the api endpoint and returns a list of the supplier_ids of suppliers that applied to be on
         the framework specified when the class was created but failed
@@ -175,7 +174,7 @@ class SupplierFrameworkDeclarations:
         """
         return [
             framework_supplier['supplierId']
-            for framework_supplier in self.api_client.find_framework_suppliers_iter(self.framework_slug)
+            for framework_supplier in self.api_client.find_framework_suppliers_iter(framework_slug)
             if framework_supplier['onFramework'] is not True
         ]
 
@@ -201,16 +200,16 @@ class SupplierFrameworkDeclarations:
             )
             return self.api_client.remove_supplier_declaration(supplier_id, framework_slug, 'user')
 
-    def remove_declaration_from_failed_applicants(self):
+    def remove_declaration_from_failed_applicants(self, framework_slug):
         """
         This method gets a list of failed applicants and then calls the remove_declaration function for each one. It
         returns None.
         :return: None
         :rtype: None
         """
-        failed_supplier_ids = self.suppliers_application_failed_to_framework()
+        failed_supplier_ids = self.suppliers_application_failed_to_framework(framework_slug)
         for supplier_id in failed_supplier_ids:
-            self.remove_declaration(supplier_id, self.framework_slug)
+            self.remove_declaration(supplier_id, framework_slug)
 
     def _frameworks_older_than_date(self, date_closed):
         """

--- a/scripts/data-retention-remove-failed-suppliers-declarations.py
+++ b/scripts/data-retention-remove-failed-suppliers-declarations.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""
+Our data retention policy is that suppliers who fail to be accepted onto the framework have their declarations
+removed immediately. This reduces the likelihood of commercially sensitive data being leaked in the event of a breach
+
+This script is very simple and has not been upgraded to accept any arguments to prevent the possibility of accidental
+deletion. If you are in doubt use the dry run option.
+
+Usage: data-retention-remove-supplier-declarations.py <stage> <framework-slug> [--dry-run] [--verbose]
+
+Options:
+    --stage=<stage>                                       Stage to target
+    --framework-slug=<framework-slug>                     Framework to target
+
+    --dry-run
+    --verbose                                             List data that would have been stripped
+    -h, --help                                            Show this screen
+
+Examples:
+    ./scripts/data-retention-remove-failed-suppliers-declarations.py preview g-cloud-9
+    ./scripts/data-retention-remove-failed-suppliers-declarations.py preview g-cloud-9 --dry-run --verbose
+
+"""
+import logging
+import sys
+from docopt import docopt
+
+from dmapiclient import DataAPIClient
+
+sys.path.insert(0, '.')
+
+logger = logging.getLogger("script")
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers import logging_helpers
+from dmutils.env_helpers import get_api_endpoint_from_stage
+from dmscripts.data_retention_remove_supplier_declarations import remove_unsuccessful_supplier_declarations
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    # Get script arguments
+    stage = arguments['<stage>']
+
+    dry_run = arguments['--dry-run']
+    framework = arguments['<framework-slug>']
+    verbose = arguments['--verbose']
+
+    # Set defaults, instantiate clients
+    logging_helpers.configure_logger(
+        {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
+    )
+    data_api_client = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(stage),
+        auth_token=get_auth_token('api', stage)
+    )
+    remove_unsuccessful_supplier_declarations(
+        data_api_client=data_api_client,
+        logger=logger,
+        dry_run=dry_run,
+        framework_slug=framework
+    )

--- a/tests/helpers/test_supplier_data_helpers.py
+++ b/tests/helpers/test_supplier_data_helpers.py
@@ -14,25 +14,7 @@ class TestSupplierFrameworkDeclarations(BaseAssessmentTest):
     @pytest.fixture
     def mocked_api_client(self):
         from dmapiclient import DataAPIClient
-        return mock.create_autospec(DataAPIClient)
-
-    def _supplier_framework_response(self):
-        with open("tests/fixtures/test_supplier_frameworks_response.json", 'r') as response_file:
-            return json.load(response_file)['supplierFrameworks']
-
-    def test_suppliers_application_failed_to_framework(self, mocked_api_client):
-        mocked_api_client.find_framework_suppliers_iter.side_effect = lambda *args, **kwargs: \
-            iter(self._supplier_framework_response())
-        supplier_framework = SupplierFrameworkDeclarations(mocked_api_client, mock.ANY, 'g-cloud-8', dry_run=False)
-        assert supplier_framework.suppliers_application_failed_to_framework() == [12345, 23456]
-
-    def test_remove_declaration_from_suppliers(self, mocked_api_client):
-        mocked_api_client.remove_supplier_declaration.return_value = {'declaration': {}}
-        sfd = SupplierFrameworkDeclarations(mocked_api_client, mock.ANY, 'g-cloud-8', dry_run=False)
-        assert sfd.remove_declaration(1, 'g-cloud-8')['declaration'] == {}
-        mocked_api_client.remove_supplier_declaration.assert_called_with(1, 'g-cloud-8', 'user')
-
-    def test_remove_supplier_declaration_for_expired_frameworks(self, mocked_api_client):
+        mocked_api_client = mock.create_autospec(DataAPIClient)
         with freeze_time("Jan 1st, 2018"):
             mocked_api_client.find_frameworks.return_value = {
                 "frameworks": [
@@ -54,6 +36,26 @@ class TestSupplierFrameworkDeclarations(BaseAssessmentTest):
                     }
                 ]
             }
+            mocked_api_client.find_framework_suppliers_iter.side_effect = lambda *args, **kwargs: \
+                iter(self._supplier_framework_response())
+        return mocked_api_client
+
+    def _supplier_framework_response(self):
+        with open("tests/fixtures/test_supplier_frameworks_response.json", 'r') as response_file:
+            return json.load(response_file)['supplierFrameworks']
+
+    def test_suppliers_application_failed_to_framework(self, mocked_api_client):
+        supplier_framework = SupplierFrameworkDeclarations(mocked_api_client, mock.ANY, 'g-cloud-8', dry_run=False)
+        assert supplier_framework.suppliers_application_failed_to_framework() == [12345, 23456]
+
+    def test_remove_declaration_from_suppliers(self, mocked_api_client):
+        mocked_api_client.remove_supplier_declaration.return_value = {'declaration': {}}
+        sfd = SupplierFrameworkDeclarations(mocked_api_client, mock.ANY, 'g-cloud-8', dry_run=False)
+        assert sfd.remove_declaration(1, 'g-cloud-8')['declaration'] == {}
+        mocked_api_client.remove_supplier_declaration.assert_called_with(1, 'g-cloud-8', 'user')
+
+    def test_remove_supplier_declaration_for_expired_frameworks(self, mocked_api_client):
+        with freeze_time("Jan 1st, 2018"):
             sfd = SupplierFrameworkDeclarations(mocked_api_client, mock.MagicMock())
             sfd.remove_supplier_declaration_for_expired_frameworks()
             expected_calls = [
@@ -61,6 +63,15 @@ class TestSupplierFrameworkDeclarations(BaseAssessmentTest):
                 mock.call(framework_slug="framework-expired-a-decade-ago")
             ]
             mocked_api_client.find_framework_suppliers_iter.assert_has_calls(expected_calls, any_order=True)
+
+    def test_remove_declaration_from_failed_applicants(self, mocked_api_client):
+        sfd = SupplierFrameworkDeclarations(mocked_api_client, mock.MagicMock(), 'g-cloud-8', False)
+        sfd.remove_declaration_from_failed_applicants()
+        expected_calls = [
+            mock.call(supplier_id=12345, framework_slug='g-cloud-8', user='user'),
+            mock.call(supplier_id=23456, framework_slug='g-cloud-8', user='user')
+        ]
+        mocked_api_client.remove_supplier_declaration.assert_has_calls(expected_calls, any_order=True)
 
 
 class TestCountryCodeToName:

--- a/tests/helpers/test_supplier_data_helpers.py
+++ b/tests/helpers/test_supplier_data_helpers.py
@@ -45,18 +45,18 @@ class TestSupplierFrameworkDeclarations(BaseAssessmentTest):
             return json.load(response_file)['supplierFrameworks']
 
     def test_suppliers_application_failed_to_framework(self, mocked_api_client):
-        supplier_framework = SupplierFrameworkDeclarations(mocked_api_client, mock.ANY, 'g-cloud-8', dry_run=False)
-        assert supplier_framework.suppliers_application_failed_to_framework() == [12345, 23456]
+        supplier_framework = SupplierFrameworkDeclarations(mocked_api_client, mock.MagicMock(), dry_run=False)
+        assert supplier_framework.suppliers_application_failed_to_framework('g-cloud-8') == [12345, 23456]
 
     def test_remove_declaration_from_suppliers(self, mocked_api_client):
         mocked_api_client.remove_supplier_declaration.return_value = {'declaration': {}}
-        sfd = SupplierFrameworkDeclarations(mocked_api_client, mock.ANY, 'g-cloud-8', dry_run=False)
+        sfd = SupplierFrameworkDeclarations(mocked_api_client, mock.MagicMock(), dry_run=False)
         assert sfd.remove_declaration(1, 'g-cloud-8')['declaration'] == {}
         mocked_api_client.remove_supplier_declaration.assert_called_with(1, 'g-cloud-8', 'user')
 
     def test_remove_supplier_declaration_for_expired_frameworks(self, mocked_api_client):
         with freeze_time("Jan 1st, 2018"):
-            sfd = SupplierFrameworkDeclarations(mocked_api_client, mock.MagicMock())
+            sfd = SupplierFrameworkDeclarations(mocked_api_client, mock.MagicMock(), dry_run=False)
             sfd.remove_supplier_declaration_for_expired_frameworks()
             expected_calls = [
                 mock.call(framework_slug="framework-expired-three-years-ago"),
@@ -65,8 +65,8 @@ class TestSupplierFrameworkDeclarations(BaseAssessmentTest):
             mocked_api_client.find_framework_suppliers_iter.assert_has_calls(expected_calls, any_order=True)
 
     def test_remove_declaration_from_failed_applicants(self, mocked_api_client):
-        sfd = SupplierFrameworkDeclarations(mocked_api_client, mock.MagicMock(), 'g-cloud-8', False)
-        sfd.remove_declaration_from_failed_applicants()
+        sfd = SupplierFrameworkDeclarations(mocked_api_client, mock.MagicMock(), False)
+        sfd.remove_declaration_from_failed_applicants(framework_slug='g-cloud-8')
         expected_calls = [
             mock.call(supplier_id=12345, framework_slug='g-cloud-8', user='user'),
             mock.call(supplier_id=23456, framework_slug='g-cloud-8', user='user')


### PR DESCRIPTION
## What
This script builds pretty heavily on some work I've already done. It offers a script to remove declarations from the suppliers who failed to get onto a framework.

The script is called and the framework passed as an argument. It then finds all the suppliers that applied, identifies the ones who didn't make it on, and then deletes their declaration for that particular framework.

It does the filtering locally, in memory, because there doesn't seem to be an api method for finding unsuccessful suppliers. This is obviously inefficient at scale, and we estimate there's approximately 4,000 applicants per framework. However, I don't think committing more time into developing a new method is an efficient use of our time. 

[Here's a Trello card](https://trello.com/c/yOHN6iUB/3-deleting-declarations-of-unsuccessful-suppliers)