### PR TITLE
default.nix: add self-contained aws-auth.nix now that it is removed from nixpkgs

### DIFF
--- a/aws-auth.nix
+++ b/aws-auth.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, makeWrapper, jq, awscli, openssl }:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2018-04-04";
+  name = "aws-auth-${version}";
+
+  src = fetchFromGitHub {
+    owner = "alphagov";
+    repo = "aws-auth";
+    rev = "03e3eb2a0e89c6d55f0721462a6bc077aa4668bf";
+    sha256 = "0r89kvkcjsz6v9r2pk45v82v623y334b0hfvdvzfnls3j7d23m2p";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # copy script and set $PATH
+  installPhase = ''
+    install -D $src/aws-auth.sh $out/bin/aws-auth
+    wrapProgram $out/bin/aws-auth \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ awscli jq openssl ]} \
+      --unset PYTHONPATH
+  '';
+
+  meta = {
+    homepage = https://github.com/alphagov/aws-auth;
+    description = "AWS authentication wrapper to handle MFA and IAM roles";
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ in (with args; {
       pkgs.openssl
       pkgs.cacert
       pkgs.sops
-      pkgs.aws-auth
+      ((import ./aws-auth.nix) (with pkgs; { inherit stdenv fetchFromGitHub makeWrapper jq awscli openssl; }))
     ] ++ pkgs.stdenv.lib.optionals (!pkgs.stdenv.isDarwin) [
       # package not available on darwin for now - sorry you're on your own...
       pkgs.wkhtmltopdf


### PR DESCRIPTION
Make it work, basically.