### PR TITLE
threading: make all uses of multithreaded map do so through dependency injection

### DIFF
--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -189,7 +189,7 @@ def _create_row(framework_slug, record, count_statuses, framework_lot_slugs):
     ))
 
 
-def export_supplier_details(data_api_client, framework_slug, filename, framework_lot_slugs):
-    records = find_suppliers_with_details_and_draft_service_counts(data_api_client, framework_slug)
+def export_supplier_details(data_api_client, framework_slug, filename, framework_lot_slugs, map_impl=map):
+    records = find_suppliers_with_details_and_draft_service_counts(data_api_client, framework_slug, map_impl=map_impl)
     headers, rows_iter = get_csv_rows(records, framework_slug, framework_lot_slugs)
     write_csv(headers, rows_iter, filename)

--- a/dmscripts/export_framework_results_reasons.py
+++ b/dmscripts/export_framework_results_reasons.py
@@ -62,9 +62,15 @@ def find_suppliers_with_details(client,
                                 framework_slug,
                                 declaration_definite_pass_schema,
                                 declaration_baseline_schema,
-                                supplier_ids=None
+                                supplier_ids=None,
+                                map_impl=map,
                                 ):
-    records = find_suppliers_with_details_and_draft_service_counts(client, framework_slug, supplier_ids)
+    records = find_suppliers_with_details_and_draft_service_counts(
+        client,
+        framework_slug,
+        supplier_ids,
+        map_impl=map_impl,
+    )
     records = list(map(add_failed_questions(questions_numbers,
                                             declaration_definite_pass_schema,
                                             declaration_baseline_schema), records))
@@ -180,6 +186,7 @@ def export_suppliers(
     declaration_definite_pass_schema,
     declaration_baseline_schema=None,
     supplier_ids=None,
+    map_impl=map,
 ):
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
@@ -192,7 +199,8 @@ def export_suppliers(
         framework_slug,
         declaration_definite_pass_schema,
         declaration_baseline_schema,
-        supplier_ids
+        supplier_ids,
+        map_impl=map_impl,
     )
 
     handlers = [SuccessfulHandler(), FailedHandler(), DiscretionaryHandler()]

--- a/dmscripts/generate_buyer_email_list.py
+++ b/dmscripts/generate_buyer_email_list.py
@@ -1,4 +1,3 @@
-from multiprocessing.pool import ThreadPool
 from dmapiclient import HTTPError
 
 import sys
@@ -29,10 +28,9 @@ def buyer_requirements(client):
     return inner_function
 
 
-def add_buyer_requirements(client, users):
-    pool = ThreadPool(10)
+def add_buyer_requirements(client, users, map_unordered_impl=map):
     callback = buyer_requirements(client)
-    return pool.imap_unordered(callback, users)
+    return map_unordered_impl(callback, users)
 
 
 def find_buyer_users(client):
@@ -41,12 +39,12 @@ def find_buyer_users(client):
             yield user
 
 
-def list_buyers(client, output, include_briefs):
+def list_buyers(client, output, include_briefs, map_unordered_impl=map):
     writer = csv.writer(output, delimiter=',', quotechar='"')
     users = find_buyer_users(client)
 
     if include_briefs:
-        users = add_buyer_requirements(client, users)
+        users = add_buyer_requirements(client, users, map_unordered_impl=map_unordered_impl)
     else:
         users = ((user, None) for user in users)
 

--- a/dmscripts/helpers/framework_helpers.py
+++ b/dmscripts/helpers/framework_helpers.py
@@ -1,6 +1,5 @@
 from collections import Counter
 from functools import partial
-from multiprocessing.pool import ThreadPool
 import re
 
 from dmapiclient import HTTPError
@@ -39,24 +38,32 @@ def find_suppliers_on_framework(client, framework_slug):
     )
 
 
-def find_suppliers_with_details_and_draft_services(client, framework_slug, supplier_ids=None, lot=None, statuses=None):
-    pool = ThreadPool(3)
-
+def find_suppliers_with_details_and_draft_services(
+    client,
+    framework_slug,
+    supplier_ids=None,
+    lot=None,
+    statuses=None,
+    map_impl=map,
+):
     records = find_suppliers(client, framework_slug, supplier_ids)
-    records = pool.imap(partial(add_supplier_info, client), records)
-    records = pool.imap(partial(add_framework_info, client, framework_slug), records)
-    records = pool.imap(partial(add_draft_services, client, framework_slug, lot=lot, statuses=statuses), records)
+    records = map_impl(partial(add_supplier_info, client), records)
+    records = map_impl(partial(add_framework_info, client, framework_slug), records)
+    records = map_impl(partial(add_draft_services, client, framework_slug, lot=lot, statuses=statuses), records)
     records = [record for record in records if len(record["services"]) > 0]
     return records
 
 
-def find_suppliers_with_details_and_draft_service_counts(client, framework_slug, supplier_ids=None):
-    pool = ThreadPool(3)
-
+def find_suppliers_with_details_and_draft_service_counts(
+    client,
+    framework_slug,
+    supplier_ids=None,
+    map_impl=map,
+):
     records = find_suppliers(client, framework_slug, supplier_ids)
-    records = pool.imap(partial(add_supplier_info, client), records)
-    records = pool.imap(partial(add_framework_info, client, framework_slug), records)
-    records = pool.imap(partial(add_draft_counts, client, framework_slug), records)
+    records = map_impl(partial(add_supplier_info, client), records)
+    records = map_impl(partial(add_framework_info, client, framework_slug), records)
+    records = map_impl(partial(add_draft_counts, client, framework_slug), records)
     return records
 
 

