### PR TITLE
Get tokens from creds for performance platform stats script

### DIFF
--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -34,7 +34,12 @@ def get_auth_token(api, stage):
 
 
 def _get_nested_value(creds_json, env_var_path_list):
-    # Handle nested values in the credentials json
+    """
+    Handle nested values in the credentials json.
+    :param creds_json: e.g. {"performance_platform_bearer_tokens": {"g-cloud": "myToken"}}
+    :param env_var_path_list: e.g. ["performance_platform_bearer_tokens", "g-cloud"]
+    :return: e.g. "myToken"
+    """
     if len(env_var_path_list) > 1:
         return _get_nested_value(creds_json.get(env_var_path_list[0], {}), env_var_path_list[1:])
     return creds_json.get(env_var_path_list[0])

--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -5,6 +5,15 @@ import yaml
 DEV_ALIASES = ('dev', 'development', 'local')
 
 
+def _decrypt_yaml_file_with_sops(credentials_repo_path, credentials_filename):
+    creds_output = subprocess.check_output([
+        "{}/sops-wrapper".format(credentials_repo_path),
+        "-d",
+        "{}/{}".format(credentials_repo_path, credentials_filename)
+    ])
+    return yaml.safe_load(creds_output)
+
+
 def get_auth_token(api, stage):
     if stage.lower() in DEV_ALIASES:
         return 'myToken'
@@ -17,12 +26,43 @@ def get_auth_token(api, stage):
     if not auth_token:
         DM_CREDENTIALS_REPO = os.environ.get('DM_CREDENTIALS_REPO', '../digitalmarketplace-credentials')
         token_prefix = 'J' if subprocess.check_output(["whoami"]) == 'jenkins' else 'D'
-        creds = subprocess.check_output([
-            "{}/sops-wrapper".format(DM_CREDENTIALS_REPO),
-            "-d",
-            "{}/vars/{}.yaml".format(DM_CREDENTIALS_REPO, stage)
-        ])
-        auth_tokens = yaml.safe_load(creds)[api]['auth_tokens']
+        creds_json = _decrypt_yaml_file_with_sops(DM_CREDENTIALS_REPO, "vars/{}.yaml".format(stage))
+        auth_tokens = creds_json[api]['auth_tokens']
         auth_token = next(token for token in auth_tokens if token.startswith(token_prefix))
 
     return auth_token
+
+
+def _get_nested_value(creds_json, env_var_path_list):
+    # Handle nested values in the credentials json
+    if len(env_var_path_list) > 1:
+        return _get_nested_value(creds_json.get(env_var_path_list[0], {}), env_var_path_list[1:])
+    return creds_json.get(env_var_path_list[0])
+
+
+def get_jenkins_env_variable_from_credentials(env_var_dot_path, require_jenkins_user=True):
+    """
+    Scripts run on Jenkins can retrieve a variable from the Jenkins vars
+    env_var_dot_path: a dot separated string, e.g. "jenkins_env_variables.NOTIFY_API_TOKEN"
+    """
+    if require_jenkins_user and subprocess.check_output(["whoami"]) != 'jenkins':
+        raise ValueError("Only Jenkins user can retrieve this value")
+
+    DM_CREDENTIALS_REPO = os.environ.get('DM_CREDENTIALS_REPO', '../digitalmarketplace-credentials')
+    creds_json = _decrypt_yaml_file_with_sops(DM_CREDENTIALS_REPO, 'jenkins-vars/jenkins.yaml')
+
+    return _get_nested_value(creds_json, env_var_dot_path.split('.'))
+
+
+def get_jenkins_env_variable(jenkins_var_name):
+    # Check the local env first, otherwise decrypt from credentials
+    value = os.environ.get(jenkins_var_name)
+
+    if not value:
+        # Only allow Jenkins users to decrypt from credentials for now
+        value = get_jenkins_env_variable_from_credentials(
+            "jenkins_env_variables.{}".format(jenkins_var_name),
+            require_jenkins_user=True
+        )
+
+    return value

