### PR TITLE
Move get_bucket_name into helper module

### DIFF
--- a/dmscripts/bulk_upload_documents.py
+++ b/dmscripts/bulk_upload_documents.py
@@ -4,13 +4,6 @@ import csv
 
 from dmutils.documents import get_document_path, generate_download_filename
 
-BUCKET_CATEGORIES = [
-    'agreements',
-    'communications',
-    'documents',
-    'submissions'
-]
-
 
 def upload_file(bucket, dry_run, file_path, framework_slug, bucket_category, supplier_name_dict=None):
     # Retrieve the supplier ID from the filepath
@@ -43,19 +36,6 @@ def upload_file(bucket, dry_run, file_path, framework_slug, bucket_category, sup
         print(supplier_id)
     else:
         print("[Dry-run] UPLOAD: '{}' to '{}'".format(file_path, upload_path))
-
-
-def get_bucket_name(stage, bucket_category):
-    if bucket_category not in BUCKET_CATEGORIES:
-        return None
-    if stage in ['local', 'dev']:
-        return "digitalmarketplace-dev-uploads"
-    if stage not in ['preview', 'staging', 'production']:
-        return None
-
-    bucket_name = 'digitalmarketplace-{0}-{1}-{1}'.format(bucket_category, stage)
-    print("BUCKET: {}".format(bucket_name))
-    return bucket_name
 
 
 def get_all_files_of_type(local_directory, file_type):

--- a/dmscripts/bulk_upload_documents.py
+++ b/dmscripts/bulk_upload_documents.py
@@ -1,4 +1,3 @@
-import os
 import re
 import csv
 
@@ -36,13 +35,6 @@ def upload_file(bucket, dry_run, file_path, framework_slug, bucket_category, sup
         print(supplier_id)
     else:
         print("[Dry-run] UPLOAD: '{}' to '{}'".format(file_path, upload_path))
-
-
-def get_all_files_of_type(local_directory, file_type):
-    for root, subfolder, files in os.walk(local_directory):
-        for filename in files:
-            if filename.endswith(file_type):
-                yield os.path.join(root, filename)
 
 
 def get_supplier_id_from_framework_file_path(path):

--- a/dmscripts/helpers/file_helpers.py
+++ b/dmscripts/helpers/file_helpers.py
@@ -1,0 +1,8 @@
+import os
+
+
+def get_all_files_of_type(local_directory, file_type):
+    for root, subfolder, files in os.walk(local_directory):
+        for filename in files:
+            if filename.endswith(file_type):
+                yield os.path.join(root, filename)

--- a/dmscripts/helpers/s3_helpers.py
+++ b/dmscripts/helpers/s3_helpers.py
@@ -1,0 +1,21 @@
+
+BUCKET_CATEGORIES = [
+    'agreements',
+    'communications',
+    'documents',
+    'submissions',
+    'reports'
+]
+
+
+def get_bucket_name(stage, bucket_category):
+    if bucket_category not in BUCKET_CATEGORIES:
+        return None
+    if stage in ['local', 'dev']:
+        return "digitalmarketplace-dev-uploads"
+    if stage not in ['preview', 'staging', 'production']:
+        return None
+
+    bucket_name = 'digitalmarketplace-{0}-{1}-{1}'.format(bucket_category, stage)
+    print("BUCKET: {}".format(bucket_name))
+    return bucket_name

--- a/scripts/framework-applications/bulk-upload-documents.py
+++ b/scripts/framework-applications/bulk-upload-documents.py
@@ -37,8 +37,9 @@ import os
 import sys
 sys.path.insert(0, '.')
 
+from dmscripts.helpers.file_helpers import get_all_files_of_type
 from dmscripts.helpers.s3_helpers import get_bucket_name
-from dmscripts.bulk_upload_documents import get_all_files_of_type, upload_file, get_supplier_name_dict_from_tsv
+from dmscripts.bulk_upload_documents import upload_file, get_supplier_name_dict_from_tsv
 
 from docopt import docopt
 

--- a/scripts/framework-applications/bulk-upload-documents.py
+++ b/scripts/framework-applications/bulk-upload-documents.py
@@ -37,8 +37,8 @@ import os
 import sys
 sys.path.insert(0, '.')
 
-from dmscripts.bulk_upload_documents import get_bucket_name, get_all_files_of_type, \
-    upload_file, get_supplier_name_dict_from_tsv
+from dmscripts.helpers.s3_helpers import get_bucket_name
+from dmscripts.bulk_upload_documents import get_all_files_of_type, upload_file, get_supplier_name_dict_from_tsv
 
 from docopt import docopt
 

--- a/scripts/generate-supplier-user-csv.py
+++ b/scripts/generate-supplier-user-csv.py
@@ -32,10 +32,10 @@ import sys
 sys.path.insert(0, '.')
 
 from dmscripts.helpers.auth_helpers import get_auth_token
-from dmscripts.bulk_upload_documents import get_bucket_name
 from dmscripts.generate_supplier_user_csv import generate_csv_and_upload_to_s3
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
+from dmscripts.helpers.s3_helpers import get_bucket_name
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
 from docopt import docopt

--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -42,7 +42,7 @@ import sys
 sys.path.insert(0, '.')
 
 from dmscripts.helpers.auth_helpers import get_auth_token
-from dmscripts.bulk_upload_documents import get_all_files_of_type
+from dmscripts.helpers.file_helpers import get_all_files_of_type
 from dmscripts.upload_counterpart_agreements import upload_counterpart_file
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging

--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -42,10 +42,11 @@ import sys
 sys.path.insert(0, '.')
 
 from dmscripts.helpers.auth_helpers import get_auth_token
-from dmscripts.bulk_upload_documents import get_bucket_name, get_all_files_of_type
+from dmscripts.bulk_upload_documents import get_all_files_of_type
 from dmscripts.upload_counterpart_agreements import upload_counterpart_file
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
+from dmscripts.helpers.s3_helpers import get_bucket_name
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
 from docopt import docopt

--- a/tests/helpers/test_file_helpers.py
+++ b/tests/helpers/test_file_helpers.py
@@ -1,0 +1,27 @@
+import os
+import tempfile
+import shutil
+
+from dmscripts.helpers.file_helpers import get_all_files_of_type
+
+
+class TestGetAllFilesOfType:
+
+    def test_get_all_files_of_type_for_flat_folder(self):
+        temp_folder_path = tempfile.mkdtemp()
+        pdf1 = open(os.path.join(temp_folder_path, 'test1.pdf'), 'w+')
+        pdf2 = open(os.path.join(temp_folder_path, 'test2.pdf'), 'w+')
+        assert len(list(get_all_files_of_type(temp_folder_path, 'pdf'))) == 2
+        pdf1.close()
+        pdf2.close()
+        shutil.rmtree(temp_folder_path)
+
+    def test_get_all_files_of_type_for_nested_folder(self):
+        temp_folder_path = tempfile.mkdtemp()
+        pdf1 = open(os.path.join(temp_folder_path, 'test1.pdf'), 'w+')
+        nested_temp_folder_path = tempfile.mkdtemp(dir=temp_folder_path)
+        pdf2 = open(os.path.join(nested_temp_folder_path, 'test2.pdf'), 'w+')
+        assert len(list(get_all_files_of_type(temp_folder_path, 'pdf'))) == 2
+        pdf1.close()
+        pdf2.close()
+        shutil.rmtree(temp_folder_path)

--- a/tests/helpers/test_s3_helpers.py
+++ b/tests/helpers/test_s3_helpers.py
@@ -1,0 +1,24 @@
+import pytest
+from dmscripts.helpers.s3_helpers import get_bucket_name
+
+
+class TestGetBucketName:
+
+    @pytest.mark.parametrize(
+        'stage, expected_bucket_name',
+        [
+            ('local', 'digitalmarketplace-dev-uploads'),
+            ('dev', 'digitalmarketplace-dev-uploads'),
+            ('preview', 'digitalmarketplace-agreements-preview-preview'),
+            ('staging', 'digitalmarketplace-agreements-staging-staging'),
+            ('production', 'digitalmarketplace-agreements-production-production'),
+        ]
+    )
+    def test_get_bucket_name_for_agreements_documents(self, stage, expected_bucket_name):
+        assert get_bucket_name(stage, 'agreements') == expected_bucket_name
+
+    def test_get_bucket_name_returns_none_for_invalid_stage(self):
+        assert get_bucket_name('xanadu', 'agreements') is None
+
+    def test_get_bucket_name_returns_none_for_invalid_bucket_category(self):
+        assert get_bucket_name('local', 'bananas') is None

--- a/tests/test_bulk_upload_documents.py
+++ b/tests/test_bulk_upload_documents.py
@@ -1,39 +1,12 @@
-import os
-import tempfile
-import shutil
-
 try:
     import __builtin__ as builtins
 except ImportError:
     import builtins
 
-from dmscripts.bulk_upload_documents import get_all_files_of_type, \
-    get_supplier_id_from_framework_file_path, upload_file, get_document_name_from_file_path, \
-    get_supplier_name_dict_from_tsv
+from dmscripts.bulk_upload_documents import get_supplier_id_from_framework_file_path, upload_file, \
+    get_document_name_from_file_path, get_supplier_name_dict_from_tsv
 import mock
 import pytest
-
-
-class TestGetAllFilesOfType:
-
-    def test_get_all_files_of_type_for_flat_folder(self):
-        temp_folder_path = tempfile.mkdtemp()
-        pdf1 = open(os.path.join(temp_folder_path, 'test1.pdf'), 'w+')
-        pdf2 = open(os.path.join(temp_folder_path, 'test2.pdf'), 'w+')
-        assert len(list(get_all_files_of_type(temp_folder_path, 'pdf'))) == 2
-        pdf1.close()
-        pdf2.close()
-        shutil.rmtree(temp_folder_path)
-
-    def test_get_all_files_of_type_for_nested_folder(self):
-        temp_folder_path = tempfile.mkdtemp()
-        pdf1 = open(os.path.join(temp_folder_path, 'test1.pdf'), 'w+')
-        nested_temp_folder_path = tempfile.mkdtemp(dir=temp_folder_path)
-        pdf2 = open(os.path.join(nested_temp_folder_path, 'test2.pdf'), 'w+')
-        assert len(list(get_all_files_of_type(temp_folder_path, 'pdf'))) == 2
-        pdf1.close()
-        pdf2.close()
-        shutil.rmtree(temp_folder_path)
 
 
 class TestGetSupplierIDFromFrameworkFilePath:

--- a/tests/test_bulk_upload_documents.py
+++ b/tests/test_bulk_upload_documents.py
@@ -7,33 +7,11 @@ try:
 except ImportError:
     import builtins
 
-from dmscripts.bulk_upload_documents import get_bucket_name, get_all_files_of_type, \
+from dmscripts.bulk_upload_documents import get_all_files_of_type, \
     get_supplier_id_from_framework_file_path, upload_file, get_document_name_from_file_path, \
     get_supplier_name_dict_from_tsv
 import mock
 import pytest
-
-
-class TestGetBucketName:
-
-    @pytest.mark.parametrize(
-        'stage, expected_bucket_name',
-        [
-            ('local', 'digitalmarketplace-dev-uploads'),
-            ('dev', 'digitalmarketplace-dev-uploads'),
-            ('preview', 'digitalmarketplace-agreements-preview-preview'),
-            ('staging', 'digitalmarketplace-agreements-staging-staging'),
-            ('production', 'digitalmarketplace-agreements-production-production'),
-        ]
-    )
-    def test_get_bucket_name_for_agreements_documents(self, stage, expected_bucket_name):
-        assert get_bucket_name(stage, 'agreements') == expected_bucket_name
-
-    def test_get_bucket_name_returns_none_for_invalid_stage(self):
-        assert get_bucket_name('xanadu', 'agreements') is None
-
-    def test_get_bucket_name_returns_none_for_invalid_bucket_category(self):
-        assert get_bucket_name('local', 'bananas') is None
 
 
 class TestGetAllFilesOfType:


### PR DESCRIPTION
No ticket - fix for broken export scripts.

- Moves `get_bucket_name` into a new helper module
- Adds `reports` to the list of approved bucket types