### PR TITLE
Tidying framework application scripts

### DIFF
--- a/scripts/framework-applications/generate-framework-master-csv.py
+++ b/scripts/framework-applications/generate-framework-master-csv.py
@@ -15,10 +15,12 @@ Fields included:
 * The number of services submitted and left in draft per lot
 
 Usage:
-    scripts/generate-framework-master-csv.py <framework_slug> <stage> <auth_token> <output-dir> [-e <exclude_suppliers>]
+    scripts/framework-applications/generate-framework-master-csv.py <framework_slug> <stage> <auth_token> <output-dir>
+        [-e <exclude_suppliers>]
 
 Example:
-    scripts/generate-framework-master-csv.py g-cloud-11 preview myToken path/to/myfolder -e 123,456,789
+    scripts/framework-applications/generate-framework-master-csv.py g-cloud-11 preview myToken path/to/myfolder
+        -e 123,456,789
 """
 import os
 import sys

--- a/scripts/framework-applications/mark-definite-framework-results.py
+++ b/scripts/framework-applications/mark-definite-framework-results.py
@@ -22,7 +22,7 @@ not to fail this time around (or if no draft_service_schema is supplied). You ma
 suppliers. This can be done with the `supplier-id-file` option. It should be set to the path to a file containing the
 supplier ids to check, one per line.
 
-Usage: mark-definite-framework-results.py [options] <stage> <framework_slug>
+Usage: scripts/framework-applications/mark-definite-framework-results.py [options] <stage> <framework_slug>
             <declaration_definite_pass_schema_path> [<draft_service_schema_path>]
 
 --updated-by=<user_string>        Specify updated_by string to use in API requests

--- a/scripts/framework-applications/notify-successful-suppliers-for-framework.py
+++ b/scripts/framework-applications/notify-successful-suppliers-for-framework.py
@@ -3,11 +3,11 @@
 Uses the Notify API to inform suppliers of success result.
 
 Usage:
-    scripts/notify-successful-suppliers-for-framework.py <stage> <framework_slug>
+    scripts/framework-applications/notify-successful-suppliers-for-framework.py <stage> <framework_slug>
         <govuk_notify_api_key> <govuk_notify_template_id>
 
 Example:
-    scripts/notify-successful-suppliers-for-framework.py preview g-cloud-8
+    scripts/framework-applications/notify-successful-suppliers-for-framework.py preview g-cloud-11
         my-awesome-key govuk_notify_template_id
 
 Options:

--- a/scripts/framework-applications/update-framework-results.py
+++ b/scripts/framework-applications/update-framework-results.py
@@ -5,10 +5,11 @@
 Sets supplier "on framework" status for all supplier IDs read from file. Each file line should contain one supplier ID.
 
 Usage:
-    scripts/update-framework-results.py <framework> <stage> (--pass | --fail) <ids_file>
+    scripts/framework-applications/update-framework-results.py <framework> <stage> (--pass | --fail) <ids_file>
 
 Example:
-    python scripts/update-framework-results.py g-cloud-8 preview --pass --api-token=myToken ./g8-suppliers.txt
+    scripts/framework-applications/update-framework-results.py g-cloud-11 preview --pass --api-token=myToken
+        ../g11-supplier-ids.txt
 
 """
 


### PR DESCRIPTION
I've checked through all these framework scripts (ready for G11) and moved them to the `framework-applications` folder.

There are a couple more framework scripts that I haven't moved yet, because they are linked to a Jenkins job (and therefore should probably go in a separate PR).