### PR TITLE
Hide fake suppliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The `scripts` folder in this repository contains scripts that interact with the 
 * `export-framework-results-reasons.py`
 
   To be run when a framework closes for applications - produces three CSV files for pass, fail and discretionary
-  results, with relevant data to be passed to CCS.
+  results, with relevant data to be passed to CCS. To exclude fake suppliers use the -e parameter with the IDs
+  separated by commas (without spaces, e.g. -e 123,456,789). There is a list of known fake supplier IDs encrypted in 
+  the private repository.
 
 * `generate-buyer-email-list.py`
 
@@ -45,7 +47,9 @@ The `scripts` folder in this repository contains scripts that interact with the 
 
   To be run when a framework closes for applications - extracts a CSV report of all suppliers who expressed an interest
   in the framework and their eventual application status (did they make an application, only fill in the declaration,
-  how many services submitted/left in draft per lot, etc.)
+  how many services submitted/left in draft per lot, etc). To exclude fake suppliers use the -e parameter with the IDs
+  separated by commas (without spaces, e.g. -e 123,456,789). There is a list of known fake supplier IDs encrypted in 
+  the private repository.
 
 * `generate-g8-agreement-signature-pages.py` and `generate-g8-counterpart-signature-pages.py`
 
@@ -85,7 +89,9 @@ The `scripts` folder in this repository contains scripts that interact with the 
 * `mark-definite-framework-results.py`
 
   Marks suppliers as having passed/failed a framework, where the result can be determined "automatically" not requiring
-  human involvement (i.e. not "discretionary" results).
+  human involvement (i.e. not "discretionary" results). To exclude fake suppliers use the --excluded-supplier-ids with 
+  the IDs separated by commas (without spaces, e.g. --excluded-supplier-ids=123,456,789). There is a list of known 
+  fake supplier IDs encrypted in the private repository.
 
 * `notify-buyers-to-award-closed-briefs.py`
 

--- a/dmscripts/generate_framework_master_csv.py
+++ b/dmscripts/generate_framework_master_csv.py
@@ -62,7 +62,9 @@ class GenerateMasterCSV(GenerateCSVFromAPI):
 
     def get_supplier_frameworks(self):
         """Return supplier frameworks."""
-        return self.client.find_framework_suppliers(self.target_framework_slug)['supplierFrameworks']
+        return self.client.find_framework_suppliers(
+            self.target_framework_slug, with_declarations=None
+        )['supplierFrameworks']
 
     def get_supplier_application_status(self):
         """Return a dict, supplier id: application status."""

--- a/dmscripts/generate_framework_master_csv.py
+++ b/dmscripts/generate_framework_master_csv.py
@@ -25,6 +25,7 @@ class GenerateMasterCSV(GenerateCSVFromAPI):
         self.target_framework_slug = target_framework_slug
         self.framework = self.client.get_framework(target_framework_slug)['frameworks']
         self.lot_slugs = tuple(i['slug'] for i in self.framework['lots'])
