### PR TITLE
Add Python badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # digitalmarketplace-scripts
 
+![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
+
 ## A short overview of current scripts
 
 The `scripts` folder in this repository contains scripts that interact with the Digital Marketplace APIs (


### PR DESCRIPTION
Adds a nifty visual indicator of what versions of Python we support

Part of https://trello.com/c/wWFsv1SU/230-be-clear-in-our-libraries-what-versions-of-python-we-support