--- a/dmscripts/send_stats_to_performance_platform.py
+++ b/dmscripts/send_stats_to_performance_platform.py
@@ -140,8 +140,7 @@ def send_by_stage_stats(stats, timestamp_string, period, pp_bearer, pp_service, 
     } for stage in processed_stats]
 
     if dry_run:
-        print(f"Would send the following stage stats to Performance Platform API:")
-        print(data)
+        logger.info("Would send the following stage stats to Performance Platform API: {data}", extra={'data': data})
         return 200
     return send_data(data, PERFORMANCE_PLATFORM_URL_TEMPLATES[period]['stage'].format(pp_service=pp_service), pp_bearer)
 
@@ -160,8 +159,7 @@ def send_by_lot_stats(stats, timestamp_string, period, framework, pp_bearer, pp_
     } for lot in processed_stats]
 
     if dry_run:
-        print(f"Would send the following stage stats to Performance Platform API:")
-        print(data)
+        logger.info("Would send the following lot stats to Performance Platform API: {data}", extra={'data': data})
         return 200
 
     return send_data(data, PERFORMANCE_PLATFORM_URL_TEMPLATES[period]['lot'].format(pp_service=pp_service), pp_bearer)
@@ -179,7 +177,10 @@ def send_framework_stats(data_api_client, framework_slug, period, pp_bearer, pp_
         (now - timedelta(hours=1)).strftime(HOURLY_TIME_FORMAT)
     )
     if dry_run:
-        print(f"Gathering {framework_slug} stats for the last {period}")
+        logger.info(
+            "Gathering {framework_slug} stats for the last {period}",
+            extra={'framework_slug': framework_slug, 'period': period}
+        )
 
     res1 = send_by_stage_stats(stats, timestamp_string, period, pp_bearer, pp_service, dry_run)
     res2 = send_by_lot_stats(stats, timestamp_string, period, framework, pp_bearer, pp_service, dry_run)

--- a/scripts/framework-applications/send-stats-to-performance-platform.py
+++ b/scripts/framework-applications/send-stats-to-performance-platform.py
@@ -3,8 +3,8 @@
 Script to fetch application statistics for a framework from the API and push them to the Performance Platform.
 
 Usage:
-    scripts/send-stats-to-performance-platform.py <framework_slug> <stage> <pp_service> (--day | --hour)
-    [<pp_bearer>] [--dry-run]
+    scripts/framework-applications/send-stats-to-performance-platform.py <framework_slug> <stage> <pp_service>
+    (--day | --hour) [<pp_bearer>] [--dry-run]
 """
 import sys
 

--- a/scripts/send-stats-to-performance-platform.py
+++ b/scripts/send-stats-to-performance-platform.py
@@ -3,7 +3,8 @@
 Script to fetch application statistics for a framework from the API and push them to the Performance Platform.
 
 Usage:
-    scripts/send-stats-to-performance-platform.py <framework_slug> <stage> <pp_bearer> <pp_service> (--day | --hour)
+    scripts/send-stats-to-performance-platform.py <framework_slug> <stage> <pp_service> (--day | --hour)
+    [<pp_bearer>] [--dry-run]
 """
 import sys
 
@@ -12,7 +13,7 @@ from docopt import docopt
 from dmapiclient import DataAPIClient
 
 sys.path.insert(0, '.')
-from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.auth_helpers import get_auth_token, get_jenkins_env_variable_from_credentials
 from dmscripts.send_stats_to_performance_platform import send_framework_stats
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
@@ -23,10 +24,20 @@ if __name__ == "__main__":
     STAGE = arguments['<stage>']
     FRAMEWORK_SLUG = arguments['<framework_slug>']
     PERIOD = 'day' if arguments['--day'] else 'hour'
+    DRY_RUN = arguments['--dry-run']
+
+    if FRAMEWORK_SLUG.startswith('g-cloud'):
+        token_group = 'g-cloud'
+    else:
+        token_group = 'digital-outcomes-specialists'  # That's how the token is stored :(
 
     api_url = get_api_endpoint_from_stage(STAGE)
     client = DataAPIClient(api_url, get_auth_token('api', STAGE))
