### PR TITLE
simplify-mark-framework-results-script

### DIFF
--- a/dmscripts/export_framework_results_reasons.py
+++ b/dmscripts/export_framework_results_reasons.py
@@ -24,7 +24,7 @@ def get_validation_errors(candidate, schema):
 
 def add_failed_questions(questions_numbers,
                          declaration_definite_pass_schema,
-                         declaration_baseline_schema
+                         declaration_discretionary_pass_schema
                          ):
     def inner(record):
         if record['declaration'].get('status') != 'complete':
@@ -34,8 +34,11 @@ def add_failed_questions(questions_numbers,
 
         all_failed_keys = get_validation_errors(record['declaration'], declaration_definite_pass_schema)
 
-        if declaration_baseline_schema:
-            baseline_only_failed_keys = get_validation_errors(record['declaration'], declaration_baseline_schema)
+        if declaration_discretionary_pass_schema:
+            baseline_only_failed_keys = get_validation_errors(
+                record['declaration'],
+                declaration_discretionary_pass_schema
+            )
         else:
             baseline_only_failed_keys = all_failed_keys
 
@@ -61,7 +64,7 @@ def find_suppliers_with_details(client,
                                 questions_numbers,
                                 framework_slug,
                                 declaration_definite_pass_schema,
-                                declaration_baseline_schema,
+                                declaration_discretionary_pass_schema,
                                 supplier_ids=None,
                                 map_impl=map,
                                 ):
@@ -73,7 +76,7 @@ def find_suppliers_with_details(client,
     )
     records = list(map(add_failed_questions(questions_numbers,
                                             declaration_definite_pass_schema,
-                                            declaration_baseline_schema), records))
+                                            declaration_discretionary_pass_schema), records))
 
     return records
 
@@ -184,7 +187,7 @@ def export_suppliers(
     content_loader,
     output_dir,
     declaration_definite_pass_schema,
-    declaration_baseline_schema=None,
+    declaration_discretionary_pass_schema=None,
     supplier_ids=None,
     map_impl=map,
 ):
@@ -198,7 +201,7 @@ def export_suppliers(
         questions_numbers,
         framework_slug,
         declaration_definite_pass_schema,
-        declaration_baseline_schema,
+        declaration_discretionary_pass_schema,
         supplier_ids,
         map_impl=map_impl,
     )

--- a/dmscripts/mark_definite_framework_results.py
+++ b/dmscripts/mark_definite_framework_results.py
@@ -75,29 +75,43 @@ def mark_definite_framework_results(
     updated_by,
     framework_slug,
     declaration_definite_pass_schema,
-    declaration_baseline_schema=None,
+    declaration_discretionary_pass_schema=None,
     service_schema=None,
-    dry_run=True,
-    reassess_passed=False,
-    reassess_failed=False,
+    reassess_passed_suppliers=False,
+    reassess_failed_suppliers=False,
     reassess_failed_draft_services=False,
-    logger=logging.getLogger("script"),
+    dry_run=True,
     supplier_ids=None,
+    logger=logging.getLogger("script"),
 ):
     interested_supplier_ids = supplier_ids or client.get_interested_suppliers(
         framework_slug
     ).get('interestedSuppliers', ())
     total_interested_suppliers = len(interested_supplier_ids)
+
+    # Loop over suppliers breaking out if they pass or fail, if they make it to the end they get a discretionary pass
     for i, supplier_id in enumerate(interested_supplier_ids, start=1):
-        logger.info("Supplier {i}/{total_interested_suppliers}: {supplier_id}",
-                    extra={'i': i, 'supplier_id': supplier_id,
-                           'total_interested_suppliers': total_interested_suppliers})
+        logger.info(
+            "Supplier {i}/{total_interested_suppliers}: {supplier_id}",
+            extra={'i': i, 'supplier_id': supplier_id, 'total_interested_suppliers': total_interested_suppliers}
+        )
         supplier_framework = client.get_supplier_framework_info(supplier_id, framework_slug)["frameworkInterest"]
