### PR TITLE
Update digitalmarketplace-utils from 46.3.0 to 48.1.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ Flask==1.0.2
 itsdangerous==0.24 # pyup: ignore
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@46.3.0#egg=digitalmarketplace-utils==46.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.1.0#egg=digitalmarketplace-utils==48.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==1.0.2
 itsdangerous==0.24 # pyup: ignore
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@46.3.0#egg=digitalmarketplace-utils==46.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.1.0#egg=digitalmarketplace-utils==48.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
 
@@ -25,7 +25,8 @@ yq==2.7.2
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 attrs==19.1.0
-boto3==1.9.115
+blinker==1.4
+boto3==1.9.130
 botocore==1.12.115
 certifi==2019.3.9
 cffi==1.12.2
@@ -41,10 +42,11 @@ Flask-Script==2.0.6
 Flask-WTF==0.14.2
 fleep==1.0.1
 future==0.17.1
-govuk-country-register==0.2.2
+gds-metrics==0.2.0
+govuk-country-register==0.3.0
 idna==2.8
 inflection==0.3.1
-Jinja2==2.10
+Jinja2==2.10.1
 jmespath==0.9.4
 mailchimp3==3.0.6
 Markdown==2.6.11
@@ -53,18 +55,19 @@ monotonic==1.5
 notifications-python-client==5.3.0
 numpy==1.16.2
 odfpy==1.4.0
+prometheus-client==0.2.0
 pyasn1==0.4.5
 pycparser==2.19
 PyJWT==1.7.1
 pyrsistent==0.14.11
-pytz==2018.9
+pytz==2019.1
 PyYAML==3.13
 requests==2.21.0
 rsa==3.4.2
 s3transfer==0.2.0
 six==1.12.0
 urllib3==1.24.1
-Werkzeug==0.14.1
+Werkzeug==0.15.2
 workdays==1.4
 WTForms==2.2.1
 xmltodict==0.12.0


### PR DESCRIPTION
This will allow scripts to recognise email addresses separated by ampersands (see alphagov/digitalmarketplace-utils#515).