+    # Use the token if supplied, otherwise look in credentials
+    pp_auth_token = arguments['<pp_bearer>'] or get_jenkins_env_variable_from_credentials(
+        'performance_platform_bearer_tokens.{}'.format(token_group)
+    )
 
-    ok = send_framework_stats(client, FRAMEWORK_SLUG, PERIOD, arguments['<pp_bearer>'], arguments['<pp_service>'])
+    ok = send_framework_stats(client, FRAMEWORK_SLUG, PERIOD, pp_auth_token, arguments['<pp_service>'], dry_run=DRY_RUN)
     if not ok:
         sys.exit(1)

--- a/tests/helpers/test_auth_helpers.py
+++ b/tests/helpers/test_auth_helpers.py
@@ -1,0 +1,79 @@
+import os
+import mock
+import pytest
+
+from dmscripts.helpers.auth_helpers import get_jenkins_env_variable_from_credentials, get_jenkins_env_variable
+
+
+@mock.patch.dict(os.environ, {'DM_CREDENTIALS_REPO': '/path/to/credentials'})
+@mock.patch('dmscripts.helpers.auth_helpers._decrypt_yaml_file_with_sops')
+class TestGetJenkinsEnvVariablesFromCredentials:
+
+    @pytest.mark.parametrize(
+        'decrypted_json, var_path', [
+            ({"foo": {"bar": "hurray"}}, "foo.bar"),
+            ({"foo": "hurray"}, "foo"),
+        ]
+    )
+    def test_get_jenkins_env_variable_from_credentials_decrypts_nested_yaml(
+        self, decrypt_yaml_file_with_sops, decrypted_json, var_path
+    ):
+        decrypt_yaml_file_with_sops.return_value = decrypted_json
+
+        assert get_jenkins_env_variable_from_credentials(var_path, require_jenkins_user=False) == "hurray"
+        assert decrypt_yaml_file_with_sops.call_args_list == [
+            mock.call("/path/to/credentials", "jenkins-vars/jenkins.yaml")
+        ]
+
+    @pytest.mark.parametrize(
+        'decrypted_json', [
+            {"foo": {"boo": "hurray"}},
+            {"bar": "foo"},
+            {},
+        ]
+    )
+    def test_get_jenkins_env_variable_from_credentials_handles_nonexistent_path(
+        self, decrypt_yaml_file_with_sops, decrypted_json
+    ):
+        decrypt_yaml_file_with_sops.return_value = decrypted_json
+
+        assert get_jenkins_env_variable_from_credentials('foo.bar', require_jenkins_user=False) is None
+        assert decrypt_yaml_file_with_sops.call_args_list == [
+            mock.call("/path/to/credentials", "jenkins-vars/jenkins.yaml")
+        ]
+
+    @mock.patch('subprocess.check_output')
+    def test_get_jenkins_env_variable_from_credentials_checks_for_jenkins_user(
+        self, check_whoami_output, decrypt_yaml_file_with_sops
+    ):
+        decrypt_yaml_file_with_sops.return_value = {"foo": {"bar": "hurray"}}
+        check_whoami_output.return_value = 'jenkins'
+
+        get_jenkins_env_variable_from_credentials('foo.bar', require_jenkins_user=True)
+        assert decrypt_yaml_file_with_sops.call_args_list == [
+            mock.call("/path/to/credentials", "jenkins-vars/jenkins.yaml")
+        ]
+
+    @mock.patch('subprocess.check_output')
+    def test_get_jenkins_env_variable_from_credentials_raises_if_not_jenkins_user(self, check_whoami_output, _):
+        check_whoami_output.return_value = 'some other user'
+
+        with pytest.raises(ValueError) as excinfo:
+            get_jenkins_env_variable_from_credentials('foo.bar', require_jenkins_user=True)
+        assert str(excinfo.value) == "Only Jenkins user can retrieve this value"
+
+
+@mock.patch('dmscripts.helpers.auth_helpers.get_jenkins_env_variable_from_credentials')
+class TestGetJenkinsEnvVariables:
+
+    @mock.patch.dict(os.environ, {'MY_VAR': "I was hiding in the env all along"})
+    def test_get_jenkins_env_variable_looks_in_os_environ_first(self, get_var_from_creds):
+        assert get_jenkins_env_variable("MY_VAR") == "I was hiding in the env all along"
+        assert get_var_from_creds.called is False
+
+    @mock.patch.dict(os.environ, {'NOT_MY_VAR': "Nothing to see here mate"})
+    def test_get_jenkins_env_variable_uses_creds_file_if_not_in_os_environ(self, get_var_from_creds):
+        assert get_jenkins_env_variable("MY_VAR") == get_var_from_creds.return_value
+        assert get_var_from_creds.call_args_list == [
+            mock.call('jenkins_env_variables.MY_VAR', require_jenkins_user=True)
+        ]

