### PR TITLE
Don't fetch binaries from s3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
 FROM python:3.6-slim
 
-ENV APP_DIR /app
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc g++ make git libffi-dev libssl-dev libc6-dev wget curl socat jq
+RUN wget --quiet -O /usr/local/bin/aws-auth https://raw.githubusercontent.com/alphagov/aws-auth/1741ad8b8454f54dd40fb730645fc2d6e3ed9ea9/aws-auth.sh \
+    && chmod 0755 /usr/local/bin/aws-auth
 
 RUN wget --quiet -O /usr/local/bin/sops https://github.com/mozilla/sops/releases/download/3.2.0/sops-3.2.0.linux \
     && echo 'fec5b5b5bbae922a829a6277f6d66a061d990c04132da3c82db32ccc309a22e7  /usr/local/bin/sops' | sha256sum -c - \
     && chmod 0755 /usr/local/bin/sops
 
-RUN wget --quiet -O /usr/local/bin/aws-auth https://raw.githubusercontent.com/alphagov/aws-auth/1741ad8b8454f54dd40fb730645fc2d6e3ed9ea9/aws-auth.sh \
-    && chmod 0755 /usr/local/bin/aws-auth
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gcc g++ make git libffi-dev libssl-dev libc6-dev wget curl socat jq
 
+ENV APP_DIR /app
 WORKDIR ${APP_DIR}
 
 COPY requirements.txt ${APP_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ENV APP_DIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc g++ make git libffi-dev libssl-dev libc6-dev wget curl socat
 
-RUN wget --quiet -O /usr/local/bin/sops https://s3-eu-west-1.amazonaws.com/digitalmarketplace-public/sops_linux_amd64 \
+RUN wget --quiet -O /usr/local/bin/sops https://github.com/mozilla/sops/releases/download/3.2.0/sops-3.2.0.linux \
+    && echo 'fec5b5b5bbae922a829a6277f6d66a061d990c04132da3c82db32ccc309a22e7  /usr/local/bin/sops' | sha256sum -c - \
     && chmod 0755 /usr/local/bin/sops
 
 RUN wget --quiet -O /usr/local/bin/aws-auth https://raw.githubusercontent.com/alphagov/aws-auth/1741ad8b8454f54dd40fb730645fc2d6e3ed9ea9/aws-auth.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6-slim
 ENV APP_DIR /app
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc g++ make git libffi-dev libssl-dev libc6-dev wget curl socat
+    apt-get install -y --no-install-recommends gcc g++ make git libffi-dev libssl-dev libc6-dev wget curl socat jq
 
 RUN wget --quiet -O /usr/local/bin/sops https://github.com/mozilla/sops/releases/download/3.2.0/sops-3.2.0.linux \
     && echo 'fec5b5b5bbae922a829a6277f6d66a061d990c04132da3c82db32ccc309a22e7  /usr/local/bin/sops' | sha256sum -c - \
@@ -11,9 +11,6 @@ RUN wget --quiet -O /usr/local/bin/sops https://github.com/mozilla/sops/releases
 
 RUN wget --quiet -O /usr/local/bin/aws-auth https://raw.githubusercontent.com/alphagov/aws-auth/1741ad8b8454f54dd40fb730645fc2d6e3ed9ea9/aws-auth.sh \
     && chmod 0755 /usr/local/bin/aws-auth
-
-RUN wget --quiet -O /usr/local/bin/jq https://s3-eu-west-1.amazonaws.com/digitalmarketplace-public/jq-linux64 \
-    && chmod 0755 /usr/local/bin/jq
 
 WORKDIR ${APP_DIR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,16 @@ FROM python:3.6-slim
 ENV APP_DIR /app
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc g++ make git libffi-dev libssl-dev libc6-dev wget curl socat && \
-    wget --quiet -O /usr/local/bin/sops https://s3-eu-west-1.amazonaws.com/digitalmarketplace-public/sops_linux_amd64 && chmod 0755 /usr/local/bin/sops && \
-    wget --quiet -O /usr/local/bin/aws-auth https://raw.githubusercontent.com/alphagov/aws-auth/1741ad8b8454f54dd40fb730645fc2d6e3ed9ea9/aws-auth.sh && chmod 0755 /usr/local/bin/aws-auth && \
-    wget --quiet -O /usr/local/bin/jq https://s3-eu-west-1.amazonaws.com/digitalmarketplace-public/jq-linux64 && chmod 0755 /usr/local/bin/jq
+    apt-get install -y --no-install-recommends gcc g++ make git libffi-dev libssl-dev libc6-dev wget curl socat
+
+RUN wget --quiet -O /usr/local/bin/sops https://s3-eu-west-1.amazonaws.com/digitalmarketplace-public/sops_linux_amd64 \
+    && chmod 0755 /usr/local/bin/sops
+
+RUN wget --quiet -O /usr/local/bin/aws-auth https://raw.githubusercontent.com/alphagov/aws-auth/1741ad8b8454f54dd40fb730645fc2d6e3ed9ea9/aws-auth.sh \
+    && chmod 0755 /usr/local/bin/aws-auth
+
+RUN wget --quiet -O /usr/local/bin/jq https://s3-eu-west-1.amazonaws.com/digitalmarketplace-public/jq-linux64 \
+    && chmod 0755 /usr/local/bin/jq
 
 WORKDIR ${APP_DIR}
 


### PR DESCRIPTION
The Dockerfile for digitalmarketplace-scripts currently fetches some binary dependencies from an s3 bucket managed by us. This means we are responsible for keeping these binaries up-to-date, which is a big pain.

A simpler method is to fetch the binaries from the GitHub release page; although we are still responsible for keeping the packages up-to-date, at least this way we don't have to log in to AWS ;)