### PR TITLE
Update utils (45.3.0 > 45.3.1) to use new mailchimp3 version

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,7 +7,7 @@ itsdangerous==0.24
 idna==2.7
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.3.0#egg=digitalmarketplace-utils==45.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@45.3.0#egg=digitalmarketplace-utils==45.3.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.9.0#egg=digitalmarketplace-apiclient==19.9.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.0#egg=digitalmarketplace-content-loader==5.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ itsdangerous==0.24
 idna==2.7
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.3.0#egg=digitalmarketplace-utils==45.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@45.3.0#egg=digitalmarketplace-utils==45.3.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.9.0#egg=digitalmarketplace-apiclient==19.9.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.0#egg=digitalmarketplace-content-loader==5.1.0
 
@@ -53,10 +53,10 @@ monotonic==1.5
 notifications-python-client==5.2.0
 numpy==1.15.4
 odfpy==1.4.0
-pyasn1==0.4.4
+pyasn1==0.4.5
 pycparser==2.19
 PyJWT==1.7.1
-pytz==2018.7
+pytz==2018.9
 PyYAML==3.13
 requests==2.21.0
 rsa==3.4.2


### PR DESCRIPTION
Bring in changes from https://github.com/alphagov/digitalmarketplace-utils/pull/484