+        self.excluded_supplier_ids = []
 
     def get_column_name(self, service_status, lot_slug):
         """For each lot we're working out how many submitted and non-submitted services they have.
@@ -76,6 +77,8 @@ class GenerateMasterCSV(GenerateCSVFromAPI):
         for sf in supplier_frameworks:
             # This bit takes care of the columns in static_fieldnames.
             supplier_id = sf['supplierId']
+            if supplier_id in self.excluded_supplier_ids:
+                continue  # this part excludes any supplier the executioner of the script doesn't want in the output
             declaration = sf['declaration'].get('status', '') if sf['declaration'] else ''
             supplier_info = [
                 supplier_id,

--- a/dmscripts/helpers/framework_helpers.py
+++ b/dmscripts/helpers/framework_helpers.py
@@ -36,7 +36,9 @@ def has_supplier_submitted_services(client, framework_slug, supplier_id):
 
 def find_suppliers_on_framework(client, framework_slug):
     return (
-        supplier for supplier in client.find_framework_suppliers(framework_slug)['supplierFrameworks']
+        supplier for supplier in client.find_framework_suppliers(
+            framework_slug, with_declarations=None
+        )['supplierFrameworks']
         if supplier['onFramework']
     )
 

--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -23,7 +23,9 @@ class SupplierFrameworkData(object):
 
     def get_supplier_frameworks(self):
         """Return supplier frameworks."""
-        return self.client.find_framework_suppliers(self.target_framework_slug)['supplierFrameworks']
+        return self.client.find_framework_suppliers(
+            self.target_framework_slug, with_declarations=None
+        )['supplierFrameworks']
 
     def get_supplier_users(self):
         """Return a dict, {supplier id: [users]}."""
@@ -175,7 +177,9 @@ class SupplierFrameworkDeclarations:
         """
         return [
             framework_supplier['supplierId']
-            for framework_supplier in self.api_client.find_framework_suppliers_iter(framework_slug)
+            for framework_supplier in self.api_client.find_framework_suppliers_iter(
+                framework_slug, with_declarations=None
+            )
             if framework_supplier['onFramework'] is not True
         ]
 
@@ -239,7 +243,7 @@ class SupplierFrameworkDeclarations:
         old_frameworks = self._frameworks_older_than_date(date_from)
         for framework in old_frameworks:
             suppliers_with_declarations_to_clear = self.api_client.find_framework_suppliers_iter(
-                framework_slug=framework
+                framework_slug=framework, with_declarations=None
             )
             for supplier in suppliers_with_declarations_to_clear:
                 self.remove_declaration(supplier['supplierId'], framework_slug=framework)

--- a/dmscripts/mark_definite_framework_results.py
+++ b/dmscripts/mark_definite_framework_results.py
@@ -83,11 +83,20 @@ def mark_definite_framework_results(
     dry_run=True,
     supplier_ids=None,
     logger=logging.getLogger("script"),
+    excluded_supplier_ids=None,
 ):
     interested_supplier_ids = supplier_ids or client.get_interested_suppliers(
         framework_slug
     ).get('interestedSuppliers', ())
     total_interested_suppliers = len(interested_supplier_ids)
+
+    # exclude suppliers with IDs the executioner defined
+    if excluded_supplier_ids is not None:
+        for excluded_supplier in excluded_supplier_ids.split(','):
+            try:
+                interested_supplier_ids.pop(interested_supplier_ids.index(int(excluded_supplier)))
+            except IndexError:  # occurs when .index() fails
+                continue
 
     # Loop over suppliers breaking out if they pass or fail, if they make it to the end they get a discretionary pass
     for i, supplier_id in enumerate(interested_supplier_ids, start=1):

