### PR TITLE
data_retention_remove_user_data: don't attempt to remove users from mailchimp if already personalDataRemoved

### DIFF
--- a/dmscripts/data_retention_remove_user_data.py
+++ b/dmscripts/data_retention_remove_user_data.py
@@ -20,40 +20,40 @@ def data_retention_remove_user_data(
     for user in all_users:
         last_logged_in_at = datetime.strptime(user['loggedInAt'], DATETIME_FORMAT)
         if last_logged_in_at < cutoff_date:
-            if dm_mailchimp_client is not None:
-                email_hash = dm_mailchimp_client.get_email_hash(user["emailAddress"])
-                logger.info(
-                    "Checking mailing list membership for email with hash %s (user %s)",
-                    email_hash,
-                    user["id"],
-                )
-                mailing_lists = dm_mailchimp_client.get_lists_for_email(user["emailAddress"])
-                if mailing_lists:
-                    for mailing_list in mailing_lists:
-                        logger.warn(
-                            f"%sRemoving email with hash %s from list %s ('%s')",
-                            prefix,
-                            email_hash,
-                            mailing_list["list_id"],
-                            mailing_list["name"],
-                        )
-                        if not dry_run:
-                            rm_result = dm_mailchimp_client.permanently_remove_email_from_list(
-                                email_address=user["emailAddress"],
-                                list_id=mailing_list["list_id"],
-                            )
-                            if not rm_result:
-                                raise MailchimpRemovalFailed(
-                                    "Mailchimp failure trying to permanently_remove_email_from_list"
-                                )
-                else:
+            if not user['personalDataRemoved']:
+                if dm_mailchimp_client is not None:
+                    email_hash = dm_mailchimp_client.get_email_hash(user["emailAddress"])
                     logger.info(
-                        "%s not a member of any mailing lists",
+                        "Checking mailing list membership for email with hash %s (user %s)",
                         email_hash,
                         user["id"],
                     )
+                    mailing_lists = dm_mailchimp_client.get_lists_for_email(user["emailAddress"])
+                    if mailing_lists:
+                        for mailing_list in mailing_lists:
+                            logger.warn(
+                                f"%sRemoving email with hash %s from list %s ('%s')",
+                                prefix,
+                                email_hash,
+                                mailing_list["list_id"],
+                                mailing_list["name"],
+                            )
+                            if not dry_run:
+                                rm_result = dm_mailchimp_client.permanently_remove_email_from_list(
+                                    email_address=user["emailAddress"],
+                                    list_id=mailing_list["list_id"],
+                                )
+                                if not rm_result:
+                                    raise MailchimpRemovalFailed(
+                                        "Mailchimp failure trying to permanently_remove_email_from_list"
+                                    )
+                    else:
+                        logger.info(
+                            "%s not a member of any mailing lists",
+                            email_hash,
+                            user["id"],
+                        )
 
-            if not user['personalDataRemoved']:
                 logger.warn(
                     f"{prefix}Removing personal data in API for user: {user['id']}"
                 )

--- a/dmscripts/data_retention_remove_user_data.py
+++ b/dmscripts/data_retention_remove_user_data.py
@@ -15,50 +15,48 @@ def data_retention_remove_user_data(
 ):
     cutoff_date = datetime.now() - timedelta(days=365 * 3)
     prefix = '[DRY RUN]: ' if dry_run else ''
-    all_users = data_api_client.find_users_iter()
 
-    for user in all_users:
+    for user in data_api_client.find_users_iter(personal_data_removed=False):
         last_logged_in_at = datetime.strptime(user['loggedInAt'], DATETIME_FORMAT)
         if last_logged_in_at < cutoff_date:
-            if not user['personalDataRemoved']:
-                if dm_mailchimp_client is not None:
-                    email_hash = dm_mailchimp_client.get_email_hash(user["emailAddress"])
+            if dm_mailchimp_client is not None:
+                email_hash = dm_mailchimp_client.get_email_hash(user["emailAddress"])
+                logger.info(
+                    "Checking mailing list membership for email with hash %s (user %s)",
+                    email_hash,
+                    user["id"],
+                )
+                mailing_lists = dm_mailchimp_client.get_lists_for_email(user["emailAddress"])
+                if mailing_lists:
+                    for mailing_list in mailing_lists:
+                        logger.warn(
+                            f"%sRemoving email with hash %s from list %s ('%s')",
+                            prefix,
+                            email_hash,
+                            mailing_list["list_id"],
+                            mailing_list["name"],
+                        )
+                        if not dry_run:
+                            rm_result = dm_mailchimp_client.permanently_remove_email_from_list(
+                                email_address=user["emailAddress"],
+                                list_id=mailing_list["list_id"],
+                            )
+                            if not rm_result:
+                                raise MailchimpRemovalFailed(
+                                    "Mailchimp failure trying to permanently_remove_email_from_list"
+                                )
+                else:
                     logger.info(
-                        "Checking mailing list membership for email with hash %s (user %s)",
+                        "%s not a member of any mailing lists",
                         email_hash,
                         user["id"],
                     )
-                    mailing_lists = dm_mailchimp_client.get_lists_for_email(user["emailAddress"])
-                    if mailing_lists:
-                        for mailing_list in mailing_lists:
-                            logger.warn(
-                                f"%sRemoving email with hash %s from list %s ('%s')",
-                                prefix,
-                                email_hash,
-                                mailing_list["list_id"],
-                                mailing_list["name"],
-                            )
-                            if not dry_run:
-                                rm_result = dm_mailchimp_client.permanently_remove_email_from_list(
-                                    email_address=user["emailAddress"],
-                                    list_id=mailing_list["list_id"],
-                                )
-                                if not rm_result:
-                                    raise MailchimpRemovalFailed(
-                                        "Mailchimp failure trying to permanently_remove_email_from_list"
-                                    )
-                    else:
-                        logger.info(
-                            "%s not a member of any mailing lists",
-                            email_hash,
-                            user["id"],
-                        )
 
-                logger.warn(
-                    f"{prefix}Removing personal data in API for user: {user['id']}"
+            logger.warn(
+                f"{prefix}Removing personal data in API for user: {user['id']}"
+            )
+            if not dry_run:
+                data_api_client.remove_user_personal_data(
+                    user['id'],
+                    'Data Retention Script {}'.format(datetime.now().isoformat())
                 )
-                if not dry_run:
-                    data_api_client.remove_user_personal_data(
-                        user['id'],
-                        'Data Retention Script {}'.format(datetime.now().isoformat())
-                    )

--- a/tests/test_data_retention_remove_user_data.py
+++ b/tests/test_data_retention_remove_user_data.py
@@ -7,8 +7,8 @@ from dmscripts.data_retention_remove_user_data import data_retention_remove_user
 
 
 class TestDataRetentionRemoveUserData:
-    def _find_users_iter_side_effect(self, *args, **kwargs):
-        return iter((
+    def _find_users_iter_side_effect(self, *args, **kw):
+        return (user for user in (
             {
                 "id": 1234,
                 "emailAddress": "walkup@walkup.eggs",
@@ -45,7 +45,7 @@ class TestDataRetentionRemoveUserData:
                 "loggedInAt": "2001-01-12T13:33:34.00000Z",
                 "personalDataRemoved": True,
             },
-        ))
+        ) if user["personalDataRemoved"] == kw.get("personal_data_removed") or kw.get("personal_data_removed") is None)
 
     def _get_email_hash_side_effect(self, email):
         return f"hashfor({email})"
@@ -89,7 +89,7 @@ class TestDataRetentionRemoveUserData:
             )
 
         assert data_api_client.mock_calls == [
-            mock.call.find_users_iter(),
+            mock.call.find_users_iter(personal_data_removed=False),
         ] + ([] if dry_run else [
             mock.call.remove_user_personal_data(1234, "Data Retention Script 2004-06-16T13:01:02"),
             mock.call.remove_user_personal_data(1235, "Data Retention Script 2004-06-16T13:01:02"),
@@ -139,7 +139,7 @@ class TestDataRetentionRemoveUserData:
                 )
 
         assert data_api_client.mock_calls == [
-            mock.call.find_users_iter(),
+            mock.call.find_users_iter(personal_data_removed=False),
             mock.call.remove_user_personal_data(1234, "Data Retention Script 2004-06-16T13:01:02"),
             # importantly missing call to remove 1236 (alaki@abe-aku.ta)'s data from the API because the call to remove
             # their email from mailchimp failed.

--- a/tests/test_data_retention_remove_user_data.py
+++ b/tests/test_data_retention_remove_user_data.py
@@ -19,7 +19,7 @@ class TestDataRetentionRemoveUserData:
                 "id": 1235,
                 "emailAddress": "alaki@abe-aku.ta",
                 "loggedInAt": "2001-01-12T13:33:33.00000Z",
-                "personalDataRemoved": True,
+                "personalDataRemoved": False,
             },
             {
                 "id": 1236,
@@ -39,6 +39,12 @@ class TestDataRetentionRemoveUserData:
                 "loggedInAt": "2001-12-13T14:56:56.00000Z",
                 "personalDataRemoved": False,
             },
+            {
+                "id": 1239,
+                "emailAddress": "<removed>@1234.net",
+                "loggedInAt": "2001-01-12T13:33:34.00000Z",
+                "personalDataRemoved": True,
+            },
         ))
 
     def _get_email_hash_side_effect(self, email):
@@ -55,6 +61,7 @@ class TestDataRetentionRemoveUserData:
                 {"list_id": "ce", "name": "Cork Examiner"},
             ),
             "ananias@praisegod.barebones": (),
+            "<removed>@1234.net": (),
         }[email_address]
 
     @pytest.mark.parametrize("dry_run", (False, True,))
@@ -85,6 +92,7 @@ class TestDataRetentionRemoveUserData:
             mock.call.find_users_iter(),
         ] + ([] if dry_run else [
             mock.call.remove_user_personal_data(1234, "Data Retention Script 2004-06-16T13:01:02"),
+            mock.call.remove_user_personal_data(1235, "Data Retention Script 2004-06-16T13:01:02"),
             mock.call.remove_user_personal_data(1236, "Data Retention Script 2004-06-16T13:01:02"),
         ])
 


### PR DESCRIPTION
Another stupidity I've realized related to my implementation of https://trello.com/c/QROOUpoX

If `user["personalDataRemoved"]`, then the `emailAddress` we're given will already be garbage and looking it up in mailchimp is meaningless.