### PR TITLE
notify_suppliers_of_brief_withdrawal.py: use get_email_addresses from helpers to process emails

### DIFF
--- a/dmscripts/notify_suppliers_of_brief_withdrawal.py
+++ b/dmscripts/notify_suppliers_of_brief_withdrawal.py
@@ -1,11 +1,16 @@
-from dmutils.email.helpers import hash_string
+from itertools import chain
+
+from dmutils.email.helpers import get_email_addresses, hash_string
 
 from dmutils.env_helpers import get_web_url_from_stage
 
 
 def get_brief_response_emails(data_api_client, brief_id):
     responses = data_api_client.find_brief_responses_iter(brief_id=brief_id, status="submitted")
-    return [response["respondToEmailAddress"] for response in responses]
+    return list(chain.from_iterable(
+        get_email_addresses(response["respondToEmailAddress"])
+        for response in responses
+    ))
 
 
 def create_context_for_brief(stage, brief):

--- a/tests/test_notify_suppliers_of_brief_withdrawal.py
+++ b/tests/test_notify_suppliers_of_brief_withdrawal.py
@@ -22,7 +22,8 @@ WITHDRAWN_BRIEFS = (
 
 BRIEF_RESPONSES = (
     {"id": 4321, "respondToEmailAddress": "email@me.now"},
-    {"id": 4389, "respondToEmailAddress": "email@them.now"}
+    {"id": 4389, "respondToEmailAddress": "email@them.now"},
+    {"id": 4379, "respondToEmailAddress": " email@both.this, and@that.please"},
 )
 
 
@@ -35,7 +36,12 @@ EXPECTED_BRIEF_CONTEXT = {
 @mock.patch('dmapiclient.DataAPIClient', autospec=True)
 def test_get_brief_response_emails(data_api_client):
     data_api_client.find_brief_responses_iter.return_value = BRIEF_RESPONSES
-    assert tested_script.get_brief_response_emails(data_api_client, {"id": 1234}) == ["email@me.now", "email@them.now"]
+    assert tested_script.get_brief_response_emails(data_api_client, {"id": 1234}) == [
+        "email@me.now",
+        "email@them.now",
+        "email@both.this",
+        "and@that.please",
+    ]
 
 
 def test_create_context_for_brief():
@@ -66,7 +72,7 @@ def test_main_calls_correct_script_methods(
     assert create_context_for_brief.call_args_list == [mock.call("preview", WITHDRAWN_BRIEFS[0])]
     assert notify_client.send_email.call_args_list == [
         mock.call("email@me.now", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False),
-        mock.call("email@them.now", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False)
+        mock.call("email@them.now", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False),
     ]
 
 
@@ -87,7 +93,9 @@ def test_main_calls_correct_external_client_methods(data_api_client, notify_clie
     assert data_api_client.find_briefs_iter.call_args_list == expected_call_args
     assert notify_client.send_email.call_args_list == [
         mock.call("email@me.now", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False),
-        mock.call("email@them.now", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False)
+        mock.call("email@them.now", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False),
+        mock.call("email@both.this", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False),
+        mock.call("and@that.please", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False),
     ]
 
 


### PR DESCRIPTION
To sort out https://trello.com/c/rNsjCmNh

This is a minimal fix allow support of splitting on multiple-address separators.

Going further to give this script better ergonomics I think we should consider combining it with `notify_suppliers_of_awarded_briefs.py` as elaborated on in https://trello.com/c/wDzrqj9n