### PR TITLE
Bumps utils to 45.1.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ Flask==1.0.2
 itsdangerous==0.24
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.9.0#egg=digitalmarketplace-apiclient==19.9.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.0#egg=digitalmarketplace-content-loader==5.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==1.0.2
 itsdangerous==0.24
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.9.0#egg=digitalmarketplace-apiclient==19.9.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.0#egg=digitalmarketplace-content-loader==5.1.0
 
@@ -26,20 +26,21 @@ yq==2.4.1
 asn1crypto==0.24.0
 boto3==1.7.83
 botocore==1.10.84
-certifi==2018.10.15
+certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
 Click==7.0
 colorama==0.3.9
 contextlib2==0.5.5
 cryptography==2.3.1
+defusedxml==0.5.0
 docutils==0.14
 Flask-Login==0.4.1
 Flask-Script==2.0.6
 Flask-WTF==0.14.2
 fleep==1.0.1
 future==0.17.1
-idna==2.7
+idna==2.8
 inflection==0.3.1
 Jinja2==2.10
 jmespath==0.9.3
@@ -50,16 +51,16 @@ MarkupSafe==1.1.0
 monotonic==1.5
 notifications-python-client==5.2.0
 numpy==1.15.4
-odfpy==1.3.6
+odfpy==1.4.0
 pyasn1==0.4.4
 pycparser==2.19
-PyJWT==1.6.4
+PyJWT==1.7.1
 pytz==2018.7
 PyYAML==3.13
-requests==2.20.1
+requests==2.21.0
 rsa==3.4.2
 s3transfer==0.1.13
-six==1.11.0
+six==1.12.0
 urllib3==1.24.1
 Werkzeug==0.14.1
 workdays==1.4


### PR DESCRIPTION
This commit bumps the utils version to 45.1.1

This update should give us a more sensible timeout for mailchimp

[Ticket](https://trello.com/c/WvbcusNy/545-bump-utils-in-scripts-for-new-mailchmp-timeout)