-        if (supplier_framework["onFramework"] is False and not reassess_failed) or \
-                (supplier_framework["onFramework"] is True and not reassess_passed):
-            logger.info("\tSkipping: already %s", "passed" if supplier_framework["onFramework"] else "failed")
+
+        # Skip suppliers who have already failed?
+        if not reassess_failed_suppliers and supplier_framework["onFramework"] is False:
+            logger.info("\tSkipping: already failed")
+            continue
+        # Skip suppliers who have already passed?
+        if not reassess_passed_suppliers and supplier_framework["onFramework"] is True:
+            logger.info("\tSkipping: already passed")
             continue
 
+        # A supplier must have completed their declaration to pass their application
+        if supplier_framework["declaration"].get("status") != "complete":
+            fail_supplier(supplier_id, framework_slug, updated_by, supplier_framework, client, logger, dry_run=dry_run)
+            continue
+
+        # A supplier should have at least one valid service to pass their application
         service_counter = _assess_draft_services(
             client,
             updated_by,
@@ -108,42 +122,63 @@ def mark_definite_framework_results(
             reassess_failed_draft_services=reassess_failed_draft_services,
             logger=logger
         )
+        if not service_counter["passed"]:
+            fail_supplier(supplier_id, framework_slug, updated_by, supplier_framework, client, logger, dry_run=dry_run)
+            continue
 
-        if (
-            supplier_framework["declaration"].get("status") == "complete"
-            and service_counter["passed"]
-            and _passes_validation(
+        # Check for a definite pass
+        supplier_passes_validation = _passes_validation(
+            supplier_framework["declaration"],
+            declaration_definite_pass_schema,
+            logger,
+            schema_name="declaration_definite_pass_schema",
+            tablevel=1
+        )
+        if supplier_passes_validation:
+            # Congratulations supplier, you pass!
+            pass_supplier(supplier_id, framework_slug, updated_by, supplier_framework, client, logger, dry_run=dry_run)
+            continue
+
+        # The supplier didn't pass, but check for, and default to, a discretionary pass
+        if declaration_discretionary_pass_schema:
+            supplier_passes_discretionary_validation = _passes_validation(
                 supplier_framework["declaration"],
-                declaration_definite_pass_schema,
+                declaration_discretionary_pass_schema,
                 logger,
-                schema_name="declaration_definite_pass_schema",
-                tablevel=1)
-        ):
-            logger.info("\tResult: PASS")
-            if not dry_run:
-                if supplier_framework["onFramework"] is not True:
-                    client.set_framework_result(supplier_id, framework_slug, True, updated_by)
-                else:
-                    logger.debug("\tUnchanged result - not re-setting")
-        elif supplier_framework["declaration"].get("status") != "complete" or (not service_counter["passed"]) or \
-                (declaration_baseline_schema and not _passes_validation(
-                    supplier_framework["declaration"],
-                    declaration_baseline_schema,
-                    logger,
-                    schema_name="declaration_baseline_schema",
-                    tablevel=1,
-                )):
-            logger.info("\tResult: FAIL")
-            if not dry_run:
-                if supplier_framework["onFramework"] is not False:
-                    client.set_framework_result(supplier_id, framework_slug, False, updated_by)
-                else:
-                    logger.debug("\tUnchanged result - not re-setting")
-        else:
-            # a result of DISCRETIONARY should pretty much never overwrite an already-made decision
-            logger.info(
-                "\tResult: DISCRETIONARY%s",
-                " (but leaving as {})".format(
-                    "PASS" if supplier_framework["onFramework"] else "FAIL"
-                ) if supplier_framework["onFramework"] is not None else "",
+                schema_name="declaration_discretionary_pass_schema",
+                tablevel=1,
             )
+            if not supplier_passes_discretionary_validation:
+                fail_supplier(
+                    supplier_id,
+                    framework_slug,
+                    updated_by,
+                    supplier_framework,
+                    client,
+                    logger,
+                    dry_run=dry_run
+                )
+                continue
+        # a result of DISCRETIONARY should pretty much never overwrite an already-made decision
+        log_message = "\tResult: DISCRETIONARY%s"
+        if supplier_framework["onFramework"] is not None:
+            log_message += " (but leaving as {})".format("PASS" if supplier_framework["onFramework"] else "FAIL")
+        logger.info(log_message)
+
+
+def pass_supplier(supplier_id, framework_slug, updated_by, supplier_framework, client, logger, dry_run=True):
+    logger.info("\tResult: PASS")
+    if not dry_run:
+        if supplier_framework["onFramework"] is not True:
+            client.set_framework_result(supplier_id, framework_slug, True, updated_by)
+        else:
+            logger.debug("\tUnchanged result - not re-setting")
+
+
+def fail_supplier(supplier_id, framework_slug, updated_by, supplier_framework, client, logger, dry_run=True):
+    logger.info("\tResult: FAIL")
+    if not dry_run:
+        if supplier_framework["onFramework"] is not False:
+            client.set_framework_result(supplier_id, framework_slug, False, updated_by)
+        else:
+            logger.debug("\tUnchanged result - not re-setting")

--- a/scripts/export-framework-results-reasons.py
+++ b/scripts/export-framework-results-reasons.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     content_loader = ContentLoader(args['<content_path>'])
 
     declaration_definite_pass_schema = json.load(open(args["<declaration_schema_path>"], "r"))
-    declaration_baseline_schema = (declaration_definite_pass_schema.get("definitions") or {}).get("baseline")
+    declaration_discretionary_pass_schema = (declaration_definite_pass_schema.get("definitions") or {}).get("baseline")
 
     supplier_id_file = args['<supplier_id_file>']
     supplier_ids = get_supplier_ids_from_file(supplier_id_file)
@@ -53,7 +53,7 @@ if __name__ == '__main__':
         content_loader,
         args['<output_dir>'],
         declaration_definite_pass_schema,
-        declaration_baseline_schema,
+        declaration_discretionary_pass_schema,
         supplier_ids,
         map_impl=pool.imap,
     )

--- a/scripts/mark-definite-framework-results.py
+++ b/scripts/mark-definite-framework-results.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     declaration_definite_pass_schema = json.load(open(args["<declaration_definite_pass_schema_path>"], "r"))
 
-    declaration_baseline_schema = \
+    declaration_discretionary_pass_schema = \
         (declaration_definite_pass_schema.get("definitions") or {}).get("baseline")
 
     service_schema = json.load(
@@ -76,10 +76,10 @@ if __name__ == "__main__":
         updated_by,
         args["<framework_slug>"],
         declaration_definite_pass_schema,
-        declaration_baseline_schema=declaration_baseline_schema,
+        declaration_discretionary_pass_schema=declaration_discretionary_pass_schema,
         service_schema=service_schema,
-        reassess_passed=args["--reassess-passed-sf"],
-        reassess_failed=args["--reassess-failed-sf"],
+        reassess_passed_suppliers=args["--reassess-passed-sf"],
+        reassess_failed_suppliers=args["--reassess-failed-sf"],
         reassess_failed_draft_services=args["--reassess-failed-draft-services"],
         dry_run=args["--dry-run"],
         supplier_ids=supplier_ids,

--- a/tests/test_mark_definite_framework_results.py
+++ b/tests/test_mark_definite_framework_results.py
@@ -7,20 +7,27 @@ from dmscripts.mark_definite_framework_results import mark_definite_framework_re
 from .assessment_helpers import BaseAssessmentTest, BaseAssessmentMismatchedOnFrameworksTestMixin
 
 
-class _BaseMarkResultsTestMixin(object):
-    def _assert_actions(self, expected_sf_actions, expected_ds_actions, dry_run=False):
-        # comparing these with the order normalized because we don't really care about that - unless of course the same
-        # object is being written to twice (and hence overwritten) - but that's not a desired behaviour anyway and
-        # it wouldn't be something sensible to assert for.
-        assert sorted(self.mock_data_client.set_framework_result.call_args_list, key=lambda c: c[0]) == (sorted((
-            ((k, "h-cloud-99", act, "Blazes Boylan"), {},) for k, act in expected_sf_actions.items()
-        ), key=lambda c: c[0]) if not dry_run else [])
-        assert sorted(self.mock_data_client.update_draft_service_status.call_args_list, key=lambda c: c[0]) == (sorted((
-            ((k, "submitted" if act else "failed", "Blazes Boylan"), {},) for k, act in expected_ds_actions.items()
-        ), key=lambda c: c[0]) if not dry_run else [])
+def _assert_draft_service_result_actions(client, expected_draft_services_actions, dry_run=False):
+    update_draft_service_status_calls = [call[0] for call in client.update_draft_service_status.call_args_list]
+
+    expected_calls = [] if dry_run else [
+        (supplier_id, "submitted" if submitted else "failed", "Blazes Boylan")
+        for supplier_id, submitted
+        in expected_draft_services_actions
+    ]
+    assert update_draft_service_status_calls == expected_calls
 
 
-class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
+def _assert_set_framework_result_actions(client, expected_set_framework_actions, dry_run=False):
+    set_framework_result_calls = [call[0] for call in client.set_framework_result.call_args_list]
+
+    expected_calls = [] if dry_run else [
+        (supplier_id, "h-cloud-99", result, "Blazes Boylan") for supplier_id, result in expected_set_framework_actions
+    ]
+    assert set_framework_result_calls == expected_calls
+
+
+class TestNoPrevResults(BaseAssessmentTest):
     def _get_supplier_frameworks(self):
         # no onFramework values should be set yet
         return {
@@ -38,14 +45,14 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
     @pytest.mark.parametrize(
         # we can very easily parametrize this into the 16 possible combinations of these flags - the results for the
         # first three flags should be identical and it's very easy to flip some of the assertions for the dry_run mode
-        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_draft_services,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
-    def test_with_ds_schema(
+    def test_with_draft_services_schema(
             self,
             reassess_passed_suppliers,
             reassess_failed_suppliers,
-            reassess_failed_suppliers_ds,
+            reassess_failed_suppliers_draft_services,
             dry_run,
     ):
         mark_definite_framework_results(
@@ -58,35 +65,36 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
             dry_run=dry_run,
             reassess_passed_suppliers=reassess_passed_suppliers,
             reassess_failed_suppliers=reassess_failed_suppliers,
-            reassess_failed_draft_services=reassess_failed_suppliers_ds,
+            reassess_failed_draft_services=reassess_failed_suppliers_draft_services,
         )
 
-        expected_sf_actions = {
-            2345: False,
-            3456: False,
-            4321: True,
-            4567: False,
-            5432: False,
-            6543: True,
-            8765: True,
-        }
-        expected_ds_actions = {
-            999003: False,
-            999005: False,
-            999012: False,
-        }
-        self._assert_actions(expected_sf_actions, expected_ds_actions, dry_run=dry_run)
+        expected_set_framework_actions = (
+            (2345, False),
+            (3456, False),
+            (4321, True),
+            (4567, False),
+            (5432, False),
+            (6543, True),
+            (8765, True),
+        )
+        expected_draft_services_actions = (
+            (999003, False),
+            (999005, False),
+            (999012, False),
+        )
+        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
+        _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_draft_services,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
-    def test_without_ds_schema(
+    def test_without_draft_services_schema(
             self,
             reassess_passed_suppliers,
             reassess_failed_suppliers,
-            reassess_failed_suppliers_ds,
+            reassess_failed_suppliers_draft_services,
             dry_run,
     ):
         mark_definite_framework_results(
@@ -99,31 +107,31 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
             dry_run=dry_run,
             reassess_passed_suppliers=reassess_passed_suppliers,
             reassess_failed_suppliers=reassess_failed_suppliers,
-            reassess_failed_draft_services=reassess_failed_suppliers_ds,
+            reassess_failed_draft_services=reassess_failed_suppliers_draft_services,
         )
 
-        expected_sf_actions = {
-            2345: False,
-            3456: True,
-            4321: True,
-            4567: False,
-            5432: False,
-            6543: True,
-            8765: True,
-        }
-        expected_ds_actions = {}
-        self._assert_actions(expected_sf_actions, expected_ds_actions, dry_run=dry_run)
+        expected_set_framework_actions = (
+            (2345, False),
+            (3456, True),
+            (4321, True),
+            (4567, False),
+            (5432, False),
+            (6543, True),
+            (8765, True),
+        )
+
+        _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_draft_services,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
-    def test_no_baseline_schema(
+    def test_no_discretionary_pass_schema(
         self,
         reassess_passed_suppliers,
         reassess_failed_suppliers,
-        reassess_failed_suppliers_ds,
+        reassess_failed_suppliers_draft_services,
         dry_run,
     ):
         mark_definite_framework_results(
@@ -136,34 +144,35 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
             dry_run=dry_run,
             reassess_passed_suppliers=reassess_passed_suppliers,
             reassess_failed_suppliers=reassess_failed_suppliers,
-            reassess_failed_draft_services=reassess_failed_suppliers_ds,
+            reassess_failed_draft_services=reassess_failed_suppliers_draft_services,
         )
 
-        expected_sf_actions = {
-            3456: False,
-            4321: True,
-            4567: False,
-            5432: False,
-            6543: True,
-            8765: True,
-        }
-        expected_ds_actions = {
-            999003: False,
-            999005: False,
-            999012: False,
-        }
-        self._assert_actions(expected_sf_actions, expected_ds_actions, dry_run=dry_run)
+        expected_set_framework_actions = (
+            (3456, False),
+            (4321, True),
+            (4567, False),
+            (5432, False),
+            (6543, True),
+            (8765, True),
+        )
+        expected_draft_services_actions = (
+            (999003, False),
+            (999005, False),
+            (999012, False),
+        )
+        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
+        _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_draft_services,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
     def test_neither_optional_schema(
         self,
         reassess_passed_suppliers,
         reassess_failed_suppliers,
-        reassess_failed_suppliers_ds,
+        reassess_failed_suppliers_draft_services,
         dry_run,
     ):
         mark_definite_framework_results(
@@ -176,22 +185,22 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
             dry_run=dry_run,
             reassess_passed_suppliers=reassess_passed_suppliers,
             reassess_failed_suppliers=reassess_failed_suppliers,
-            reassess_failed_draft_services=reassess_failed_suppliers_ds,
+            reassess_failed_draft_services=reassess_failed_suppliers_draft_services,
         )
 
-        expected_sf_actions = {
-            3456: True,
-            4321: True,
-            4567: False,
-            5432: False,
-            6543: True,
-            8765: True,
-        }
-        expected_ds_actions = {}
-        self._assert_actions(expected_sf_actions, expected_ds_actions, dry_run=dry_run)
+        expected_set_framework_actions = (
+            (3456, True),
+            (4321, True),
+            (4567, False),
+            (5432, False),
+            (6543, True),
+            (8765, True),
+        )
+
+        _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
 
-class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrameworksTestMixin, BaseAssessmentTest):
+class TestPrevResults(BaseAssessmentMismatchedOnFrameworksTestMixin, BaseAssessmentTest):
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
     @pytest.mark.parametrize("dry_run", (False, True,),)
     def test_reassess_none(self, dry_run,):
@@ -208,16 +217,17 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             reassess_failed_draft_services=False,
         )
 
-        expected_sf_actions = {
-            2345: False,
-            5432: False,
-            6543: False,
-            8765: True,
-        }
-        expected_ds_actions = {
-            999003: False,
-        }
-        self._assert_actions(expected_sf_actions, expected_ds_actions, dry_run=dry_run)
+        expected_set_framework_actions = (
+            (2345, False),
+            (5432, False),
+            (6543, False),
+            (8765, True),
+        )
+        expected_draft_services_actions = (
+            (999003, False),
+        )
+        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
+        _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
     @pytest.mark.parametrize("dry_run", (False, True,),)
@@ -235,17 +245,18 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             reassess_failed_draft_services=False,
         )
 
-        expected_sf_actions = {
-            2345: False,
-            4321: True,
-            5432: False,
-            6543: False,
-            8765: True,
-        }
-        expected_ds_actions = {
-            999003: False,
-        }
-        self._assert_actions(expected_sf_actions, expected_ds_actions, dry_run=dry_run)
+        expected_set_framework_actions = (
+            (2345, False),
+            (4321, True),
+            (5432, False),
+            (6543, False),
+            (8765, True),
+        )
+        expected_draft_services_actions = (
+            (999003, False),
+        )
+        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
+        _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
     @pytest.mark.parametrize("dry_run", (False, True,),)
@@ -263,18 +274,19 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             reassess_failed_draft_services=False,
         )
 
-        expected_sf_actions = {
-            2345: False,
-            3456: False,
-            5432: False,
-            6543: False,
-            8765: True,
-        }
-        expected_ds_actions = {
-            999003: False,
-            999005: False,
-        }
-        self._assert_actions(expected_sf_actions, expected_ds_actions, dry_run=dry_run)
+        expected_set_framework_actions = (
+            (2345, False),
+            (3456, False),
+            (5432, False),
+            (6543, False),
+            (8765, True),
+        )
+        expected_draft_services_actions = (
+            (999003, False),
+            (999005, False),
+        )
+        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
+        _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
     @pytest.mark.parametrize("dry_run", (False, True,),)
@@ -292,21 +304,22 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             reassess_failed_draft_services=True,
         )
 
-        expected_sf_actions = {
-            2345: False,
-            3456: False,
-            4321: True,
-            5432: False,
-            6543: True,
-            8765: True,
-        }
-        expected_ds_actions = {
-            999003: False,
-            999005: False,
-            999010: True,
-            999014: True,
-        }
-        self._assert_actions(expected_sf_actions, expected_ds_actions, dry_run=dry_run)
+        expected_set_framework_actions = (
+            (2345, False),
+            (3456, False),
+            (4321, True),
+            (5432, False),
+            (6543, True),
+            (8765, True),
+        )
+        expected_draft_services_actions = (
+            (999003, False),
+            (999005, False),
+            (999010, True),
+            (999014, True),
+        )
+        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
+        _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
     @pytest.mark.parametrize("dry_run", (False, True,),)
@@ -324,16 +337,17 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             reassess_failed_draft_services=True,
         )
 
-        expected_sf_actions = {
-            2345: False,
-            4321: True,
-            5432: False,
-            6543: True,
-            8765: True,
-        }
-        expected_ds_actions = {
-            999010: True,
-            999012: True,
-            999014: True,
-        }
-        self._assert_actions(expected_sf_actions, expected_ds_actions, dry_run=dry_run)
+        expected_set_framework_actions = (
+            (2345, False),
+            (4321, True),
+            (5432, False),
+            (6543, True),
+            (8765, True),
+        )
+        expected_draft_services_actions = (
+            (999010, True),
+            (999012, True),
+            (999014, True),
+        )
+        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
+        _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)