--- a/dmscripts/mark_definite_framework_results.py
+++ b/dmscripts/mark_definite_framework_results.py
@@ -92,11 +92,7 @@ def mark_definite_framework_results(
 
     # exclude suppliers with IDs the executioner defined
     if excluded_supplier_ids is not None:
-        for excluded_supplier in excluded_supplier_ids.split(','):
-            try:
-                interested_supplier_ids.pop(interested_supplier_ids.index(int(excluded_supplier)))
-            except IndexError:  # occurs when .index() fails
-                continue
+        interested_supplier_ids = list(set(interested_supplier_ids) - set(excluded_supplier_ids))
 
     # Loop over suppliers breaking out if they pass or fail, if they make it to the end they get a discretionary pass
     for i, supplier_id in enumerate(interested_supplier_ids, start=1):

--- a/dmscripts/scan_g_cloud_services_for_bad_words.py
+++ b/dmscripts/scan_g_cloud_services_for_bad_words.py
@@ -15,7 +15,7 @@ CSV_FIELD_NAMES = [
 
 
 def get_suppliers(client, framework_slug):
-    suppliers = client.find_framework_suppliers(framework_slug)
+    suppliers = client.find_framework_suppliers(framework_slug, with_declarations=None)
     suppliers = suppliers["supplierFrameworks"]
     if framework_slug == "g-cloud-6":
         suppliers_on_framework = suppliers

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,7 +6,7 @@ itsdangerous==0.24 # pyup: ignore
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.1.0#egg=digitalmarketplace-utils==48.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.0.0#egg=digitalmarketplace-apiclient==20.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
 
 awscli==1.16.144

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ itsdangerous==0.24 # pyup: ignore
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.1.0#egg=digitalmarketplace-utils==48.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.0.0#egg=digitalmarketplace-apiclient==20.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
 
 awscli==1.16.144

--- a/scripts/export-framework-results-reasons.py
+++ b/scripts/export-framework-results-reasons.py
@@ -14,7 +14,7 @@ Produces three files;
 
 Usage:
     scripts/export-framework-results-reasons.py [-h] <stage> <framework_slug> <content_path> <output_dir>
-      <declaration_schema_path> [<supplier_id_file>]
+      <declaration_schema_path> [<supplier_id_file>][-e <excluded_supplier_ids>]
 
 Options:
     -h --help
@@ -44,6 +44,13 @@ if __name__ == '__main__':
 
     supplier_id_file = args['<supplier_id_file>']
     supplier_ids = get_supplier_ids_from_file(supplier_id_file)
+    # exclude suppliers with IDs the executioner defined
+    if args['<excluded_supplier_ids>'] is not None and supplier_ids is not None:
+        for excluded_supplier in args['<excluded_supplier_ids>'].split(','):
+            try:
+                supplier_ids.pop(supplier_ids.index(int(excluded_supplier)))
+            except IndexError:  # occurs when .index() fails
+                continue
 
     pool = ThreadPool(3)
 

--- a/scripts/export-framework-results-reasons.py
+++ b/scripts/export-framework-results-reasons.py
@@ -46,11 +46,7 @@ if __name__ == '__main__':
     supplier_ids = get_supplier_ids_from_file(supplier_id_file)
     # exclude suppliers with IDs the executioner defined
     if args['<excluded_supplier_ids>'] is not None and supplier_ids is not None:
-        for excluded_supplier in args['<excluded_supplier_ids>'].split(','):
-            try:
-                supplier_ids.pop(supplier_ids.index(int(excluded_supplier)))
-            except IndexError:  # occurs when .index() fails
-                continue
+        supplier_ids = list(set(supplier_ids) - set([int(n) for n in args['<excluded_supplier_ids>'].split(',')]))
 
     pool = ThreadPool(3)
 

--- a/scripts/generate-framework-master-csv.py
+++ b/scripts/generate-framework-master-csv.py
@@ -15,10 +15,10 @@ Fields included:
 * The number of services submitted and left in draft per lot
 
 Usage:
-    scripts/generate-framework-master-csv.py <framework_slug> <stage> <auth_token> <output-dir> [--excluded-supplier-ids=<excluded_supplier_ids>]
+    scripts/generate-framework-master-csv.py <framework_slug> <stage> <auth_token> <output-dir> [-e <excluded_supplier_ids>]
 
 Example:
-    scripts/generate-framework-master-csv.py g-cloud-11 preview myToken path/to/myfolder --excluded-supplier-ids=123,456,789
+    scripts/generate-framework-master-csv.py g-cloud-11 preview myToken path/to/myfolder -e 123,456,789
 """
 import os
 import sys
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         target_framework_slug=framework_slug
     )
 
-    if arguments.get('<excluded_supplier_ids>', False):  # updates the generator with any IDs the user wants excluded
+    if arguments['<excluded_supplier_ids>'] is not None:  # updates the generator with any IDs the user wants excluded
         csv_builder.excluded_supplier_ids = [int(n) for n in arguments['<excluded_supplier_ids>'].split(',')]
     
     csv_builder.populate_output()

--- a/scripts/generate-framework-master-csv.py
+++ b/scripts/generate-framework-master-csv.py
@@ -15,10 +15,10 @@ Fields included:
 * The number of services submitted and left in draft per lot
 
 Usage:
-    scripts/generate-framework-master-csv.py <framework_slug> <stage> <auth_token> <output-dir> <excluded_supplier_ids>
+    scripts/generate-framework-master-csv.py <framework_slug> <stage> <auth_token> <output-dir> [--excluded-supplier-ids=<excluded_supplier_ids>]
 
 Example:
-    scripts/generate-framework-master-csv.py g-cloud-11 preview myToken path/to/myfolder 123,456,789
+    scripts/generate-framework-master-csv.py g-cloud-11 preview myToken path/to/myfolder --excluded-supplier-ids=123,456,789
 """
 import os
 import sys
@@ -55,7 +55,8 @@ if __name__ == "__main__":
         client=client,
         target_framework_slug=framework_slug
     )
-    if arguments['<excluded_supplier_ids>']:  # updates the generator with any IDs the user wants excluded
+
+    if arguments.get('<excluded_supplier_ids>', False):  # updates the generator with any IDs the user wants excluded
         csv_builder.excluded_supplier_ids = [int(n) for n in arguments['<excluded_supplier_ids>'].split(',')]
     
     csv_builder.populate_output()

--- a/scripts/generate-framework-master-csv.py
+++ b/scripts/generate-framework-master-csv.py
@@ -15,10 +15,10 @@ Fields included:
 * The number of services submitted and left in draft per lot
 
 Usage:
-    scripts/generate-framework-master-csv.py <framework_slug> <stage> <auth_token> <output-dir>
+    scripts/generate-framework-master-csv.py <framework_slug> <stage> <auth_token> <output-dir> <excluded_supplier_ids>
 
 Example:
-    scripts/generate-framework-master-csv.py g-cloud-11 preview myToken path/to/myfolder
+    scripts/generate-framework-master-csv.py g-cloud-11 preview myToken path/to/myfolder 123,456,789
 """
 import os
 import sys
@@ -55,6 +55,9 @@ if __name__ == "__main__":
         client=client,
         target_framework_slug=framework_slug
     )
+    if arguments['<excluded_supplier_ids>']:  # updates the generator with any IDs the user wants excluded
+        csv_builder.excluded_supplier_ids = [int(n) for n in arguments['<excluded_supplier_ids>'].split(',')]
+    
     csv_builder.populate_output()
 
     with open(os.path.join(output_dir, filename), 'w') as csvfile:

--- a/scripts/generate-framework-master-csv.py
+++ b/scripts/generate-framework-master-csv.py
@@ -15,7 +15,7 @@ Fields included:
 * The number of services submitted and left in draft per lot
 
 Usage:
-    scripts/generate-framework-master-csv.py <framework_slug> <stage> <auth_token> <output-dir> [-e <excluded_supplier_ids>]
+    scripts/generate-framework-master-csv.py <framework_slug> <stage> <auth_token> <output-dir> [-e <exclude_suppliers>]
 
 Example:
     scripts/generate-framework-master-csv.py g-cloud-11 preview myToken path/to/myfolder -e 123,456,789
@@ -56,9 +56,9 @@ if __name__ == "__main__":
         target_framework_slug=framework_slug
     )
 
-    if arguments['<excluded_supplier_ids>'] is not None:  # updates the generator with any IDs the user wants excluded
-        csv_builder.excluded_supplier_ids = [int(n) for n in arguments['<excluded_supplier_ids>'].split(',')]
-    
+    if arguments['<exclude_suppliers>'] is not None:  # updates the generator with any IDs the user wants excluded
+        csv_builder.excluded_supplier_ids = [int(n) for n in arguments['<exclude_suppliers>'].split(',')]
+
     csv_builder.populate_output()
 
     with open(os.path.join(output_dir, filename), 'w') as csvfile:

--- a/scripts/mark-definite-framework-results.py
+++ b/scripts/mark-definite-framework-results.py
@@ -54,6 +54,7 @@ from dmutils.env_helpers import get_api_endpoint_from_stage
 if __name__ == "__main__":
     from docopt import docopt
     args = docopt(__doc__)
+
     client = DataAPIClient(get_api_endpoint_from_stage(args["<stage>"], "api"), get_auth_token('api', args['<stage>']))
     updated_by = args["--updated-by"] or getpass.getuser()
 

--- a/scripts/mark-definite-framework-results.py
+++ b/scripts/mark-definite-framework-results.py
@@ -32,6 +32,7 @@ Usage: mark-definite-framework-results.py [options] <stage> <framework_slug>
 --reassess-failed-draft-services  Don't skip draft_services with "failed" status
 -v, --verbose                     Produce more detailed console output
 --supplier-id-file=<path>         Path to file containing supplier ids to check. One ID per line.
+--excluded-supplier-ids=<esis>    Supplier IDs to be excluded.
 """
 import sys
 sys.path.insert(0, '.')
@@ -53,7 +54,6 @@ from dmutils.env_helpers import get_api_endpoint_from_stage
 if __name__ == "__main__":
     from docopt import docopt
     args = docopt(__doc__)
-
     client = DataAPIClient(get_api_endpoint_from_stage(args["<stage>"], "api"), get_auth_token('api', args['<stage>']))
     updated_by = args["--updated-by"] or getpass.getuser()
 
@@ -83,4 +83,5 @@ if __name__ == "__main__":
         reassess_failed_draft_services=args["--reassess-failed-draft-services"],
         dry_run=args["--dry-run"],
         supplier_ids=supplier_ids,
+        excluded_supplier_ids=args["--excluded-supplier-ids"],
     )

