### PR TITLE
get-model-data: add "completed outcomes" export

### DIFF
--- a/dmscripts/models/modeltrawler.py
+++ b/dmscripts/models/modeltrawler.py
@@ -66,7 +66,7 @@ class ModelTrawler():
             filtered_dict = {}
             for key in _keys:
                 if isinstance(key, (list, tuple)):
-                    filtered_dict[key[len(key) - 1]] = _get_nested_values(list(key), model_dict)
+                    filtered_dict[".".join(str(k) for k in key)] = _get_nested_values(list(key), model_dict)
                 else:
                     filtered_dict[key] = model_dict.get(key, '')
 

--- a/dmscripts/models/modeltrawler.py
+++ b/dmscripts/models/modeltrawler.py
@@ -34,7 +34,7 @@ class ModelTrawler():
         def _get_nested_values(nested_keys, val):
             try:
                 return val if not len(nested_keys) else _get_nested_values(nested_keys, val[nested_keys.pop(0)])
-            except (KeyError, IndexError):
+            except (KeyError, IndexError, TypeError):
                 # objects/arrays might be empty for some returned models
                 return ''
 

--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -435,6 +435,25 @@ CONFIGS = [
             'lockedSearchServicesCount',
         ),
     },
+    {
+        'name': 'completed_outcomes',
+        'base_model': 'outcomes',
+        'get_data_kwargs': {'completed': True},
+        'keys': (
+            'id',
+            'completedAt',
+            'result',
+            ('resultOfDirectAward', 'project', 'id',),
+            ('resultOfDirectAward', 'search', 'id',),
+            ('resultOfDirectAward', 'archivedService', 'service', 'id',),
+            ('resultOfFurtherCompetition', 'brief', 'id',),
+            ('resultOfFurtherCompetition', 'briefResponse', 'id',),
+            ('award', 'startDate',),
+            ('award', 'endDate',),
+            ('award', 'awardingOrganisationName',),
+            ('award', 'awardValue',),
+        ),
+    },
 ]
 
 if __name__ == '__main__':

--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -165,7 +165,7 @@ CONFIGS = [
         'process_fields': {
             'createdAt': format_datetime_string_as_date,
             'publishedAt': format_datetime_string_as_date,
-            'emailAddress': remove_username_from_email_address,
+            'users.0.emailAddress': remove_username_from_email_address,
             'clarificationQuestions': len,
         },
         'sort_by': 'createdAt'
@@ -294,7 +294,7 @@ CONFIGS = [
             'lot',
             'specialistRole',
             'organisation',
-            'emailAddress',
+            'users.0.emailAddress',
             'location',
             'publishedAt',
             'requirementsLength',
@@ -329,7 +329,7 @@ CONFIGS = [
         'duplicate_fields': [('id_data', 'brief_id_copy')],
         'process_fields': {
             'id_data': construct_brief_url,
-            'emailAddress': remove_username_from_email_address,
+            'users.0.emailAddress': remove_username_from_email_address,
             'requirementsLength': lambda i: i or '2 weeks',
         },
         'rename_fields': {
@@ -340,7 +340,7 @@ CONFIGS = [
             'lot': 'Category',
             'specialistRole': 'Specialist',
             'organisation': 'Organisation Name',
-            'emailAddress': 'Buyer Domain',
+            'users.0.emailAddress': 'Buyer Domain',
             'location': 'Location Of The Work',
             'publishedAt': 'Published At',
             'requirementsLength': 'Open For',
@@ -515,9 +515,10 @@ if __name__ == '__main__':
 
         # Only keep requested keys in the output CSV
         keys = [
-            k[-1] if isinstance(k, (tuple, list)) else k
-            for k in config['keys']
-            if (k[-1] if isinstance(k, (tuple, list)) else k) in data
+            j for j in (
+                ".".join(str(part) for part in k) if isinstance(k, (tuple, list)) else k
+                for k in config['keys']
+            ) if j in data
         ]
         data = data[keys]
 

--- a/tests/models/test_modeltrawler.py
+++ b/tests/models/test_modeltrawler.py
@@ -52,8 +52,8 @@ class TestModelTrawlerMethods:
 
         expected_model_dict = {
             'id': 1,
-            'name': 'Super cloud supplier',
-            'emailAddress': 'user@gov.uk'
+            'supplier.name': 'Super cloud supplier',
+            'users.0.emailAddress': 'user@gov.uk'
         }
 
         mt = ModelTrawler('fake_table', FakeClient())
@@ -66,8 +66,8 @@ class TestModelTrawlerMethods:
         )
 
         expected_model_data = (
-            {'id': 1, 'emailAddress': 'user@gov.uk'},
-            {'id': 2, 'emailAddress': 'user2@gov.uk'}
+            {'id': 1, 'users.0.emailAddress': 'user@gov.uk'},
+            {'id': 2, 'users.0.emailAddress': 'user2@gov.uk'}
         )
 
         with mock.patch.object(FakeClient, 'find_fake_table_iter', return_value=iter(self.model_data)):
@@ -80,7 +80,7 @@ class TestModelTrawlerMethods:
             ('users', 0, 'emailAddress')
         )
 
-        expected_model_data = ({'id': 1, 'emailAddress': 'user@gov.uk'},)
+        expected_model_data = ({'id': 1, 'users.0.emailAddress': 'user@gov.uk'},)
 
         with mock.patch.object(FakeClient, 'find_fake_table_iter', return_value=iter(self.model_data)):
             mt = ModelTrawler('fake_table', FakeClient())


### PR DESCRIPTION
https://trello.com/c/t2N1EqPk/

This required changing the way column headers are generated from "nested fields". Previously the innermost field name of a chain would be picked, but this is vulnerable to clashes, as will happen when multiple nested dictionaries with `id` attributes are desired. The change is to `.`-concatenate the field names. The only effect this should have on existing exports is changing one header in `briefs.csv` from `emailAddress` to `users.0.emailAddress`. Ash reckons this shouldn't break any of his stuff but we're going to make sure with a dry run from a local machine before merging.