### PR TITLE
rotate-api-tokens.sh: make get_jenkins_env_token_name aware of antivirus_api

### DIFF
--- a/scripts/rotate-api-tokens.sh
+++ b/scripts/rotate-api-tokens.sh
@@ -36,6 +36,8 @@ function get_jenkins_env_token_name() {
     app_name="DATA_API"
   elif [[ "$1" == "search_api" ]]; then
     app_name="SEARCH_API"
+  elif [[ "$1" == "antivirus_api" ]]; then
+    app_name="ANTIVIRUS_API"
   else
     exit 3
   fi


### PR DESCRIPTION
I think this is the cause of the incorrectly-generated PR https://github.com/alphagov/digitalmarketplace-credentials/pull/191