### PR TITLE
Fix csv export so only aborts if no data found

### DIFF
--- a/dmscripts/generate_supplier_user_csv.py
+++ b/dmscripts/generate_supplier_user_csv.py
@@ -143,7 +143,7 @@ def generate_csv_and_upload_to_s3(
     else:
         headers, rows, download_filename = generate_supplier_csv(framework_slug, data_api_client, logger=logger)
 
-    if not rows:
+    if not download_filename:
         return False
 
     # Save CSV to output dir and upload to S3

--- a/dmscripts/generate_supplier_user_csv.py
+++ b/dmscripts/generate_supplier_user_csv.py
@@ -9,7 +9,7 @@ def generate_supplier_csv(framework_slug, data_api_client, logger):
 
     supplier_rows = data_api_client.export_suppliers(framework_slug).get('suppliers', [])
     if not supplier_rows:
-        logger.info('No supplier data found for framework {}'.format(framework_slug))
+        logger.warn('No supplier data found for framework {}'.format(framework_slug))
         return [], [], None
 
     supplier_and_framework_headers = [
@@ -75,7 +75,7 @@ def generate_user_csv(framework_slug, data_api_client, user_research_opted_in, l
     ]
     user_rows = data_api_client.export_users(framework_slug).get('users', [])
     if not user_rows:
-        logger.info('No user data found for framework {}'.format(framework_slug))
+        logger.warn('No user data found for framework {}'.format(framework_slug))
         return [], [], None
 
     if user_research_opted_in:

--- a/tests/test_generate_supplier_user_csv.py
+++ b/tests/test_generate_supplier_user_csv.py
@@ -234,3 +234,43 @@ def test_generate_user_csv_generates_csv_and_uploads_to_s3(upload_to_s3, generat
             'data/filename.csv', 'g-cloud-10', 'filename.csv', bucket, dry_run=False, logger='logger'
         )
     ]
+
+
+@mock.patch('dmscripts.generate_supplier_user_csv._build_csv')
+@mock.patch("dmscripts.generate_supplier_user_csv.upload_to_s3")
+def test_generate_csv_and_upload_to_s3_returns_ok_if_no_users_opted_in(upload_to_s3, build_csv):
+    bucket = mock.Mock()
+    data_api_client = mock.Mock()
+    data_api_client.export_users.return_value = {
+        "users": [
+            {
+                "application_result": "pass",
+                "application_status": "no_application",
+                "declaration_status": "unstarted",
+                "email address": "1234@example.com",
+                "framework_agreement": True,
+                "published_service_count": 4,
+                "supplier_id": 1234,
+                "user_name": "Test user 1",
+                "user_research_opted_in": False,
+                "variations_agreed": ""
+            },
+            {
+                "application_result": "pass",
+                "application_status": "no_application",
+                "declaration_status": "unstarted",
+                "email address": "5678@example.com",
+                "framework_agreement": True,
+                "published_service_count": 3,
+                "supplier_id": 5678,
+                "user_name": "Test user 2",
+                "user_research_opted_in": False,
+                "variations_agreed": ""
+            }
+        ]
+    }
+
+    ok = generate_csv_and_upload_to_s3(
+        bucket, "g-cloud-11", "users", "data", data_api_client, user_research_opted_in=True
+    )
+    assert ok


### PR DESCRIPTION
We had an issue where CSVs with no rows were being created legitimately (because there were no entries in the database that fit the criteria), but the CSV export script was failing to upload this to s3 as it thought this was due to an error.

This PR changes the `generate_csv_and_upload_to_s3` procedure so it only aborts if it does not have a valid s3 filename.

This does mean that in future it is possible for CSVs with only a header row to be uploaded.