### PR TITLE
Rename send-dos-opportunities to notify-suppliers-of-new-dos-opportunities

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The `scripts` folder in this repository contains scripts that interact with the 
 
   Checks all free-text fields in G-Cloud services for "bad words" and generates a CSV report of any bad words found.
 
-* `send-dos-opportunities-email.py`
+* `notify-suppliers-of-new-dos-opportunities.py`
 
   **Runs Mon-Fri 8:00am on Jenkins**. Send emails with new opportunities on a lot to suppliers who are on this lot.
 

--- a/scripts/notify-suppliers-of-new-dos-opportunities.py
+++ b/scripts/notify-suppliers-of-new-dos-opportunities.py
@@ -26,11 +26,11 @@ Description:
     failed.
 
 Usage:
-    send-dos-opportunities-email.py <stage> <mailchimp_username> <mailchimp_api_key> <framework_slug>
+    notify-suppliers-of-new-dos-opportunities.py <stage> <mailchimp_username> <mailchimp_api_key> <framework_slug>
         [--number_of_days=<number_of_days>] [--list_id=<list_id>] [--lot_slug=<lot_slug>]
 
 Example:
-    send-dos-opportunities-email.py
+    notify-suppliers-of-new-dos-opportunities.py
         preview user@gds.gov.uk 7483crh87h34c3 digital-outcomes-and-specialists-3
         --number_of_days=3 --list_id=988972hse --lot_slug=digital-outcomes
 """


### PR DESCRIPTION
Renamed script to fit with naming pattern of other email scripts.

Although the script doesn't actually use Notify, I think this is an implementation detail ;)

If this PR does get merged then we will also need to merge a PR to change the Jenkins job (this is pending).

This is part of https://trello.com/c/aRpNbH4o/309-rename-send-dos-opportunities-emailpy-to-notify-suppliers-something-somethingpy