### PR TITLE
Align framework export filenames with CCS naming conventions

### DIFF
--- a/dmscripts/export_framework_results_reasons.py
+++ b/dmscripts/export_framework_results_reasons.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
+from datetime import datetime
 from itertools import chain
 import jsonschema
 import os
@@ -113,6 +114,10 @@ def contact_details(record):
 
 class SuccessfulHandler(object):
     NAME = 'successful'
+    CCS_FILENAME_FORMAT = '{}-automatically-successful-suppliers-{}'
+
+    def __init__(self, framework_slug, now):
+        self.filename = self.CCS_FILENAME_FORMAT.format(framework_slug, now)
 
     def matches(self, record):
         return record['onFramework'] is True
@@ -128,6 +133,10 @@ class SuccessfulHandler(object):
 
 class FailedHandler(object):
     NAME = 'failed'
+    CCS_FILENAME_FORMAT = '{}-suppliers-who-failed-{}'
+
+    def __init__(self, framework_slug, now):
+        self.filename = self.CCS_FILENAME_FORMAT.format(framework_slug, now)
 
     def matches(self, record):
         return record['onFramework'] is False
@@ -158,6 +167,10 @@ class FailedHandler(object):
 
 class DiscretionaryHandler(object):
     NAME = 'discretionary'
+    CCS_FILENAME_FORMAT = '{}-suppliers-who-declared-discretionary-data-{}'
+
+    def __init__(self, framework_slug, now):
+        self.filename = self.CCS_FILENAME_FORMAT.format(framework_slug, now)
 
     def matches(self, record):
         return record['onFramework'] is None
@@ -207,7 +220,12 @@ def export_suppliers(
         map_impl=map_impl,
     )
 
-    handlers = [SuccessfulHandler(), FailedHandler(), DiscretionaryHandler()]
+    now = datetime.utcnow().strftime("%Y-%m-%d-%H-%M")
+    handlers = [
+        SuccessfulHandler(framework_slug, now),
+        FailedHandler(framework_slug, now),
+        DiscretionaryHandler(framework_slug, now)
+    ]
 
     with MultiCSVWriter(output_dir, handlers) as writer:
         for i, record in enumerate(records):

--- a/dmscripts/helpers/csv_helpers.py
+++ b/dmscripts/helpers/csv_helpers.py
@@ -73,7 +73,7 @@ class MultiCSVWriter(object):
         return self._csv_writers[handler.NAME]
 
     def csv_path(self, handler):
-        return os.path.join(self.output_dir, handler.NAME + '.csv')
+        return os.path.join(self.output_dir, handler.filename + '.csv')
 
     def __enter__(self):
         for handler in self.handlers:

--- a/scripts/framework-applications/export-framework-applicant-details.py
+++ b/scripts/framework-applications/export-framework-applicant-details.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))
     now = datetime.datetime.now()
 
-    filename = FRAMEWORK + "-applicant_details-" + now.strftime("%Y-%m-%d_%H.%M-") + STAGE + ".csv"
+    filename = FRAMEWORK + "-supplier-about-you-data-" + now.strftime("%Y-%m-%d_%H.%M-") + STAGE + ".csv"
     filepath = OUTPUT_DIR + os.sep + filename
 
     # Create output directory if it doesn't already exist

--- a/scripts/framework-applications/generate-framework-master-csv.py
+++ b/scripts/framework-applications/generate-framework-master-csv.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     output_dir = arguments['<output-dir>']
     stage = arguments['<stage>']
     framework_slug = arguments['<framework_slug>']
-    filename = "{}-application-export-{}-{}.csv".format(
+    filename = "{}-how-application-looked-at-close-{}-{}.csv".format(
         framework_slug,
         stage,
         datetime.utcnow().strftime("%Y-%m-%d_%H.%M-")


### PR DESCRIPTION
Trello: https://trello.com/c/6YtiqGD0/522-framework-data-export-script-filenames-dont-match-the-runbook

Stressed-out devs have enough to do after closing a framework, without having to dig through the [runbook](https://docs.google.com/document/d/13wzZB2M16n4eVrn8zoaL90FkaYKksKJnUSCtUlIgPQE/edit) and rename the data export files to the format that CCS is expecting.

I've kept the datestamps (and added them to the pass/fail report) as they might still be useful.