--- a/tests/test_send_stats_to_performance_platform.py
+++ b/tests/test_send_stats_to_performance_platform.py
@@ -157,7 +157,7 @@ def test_services_by_lot():
 
 @mock.patch('dmscripts.send_stats_to_performance_platform.send_data')
 def test_send_by_stage_stats_per_day_calls_send_data_with_correct_data(send_data):
-    send_by_stage_stats(STATS_JSON, '2017-03-29T00:00:00+00:00', 'day', 'pp-bearer-token', 'gcloud')
+    send_by_stage_stats(STATS_JSON, '2017-03-29T00:00:00+00:00', 'day', 'pp-bearer-token', 'gcloud', dry_run=False)
     expected_sent_data_items = [
         {'count': 184,
          '_timestamp': '2017-03-29T00:00:00+00:00',
@@ -212,7 +212,7 @@ def test_send_by_stage_stats_per_day_calls_send_data_with_correct_data(send_data
 
 @mock.patch('dmscripts.send_stats_to_performance_platform.send_data')
 def test_send_by_stage_stats_per_hour_calls_send_data_with_correct_data(send_data):
-    send_by_stage_stats(STATS_JSON, '2017-03-29T12:00:00+00:00', 'hour', 'pp-bearer-token', 'hcloud')
+    send_by_stage_stats(STATS_JSON, '2017-03-29T12:00:00+00:00', 'hour', 'pp-bearer-token', 'hcloud', dry_run=False)
     expected_sent_data_items = [
         {'count': 184,
          '_timestamp': '2017-03-29T12:00:00+00:00',
@@ -274,6 +274,7 @@ def test_send_by_lot_stats_per_day_calls_send_data_with_correct_data(send_data):
         FRAMEWORK_JSON['frameworks'],
         'pp-bearer-token',
         'gcloud',
+        dry_run=False
     )
     expected_sent_data_items = [
         {'count': 84,
@@ -328,6 +329,7 @@ def test_send_by_lot_stats_per_hour_calls_send_data_with_correct_data(send_data)
         FRAMEWORK_JSON['frameworks'],
         'pp-bearer-token',
         'gcloud',
+        dry_run=False
     )
     expected_sent_data_items = [
         {'count': 84,


### PR DESCRIPTION
Trello: https://trello.com/c/TZoo1F5B/480-performance-platform-jenkins-job-leaks-token

The token is currently retrieved from credentials when the Jenkins job is generated from the template and output in the Jenkins console (and the config!!). 

Rather than stick yet another var into the main Jenkins config (in this case there would be one for each framework!) we can get the script to decrypt it from either the Jenkins environment (if it's there) or the credentials repo, like we do for the API tokens.

For example:

```
docker run -e DM_DATA_API_TOKEN_PREVIEW digitalmarketplace/scripts scripts/my-amazing-script.py preview --notify-api-key=ABC1234
```

Can become (with a small tweak to the script):

```
docker run -e DM_DATA_API_TOKEN_PREVIEW -e NOTIFY_API_KEY digitalmarketplace/scripts scripts/my-amazing-script.py preview
```

I've also added a `--dry-run` flag to the performance stats script, so we can test it without messing up our G11 stats.

The Jenkins job needs updating to remove the token from the script call: https://github.com/alphagov/digitalmarketplace-jenkins/pull/215