--- a/tests/test_mark_definite_framework_results.py
+++ b/tests/test_mark_definite_framework_results.py
@@ -38,21 +38,27 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
     @pytest.mark.parametrize(
         # we can very easily parametrize this into the 16 possible combinations of these flags - the results for the
         # first three flags should be identical and it's very easy to flip some of the assertions for the dry_run mode
-        "reassess_passed,reassess_failed,reassess_failed_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
-    def test_with_ds_schema(self, reassess_passed, reassess_failed, reassess_failed_ds, dry_run,):
+    def test_with_ds_schema(
+            self,
+            reassess_passed_suppliers,
+            reassess_failed_suppliers,
+            reassess_failed_suppliers_ds,
+            dry_run,
+    ):
         mark_definite_framework_results(
             self.mock_data_client,
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=reassess_passed,
-            reassess_failed=reassess_failed,
-            reassess_failed_draft_services=reassess_failed_ds,
+            reassess_passed_suppliers=reassess_passed_suppliers,
+            reassess_failed_suppliers=reassess_failed_suppliers,
+            reassess_failed_draft_services=reassess_failed_suppliers_ds,
         )
 
         expected_sf_actions = {
@@ -73,21 +79,27 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed,reassess_failed,reassess_failed_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
-    def test_without_ds_schema(self, reassess_passed, reassess_failed, reassess_failed_ds, dry_run,):
+    def test_without_ds_schema(
+            self,
+            reassess_passed_suppliers,
+            reassess_failed_suppliers,
+            reassess_failed_suppliers_ds,
+            dry_run,
+    ):
         mark_definite_framework_results(
             self.mock_data_client,
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=None,
             dry_run=dry_run,
-            reassess_passed=reassess_passed,
-            reassess_failed=reassess_failed,
-            reassess_failed_draft_services=reassess_failed_ds,
+            reassess_passed_suppliers=reassess_passed_suppliers,
+            reassess_failed_suppliers=reassess_failed_suppliers,
+            reassess_failed_draft_services=reassess_failed_suppliers_ds,
         )
 
         expected_sf_actions = {
@@ -104,14 +116,14 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed,reassess_failed,reassess_failed_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
     def test_no_baseline_schema(
         self,
-        reassess_passed,
-        reassess_failed,
-        reassess_failed_ds,
+        reassess_passed_suppliers,
+        reassess_failed_suppliers,
+        reassess_failed_suppliers_ds,
         dry_run,
     ):
         mark_definite_framework_results(
@@ -119,12 +131,12 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=None,
+            declaration_discretionary_pass_schema=None,
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=reassess_passed,
-            reassess_failed=reassess_failed,
-            reassess_failed_draft_services=reassess_failed_ds,
+            reassess_passed_suppliers=reassess_passed_suppliers,
+            reassess_failed_suppliers=reassess_failed_suppliers,
+            reassess_failed_draft_services=reassess_failed_suppliers_ds,
         )
 
         expected_sf_actions = {
@@ -144,14 +156,14 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed,reassess_failed,reassess_failed_ds,dry_run",
+        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_ds,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
     def test_neither_optional_schema(
         self,
-        reassess_passed,
-        reassess_failed,
-        reassess_failed_ds,
+        reassess_passed_suppliers,
+        reassess_failed_suppliers,
+        reassess_failed_suppliers_ds,
         dry_run,
     ):
         mark_definite_framework_results(
@@ -159,12 +171,12 @@ class TestNoPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentTest):
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=None,
+            declaration_discretionary_pass_schema=None,
             service_schema=None,
             dry_run=dry_run,
-            reassess_passed=reassess_passed,
-            reassess_failed=reassess_failed,
-            reassess_failed_draft_services=reassess_failed_ds,
+            reassess_passed_suppliers=reassess_passed_suppliers,
+            reassess_failed_suppliers=reassess_failed_suppliers,
+            reassess_failed_draft_services=reassess_failed_suppliers_ds,
         )
 
         expected_sf_actions = {
@@ -188,11 +200,11 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=False,
-            reassess_failed=False,
+            reassess_passed_suppliers=False,
+            reassess_failed_suppliers=False,
             reassess_failed_draft_services=False,
         )
 
@@ -209,17 +221,17 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
     @pytest.mark.parametrize("dry_run", (False, True,),)
-    def test_reassess_failed(self, dry_run,):
+    def test_reassess_failed_suppliers(self, dry_run,):
         mark_definite_framework_results(
             self.mock_data_client,
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=False,
-            reassess_failed=True,
+            reassess_passed_suppliers=False,
+            reassess_failed_suppliers=True,
             reassess_failed_draft_services=False,
         )
 
@@ -237,17 +249,17 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
     @pytest.mark.parametrize("dry_run", (False, True,),)
-    def test_reassess_passed(self, dry_run,):
+    def test_reassess_passed_suppliers(self, dry_run,):
         mark_definite_framework_results(
             self.mock_data_client,
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=True,
-            reassess_failed=False,
+            reassess_passed_suppliers=True,
+            reassess_failed_suppliers=False,
             reassess_failed_draft_services=False,
         )
 
@@ -272,11 +284,11 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=self._draft_service_schema(),
             dry_run=dry_run,
-            reassess_passed=True,
-            reassess_failed=True,
+            reassess_passed_suppliers=True,
+            reassess_failed_suppliers=True,
             reassess_failed_draft_services=True,
         )
 
@@ -304,11 +316,11 @@ class TestPrevResults(_BaseMarkResultsTestMixin, BaseAssessmentMismatchedOnFrame
             "Blazes Boylan",
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
-            declaration_baseline_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
+            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
             service_schema=None,
             dry_run=dry_run,
-            reassess_passed=True,
-            reassess_failed=True,
+            reassess_passed_suppliers=True,
+            reassess_failed_suppliers=True,
             reassess_failed_draft_services=True,
         )
 


### PR DESCRIPTION
Simplify script
Avoid extraneous/ confusing initialisation of service_counter
Add more comments

Makes the script a bit more verbose but I think more readable. I've annotated each of the pass/ fail conditions with a comment saying what we're checking for and what that results in.