### PR TITLE
data-retention-remove-user-data: make this also check mailchimp mailing list membership

### DIFF
--- a/dmscripts/data_retention_remove_user_data.py
+++ b/dmscripts/data_retention_remove_user_data.py
@@ -1,0 +1,56 @@
+from datetime import timedelta, datetime
+
+from dmutils.formats import DATETIME_FORMAT
+
+
+def data_retention_remove_user_data(
+    data_api_client,
+    logger,
+    dm_mailchimp_client=None,
+    dry_run=True,
+):
+    cutoff_date = datetime.now() - timedelta(days=365 * 3)
+    prefix = '[DRY RUN]: ' if dry_run else ''
+    all_users = data_api_client.find_users_iter()
+
+    for user in all_users:
+        last_logged_in_at = datetime.strptime(user['loggedInAt'], DATETIME_FORMAT)
+        if last_logged_in_at < cutoff_date:
+            if not user['personalDataRemoved']:
+                logger.warn(
+                    f"{prefix}Removing personal data in API for user: {user['id']}"
+                )
+                if not dry_run:
+                    data_api_client.remove_user_personal_data(
+                        user['id'],
+                        'Data Retention Script {}'.format(datetime.now().isoformat())
+                    )
+
+            if dm_mailchimp_client is not None:
+                email_hash = dm_mailchimp_client.get_email_hash(user["emailAddress"])
+                logger.info(
+                    "Checking mailing list membership for email with hash %s (user %s)",
+                    email_hash,
+                    user["id"],
+                )
+                mailing_lists = dm_mailchimp_client.get_lists_for_email(user["emailAddress"])
+                if mailing_lists:
+                    for mailing_list in mailing_lists:
+                        logger.warn(
+                            f"%sRemoving email with hash %s from list %s ('%s')",
+                            prefix,
+                            email_hash,
+                            mailing_list["list_id"],
+                            mailing_list["name"],
+                        )
+                        if not dry_run:
+                            dm_mailchimp_client.permanently_remove_email_from_list(
+                                email_address=user["emailAddress"],
+                                list_id=mailing_list["list_id"],
+                            )
+                else:
+                    logger.info(
+                        "%s not a member of any mailing lists",
+                        email_hash,
+                        user["id"],
+                    )

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,9 +3,11 @@
 
 Flask==1.0.2
 itsdangerous==0.24
+# Pinned because requests requires <2.8 but earlier dependencies in the list will install 2.8
+idna==2.7
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@45.3.0#egg=digitalmarketplace-utils==45.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.9.0#egg=digitalmarketplace-apiclient==19.9.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.0#egg=digitalmarketplace-content-loader==5.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,11 @@
 
 Flask==1.0.2
 itsdangerous==0.24
+# Pinned because requests requires <2.8 but earlier dependencies in the list will install 2.8
+idna==2.7
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@45.3.0#egg=digitalmarketplace-utils==45.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.9.0#egg=digitalmarketplace-apiclient==19.9.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.0#egg=digitalmarketplace-content-loader==5.1.0
 
@@ -26,40 +28,40 @@ yq==2.4.1
 asn1crypto==0.24.0
 boto3==1.7.83
 botocore==1.10.84
-certifi==2018.10.15
+certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
 Click==7.0
 colorama==0.3.9
 contextlib2==0.5.5
 cryptography==2.3.1
+defusedxml==0.5.0
 docutils==0.14
 Flask-Login==0.4.1
 Flask-Script==2.0.6
 Flask-WTF==0.14.2
 fleep==1.0.1
 future==0.17.1
-idna==2.7
 inflection==0.3.1
 Jinja2==2.10
 jmespath==0.9.3
-mailchimp3==2.0.18
+mailchimp3==3.0.6
 mandrill==1.0.57
 Markdown==2.6.11
 MarkupSafe==1.1.0
 monotonic==1.5
 notifications-python-client==5.2.0
 numpy==1.15.4
-odfpy==1.3.6
+odfpy==1.4.0
 pyasn1==0.4.4
 pycparser==2.19
-PyJWT==1.6.4
+PyJWT==1.7.1
 pytz==2018.7
 PyYAML==3.13
-requests==2.20.1
+requests==2.21.0
 rsa==3.4.2
 s3transfer==0.1.13
-six==1.11.0
+six==1.12.0
 urllib3==1.24.1
 Werkzeug==0.14.1
 workdays==1.4