--- a/scripts/oneoff/generate-fake-g-cloud-services.py
+++ b/scripts/oneoff/generate-fake-g-cloud-services.py
@@ -159,7 +159,9 @@ if __name__ == '__main__':
                                           user=identity)
 
     # 2) Find some suppliers with services on a given (old) framework (e.g. g-cloud-7)
-    suppliers = data_api_client.find_framework_suppliers(framework_slug=args.old_slug)['supplierFrameworks']
+    suppliers = data_api_client.find_framework_suppliers(
+        framework_slug=args.old_slug, with_declarations=None
+    )['supplierFrameworks']
     suppliers = [x for x in suppliers if x['supplierId'] not in SUPPLIER_BLACKLIST]
     suppliers = random.sample(suppliers, args.supplier_count)
     suppliers_prepared = set()

--- a/scripts/oneoff/save-signed-agreement-path.py
+++ b/scripts/oneoff/save-signed-agreement-path.py
@@ -49,7 +49,8 @@ if __name__ == '__main__':
     for framework_slug in FRAMEWORKS:
         # Get all supplier frameworks who have returned their agreement
         supplier_frameworks = client.find_framework_suppliers(
-            framework_slug=framework_slug, agreement_returned=True)['supplierFrameworks']
+            framework_slug=framework_slug, agreement_returned=True, with_declarations=None
+        )['supplierFrameworks']
 
         for supplier_framework in supplier_frameworks:
             print("======================")

--- a/tests/helpers/test_supplier_data_helpers.py
+++ b/tests/helpers/test_supplier_data_helpers.py
@@ -78,8 +78,8 @@ class TestSupplierFrameworkDeclarations(BaseAssessmentTest):
             )
             sfd.remove_supplier_declaration_for_expired_frameworks()
             expected_calls = [
-                mock.call(framework_slug="framework-expired-three-years-ago"),
-                mock.call(framework_slug="framework-expired-a-decade-ago")
+                mock.call(framework_slug="framework-expired-three-years-ago", with_declarations=None),
+                mock.call(framework_slug="framework-expired-a-decade-ago", with_declarations=None)
             ]
             mocked_api_client.find_framework_suppliers_iter.assert_has_calls(expected_calls, any_order=True)
 


### PR DESCRIPTION
https://trello.com/c/Px4kcY6B/462-exclude-fake-suppliers-from-framework-results-script

New optional keyword parameters to exclude fake suppliers for:
- generate-framework-master
- mark-definite-framework-results
- export-framework-results-reasons

PS: Also bumped the apiclient and explicitly calling `find_framework_suppliers` with `with_declarations=None` which used to be the default.