### PR TITLE
Change so that no suppliers/users is a warning only

### DIFF
--- a/dmscripts/generate_supplier_user_csv.py
+++ b/dmscripts/generate_supplier_user_csv.py
@@ -141,6 +141,10 @@ def generate_csv_and_upload_to_s3(
     else:
         headers, rows, download_filename = generate_supplier_csv(framework_slug, data_api_client, logger=logger)
 
+    # no need to create an empty csv
+    if not rows:
+        return True
+
     # Save CSV to output dir and upload to S3
     file_path = csv_path(output_dir, download_filename)
     _build_csv(file_path, headers, rows)

--- a/dmscripts/generate_supplier_user_csv.py
+++ b/dmscripts/generate_supplier_user_csv.py
@@ -10,7 +10,6 @@ def generate_supplier_csv(framework_slug, data_api_client, logger):
     supplier_rows = data_api_client.export_suppliers(framework_slug).get('suppliers', [])
     if not supplier_rows:
         logger.warn('No supplier data found for framework {}'.format(framework_slug))
-        return [], [], None
 
     supplier_and_framework_headers = [
         "supplier_id",
@@ -76,7 +75,6 @@ def generate_user_csv(framework_slug, data_api_client, user_research_opted_in, l
     user_rows = data_api_client.export_users(framework_slug).get('users', [])
     if not user_rows:
         logger.warn('No user data found for framework {}'.format(framework_slug))
-        return [], [], None
 
     if user_research_opted_in:
         filename = "user-research-suppliers-on-{}".format(framework_slug)
@@ -142,9 +140,6 @@ def generate_csv_and_upload_to_s3(
 
     else:
         headers, rows, download_filename = generate_supplier_csv(framework_slug, data_api_client, logger=logger)
-
-    if not download_filename:
-        return False
 
     # Save CSV to output dir and upload to S3
     file_path = csv_path(output_dir, download_filename)


### PR DESCRIPTION
Previously generate_supplier/user_csv would return early if there was no
data from the server, effectively treating this as an error.

However it is very possible that there might be no data for whatever
reason; we should warn but then continue as normal.