### PR TITLE
Fix duplicate logging output from send_dos_opportunitues_emails

### DIFF
--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -1,12 +1,11 @@
 from datetime import datetime, date, timedelta
 
 from dmscripts.helpers.html_helpers import render_html
-from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
 from dmutils.formats import DATETIME_FORMAT, DISPLAY_DATE_FORMAT
 
 
-logger = logging_helpers.configure_logger({'dmapiclient': logging.INFO})
+logger = logging.getLogger('script')
 
 
 def get_live_briefs_between_two_dates(data_api_client, lot_slug, start_date, end_date, framework_slug):


### PR DESCRIPTION
We were getting duplicated log output when running the `send-dos-opportunities-emails.py` script.

This commit fixes this by removing the logging configuration from the `send_dos_opportunities_emails.py` module, which was causing multiple logs with the same contents to exist.

Closes https://trello.com/c/u18CsU00/313-statements-are-logged-twice-on-jenkins-during-dos-opportunities-mailchimp-job