--- a/tests/test_data_retention_remove_user_data.py
+++ b/tests/test_data_retention_remove_user_data.py
@@ -1,0 +1,90 @@
+import mock
+
+from freezegun import freeze_time
+import pytest
+
+from dmscripts.data_retention_remove_user_data import data_retention_remove_user_data
+
+
+@pytest.mark.parametrize("dry_run", (False, True,))
+@pytest.mark.parametrize("with_mailchimp", (False, True,))
+@mock.patch('dmutils.email.dm_mailchimp.DMMailChimpClient', autospec=True)
+@mock.patch('dmapiclient.DataAPIClient', autospec=True)
+def test_data_retention_remove_user_data_happy_paths(data_api_client, dm_mailchimp_client, dry_run, with_mailchimp):
+    data_api_client.find_users_iter.return_value = iter((
+        {
+            "id": 1234,
+            "emailAddress": "walkup@walkup.eggs",
+            "loggedInAt": "2000-01-12T12:22:22.00000Z",
+            "personalDataRemoved": False,
+        },
+        {
+            "id": 1235,
+            "emailAddress": "alaki@abe-aku.ta",
+            "loggedInAt": "2001-01-12T13:33:33.00000Z",
+            "personalDataRemoved": True,
+        },
+        {
+            "id": 1236,
+            "emailAddress": "ananias@praisegod.barebones",
+            "loggedInAt": "1999-02-21T02:02:02.00000Z",
+            "personalDataRemoved": False,
+        },
+        {
+            "id": 1237,
+            "emailAddress": "kakachakachak@forty.warts",
+            "loggedInAt": "2001-12-13T14:55:55.00000Z",
+            "personalDataRemoved": True,
+        },
+        {
+            "id": 1238,
+            "emailAddress": "cotton@op.ol.is",
+            "loggedInAt": "2001-12-13T14:56:56.00000Z",
+            "personalDataRemoved": False,
+        },
+    ))
+    dm_mailchimp_client.get_email_hash.side_effect = lambda email: f"hashfor({email})"
+    dm_mailchimp_client.get_lists_for_email.side_effect = lambda email_address: {
+        "walkup@walkup.eggs": (
+            {"list_id": "kkp", "name": "Kilkenny People"},
+        ),
+        "alaki@abe-aku.ta": (
+            {"list_id": "nw0", "name": "Northern Whig"},
+            {"list_id": "kkp", "name": "Kilkenny People"},
+            {"list_id": "ce", "name": "Cork Examiner"},
+        ),
+        "ananias@praisegod.barebones": (),
+    }[email_address]
+
+    with freeze_time("2004-06-16T13:01:02"):
+        data_retention_remove_user_data(
+            data_api_client=data_api_client,
+            logger=mock.Mock(),
+            dm_mailchimp_client=dm_mailchimp_client if with_mailchimp else None,
+            dry_run=dry_run,
+        )
+
+    assert data_api_client.mock_calls == [
+        mock.call.find_users_iter(),
+    ] + ([] if dry_run else [
+        mock.call.remove_user_personal_data(1234, "Data Retention Script 2004-06-16T13:01:02"),
+        mock.call.remove_user_personal_data(1236, "Data Retention Script 2004-06-16T13:01:02"),
+    ])
+
+    if with_mailchimp:
+        assert dm_mailchimp_client.get_lists_for_email.mock_calls == [
+            mock.call("walkup@walkup.eggs"),
+            mock.call("alaki@abe-aku.ta"),
+            mock.call("ananias@praisegod.barebones"),
+        ]
+        assert dm_mailchimp_client.permanently_remove_email_from_list.mock_calls == ([] if dry_run else [
+            mock.call(email_address="walkup@walkup.eggs", list_id="kkp"),
+            mock.call(email_address="alaki@abe-aku.ta", list_id="nw0"),
+            mock.call(email_address="alaki@abe-aku.ta", list_id="kkp"),
+            mock.call(email_address="alaki@abe-aku.ta", list_id="ce"),
+        ])
+        # check there are no other stray calls on dm_mailchimp_client unaccounted for
+        assert all(
+            c[0] in ("get_lists_for_email", "permanently_remove_email_from_list", "get_email_hash",)
+            for c in dm_mailchimp_client.mock_calls
+        )


### PR DESCRIPTION
More thoughts here https://trello.com/c/QROOUpoX/272-users-whose-personal-data-is-removed-are-not-removed-from-mailchimp-mailing-lists

Also, refactor into separate implementation function for easy testing, add simple tests.

Depends on https://github.com/alphagov/digitalmarketplace-utils/pull/483