--- a/scripts/export-dos-outcomes.py
+++ b/scripts/export-dos-outcomes.py
@@ -7,6 +7,7 @@ of outcome the supplier provides and the locations they can provide them in.
 Usage:
     scripts/export-dos-outcomes.py <stage> <framework_slug> <content_path>
 """
+from multiprocessing.pool import ThreadPool
 import sys
 sys.path.insert(0, '.')
 
@@ -21,11 +22,12 @@ from dmscripts.helpers.framework_helpers import find_suppliers_with_details_and_
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
 
-def find_all_outcomes(client):
+def find_all_outcomes(client, map_impl=map):
     return find_suppliers_with_details_and_draft_services(client,
                                                           FRAMEWORK_SLUG,
                                                           lot="digital-outcomes",
-                                                          statuses="submitted"
+                                                          statuses="submitted",
+                                                          map_impl=map_impl,
                                                           )
 
 
@@ -72,7 +74,10 @@ if __name__ == '__main__':
 
     capabilities = get_team_capabilities(content_manifest)
     locations = get_outcomes_locations(content_manifest)
-    suppliers = find_all_outcomes(client)
+
+    pool = ThreadPool(3)
+
+    suppliers = find_all_outcomes(client, map_impl=pool.imap)
 
     write_csv_with_make_row(
         suppliers,

--- a/scripts/export-framework-applicant-details.py
+++ b/scripts/export-framework-applicant-details.py
@@ -18,6 +18,7 @@ Example:
 """
 import datetime
 import errno
+from multiprocessing.pool import ThreadPool
 import os
 import sys
 
@@ -53,4 +54,6 @@ if __name__ == '__main__':
 
     framework_lot_slugs = tuple([lot['slug'] for lot in client.get_framework(FRAMEWORK)['frameworks']['lots']])
 
-    export_supplier_details(client, FRAMEWORK, filepath, framework_lot_slugs=framework_lot_slugs)
+    pool = ThreadPool(3)
+
+    export_supplier_details(client, FRAMEWORK, filepath, framework_lot_slugs=framework_lot_slugs, map_impl=pool.imap)

--- a/scripts/export-framework-results-reasons.py
+++ b/scripts/export-framework-results-reasons.py
@@ -20,6 +20,7 @@ Options:
     -h --help
 """
 import json
+from multiprocessing.pool import ThreadPool
 import sys
 sys.path.insert(0, '.')
 
@@ -44,6 +45,8 @@ if __name__ == '__main__':
     supplier_id_file = args['<supplier_id_file>']
     supplier_ids = get_supplier_ids_from_file(supplier_id_file)
 
+    pool = ThreadPool(3)
+
     export_suppliers(
         client,
         args['<framework_slug>'],
@@ -51,5 +54,6 @@ if __name__ == '__main__':
         args['<output_dir>'],
         declaration_definite_pass_schema,
         declaration_baseline_schema,
-        supplier_ids
+        supplier_ids,
+        map_impl=pool.imap,
     )

--- a/scripts/generate-buyer-email-list.py
+++ b/scripts/generate-buyer-email-list.py
@@ -4,6 +4,7 @@ Generate a list of buyer users name and email address, optionally with a list of
 Usage:
     scripts/generate-buyer-email-list.py <stage> [--briefs]
 """
+from multiprocessing.pool import ThreadPool
 import sys
 
 sys.path.insert(0, '.')
@@ -24,4 +25,6 @@ if __name__ == '__main__':
     output = sys.stdout
     include_briefs = bool(arguments.get('--briefs'))
 
-    list_buyers(client, output, include_briefs)
+    pool = ThreadPool(10)
+
+    list_buyers(client, output, include_briefs, unordered_map_impl=pool.imap_unordered)

--- a/scripts/generate-framework-agreement-signature-pages.py
+++ b/scripts/generate-framework-agreement-signature-pages.py
@@ -41,6 +41,7 @@ Usage:
     <path_to_agreements_repo> [<supplier_id_file>]
 
 """
+from multiprocessing.pool import ThreadPool
 import os
 import shutil
 import sys
@@ -71,7 +72,14 @@ if __name__ == '__main__':
     supplier_ids = get_supplier_ids_from_file(supplier_id_file)
     html_dir = tempfile.mkdtemp()
 
-    records = find_suppliers_with_details_and_draft_service_counts(client, framework_slug, supplier_ids)
+    pool = ThreadPool(3)
+
+    records = find_suppliers_with_details_and_draft_service_counts(
+        client,
+        framework_slug,
+        supplier_ids,
+        map_impl=pool.imap,
+    )
     headers, rows = get_csv_rows(records, framework_slug, framework_lot_slugs, count_statuses=("submitted",))
     render_html_for_successful_suppliers(
         rows, framework, os.path.join(args['<path_to_agreements_repo>'], 'documents', framework['slug']), html_dir


### PR DESCRIPTION
Stumbled upon this while trying to get the test suite to pass for https://github.com/alphagov/digitalmarketplace-scripts/pull/320 instead of deadlocking on unrelated tests.

This way different implementations can be supplied on invocation and e.g. we can call each in single threaded mode by supplying the builtin `map`, which is also used as the default argument everywhere so these functions can still be called from anywhere without worrying about the map implementation and still get a safe result.

This is particularly useful for tests, where running the code in multithreaded mode complicates things and can even cause deadlocks if an instance of `mock.Mock` is shared among several threads.

Something I'm a little nervous of with this is that we obviously don't have test coverage of the actual script entry points (i.e. `scripts/*`) which I've changed to now inject the thread pool. I *think* I've got them right though.