### PR TITLE
Add script for validating AWS CloudTrail logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,14 @@ RUN wget --quiet -O /usr/local/bin/sops https://github.com/mozilla/sops/releases
     && echo 'fec5b5b5bbae922a829a6277f6d66a061d990c04132da3c82db32ccc309a22e7  /usr/local/bin/sops' | sha256sum -c - \
     && chmod 0755 /usr/local/bin/sops
 
+RUN wget --quiet -O /usr/local/bin/docopts https://github.com/docopt/docopts/releases/download/v0.6.3-alpha1/docopts \
+    && echo '45812802bef1d91d5a431c11415839d4609aa2d82cde627fad844d24e7e265e7  /usr/local/bin/docopts' | sha256sum -c - \
+    && chmod 0755 /usr/local/bin/docopts
+
+RUN wget --quiet -O /usr/local/bin/docopts.sh https://raw.githubusercontent.com/docopt/docopts/1156d73a85d5ae4810b80908dbaa46ad9222dabd/docopts.sh \
+    && echo 'd117d3290def71d6a7fdc5b67efddfc3a9299f146bb4f98f96e322222957d1ce /usr/local/bin/docopts.sh' | sha256sum -c - \
+    && chmod 0755 /usr/local/bin/docopts.sh
+
 ENV APP_DIR /app
 WORKDIR ${APP_DIR}
 

--- a/functional-tests/validate-cloudtrail-logs/config-file.fixture
+++ b/functional-tests/validate-cloudtrail-logs/config-file.fixture
@@ -1,0 +1,4 @@
+- account: test
+  profile:
+    name: test-cloudtrail-validate-logs
+  trail_arn: arn:aws:cloudtrail:::trail/test-cloudtrail

--- a/functional-tests/validate-cloudtrail-logs/config-file.t
+++ b/functional-tests/validate-cloudtrail-logs/config-file.t
@@ -1,0 +1,9 @@
+
+  $ . $TESTDIR/setup.sh
+
+validate-cloudtrail-logs expects a config file that is normally found in the credentials repo.
+You can override the config file path, but it will complain if it can't find it.
+
+  $ ./scripts/validate-cloudtrail-logs.sh --config=not-a-file $AWS_ACCOUNT now
+  error: config file 'not-a-file' does not exist
+  [1]

--- a/functional-tests/validate-cloudtrail-logs/dates.t
+++ b/functional-tests/validate-cloudtrail-logs/dates.t
@@ -1,0 +1,26 @@
+
+  $ . $TESTDIR/setup.sh
+  $ [ -n "$FAKETIME" ] || FAKETIME="2019-05-06T12:13:54Z"
+  $ command -v faketime >/dev/null 2>&1 || { >&2 echo "This test requires faketime but it is not installed. Skipping." ; exit 80; }
+  $ alias validate-cloudtrail-logs="faketime '$FAKETIME' bash ./scripts/validate-cloudtrail-logs.sh"
+
+validate-cloudtrail-logs requires at least one date, the time for the earliest log to validate. By default it will look at any logs up to the time of invocation.
+
+  $ validate-cloudtrail-logs -n $AWS_ACCOUNT '2019-06-07T09:00Z'
+  AWS_PROFILE=*-cloudtrail-validate-logs aws cloudtrail validate-logs --trail-arn arn:aws:cloudtrail:*:*:trail/*-cloudtrail --start-time 2019-06-07T09:00+00:00 --end-time 2019-05-06T12:13+00:00 (glob)
+
+You can also specify an end date
+
+  $ validate-cloudtrail-logs -n $AWS_ACCOUNT '2019-05-07T09:00Z' '2019-06-07T09:00Z'
+  AWS_PROFILE=*-cloudtrail-validate-logs aws cloudtrail validate-logs --trail-arn arn:aws:cloudtrail:*:*:trail/*-cloudtrail --start-time 2019-05-07T09:00+00:00 --end-time 2019-06-07T09:00+00:00 (glob)
+
+Either date can be described in a human readable way
+
+  $ validate-cloudtrail-logs -n $AWS_ACCOUNT '10am 1 month ago' '10am today'
+  AWS_PROFILE=*-cloudtrail-validate-logs aws cloudtrail validate-logs --trail-arn arn:aws:cloudtrail:*:*:trail/*-cloudtrail --start-time 2019-04-06T10:00+00:00 --end-time 2019-05-06T10:00+00:00 (glob)
+
+If the date can't be parsed the script will exit with an error
+
+  $ validate-cloudtrail-logs -n $AWS_ACCOUNT 'last thermidor' '10am today'
+  date: invalid date 'last thermidor'
+  [1]

--- a/functional-tests/validate-cloudtrail-logs/output.t
+++ b/functional-tests/validate-cloudtrail-logs/output.t
@@ -1,0 +1,48 @@
+
+  $ . $TESTDIR/setup.sh
+
+  $ # set up testing stubs for the 'aws cloudtrail validate-logs' command
+  $ ln $(which aws) $TMPDIR/stubs/aws-original
+  $ touch $TMPDIR/stubs/aws-stub
+  $ cat > $TMPDIR/stubs/aws << 'EOF'
+  > #!/bin/sh
+  > if [ "$1 $2" = "cloudtrail validate-logs" ]; then
+  >   exec $TMPDIR/stubs/aws-stub
+  > else
+  >   exec aws-original $@
+  > fi
+  > EOF
+  $ chmod +x $TMPDIR/stubs/aws $TMPDIR/stubs/aws-stub $TMPDIR/stubs/aws-original
+
+validate-cloudtrail-logs echoes the output of the AWS cli.
+
+  $ cat > $TMPDIR/stubs/aws-stub << EOF
+  > #!/bin/sh
+  > echo 'test stderr output' >&2
+  > echo 'test stdout output'
+  > EOF
+  $ ./scripts/validate-cloudtrail-logs.sh $AWS_ACCOUNT now
+  AWS_PROFILE=* aws cloudtrail validate-logs * (glob)
+  test stderr output
+  test stdout output
+
+validate-cloudtrail-logs exits with non-zero status if AWS cli reports invalid logs.
+
+  $ cat > $TMPDIR/stubs/aws-stub << EOF
+  > #!/bin/sh
+  > echo 'INVALID'
+  > EOF
+  $ ./scripts/validate-cloudtrail-logs.sh $AWS_ACCOUNT now
+  AWS_PROFILE=* aws cloudtrail validate-logs * (glob)
+  INVALID
+  [1]
+
+validate-cloudtrail-logs exits with non-zero status if AWS cli exits with non-zero status.
+
+  $ cat > $TMPDIR/stubs/aws-stub << EOF
+  > #!/bin/sh
+  > exit 2
+  > EOF
+  $ ./scripts/validate-cloudtrail-logs.sh $AWS_ACCOUNT now
+  AWS_PROFILE=* aws cloudtrail validate-logs * (glob)
+  [2]

--- a/functional-tests/validate-cloudtrail-logs/setup.sh
+++ b/functional-tests/validate-cloudtrail-logs/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+[ -n "$TESTDIR" ] && cd $TESTDIR/../..
+
+[ -d /usr/local/opt/coreutils/libexec/gnubin ] && PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+
+[ -n "$AWS_ACCOUNT" ] || AWS_ACCOUNT=test
+
+# Create folder for command stubs
+mkdir -p $TMPDIR/stubs
+export PATH="$TMPDIR/stubs:$PATH"
+
+# Stub out aws-auth
+cat > $TMPDIR/stubs/aws-auth << 'EOF'
+exec $@
+EOF
+chmod +x $TMPDIR/stubs/aws-auth
+
+# Stub out sops
+cat > $TMPDIR/stubs/sops << EOF
+#!/bin/sh
+cat $TESTDIR/config-file.fixture
+EOF
+chmod +x $TMPDIR/stubs/sops

--- a/functional-tests/validate-cloudtrail-logs/usage.t
+++ b/functional-tests/validate-cloudtrail-logs/usage.t
@@ -1,0 +1,9 @@
+
+  $ . $TESTDIR/setup.sh
+
+Usage:
+
+  $ ./scripts/validate-cloudtrail-logs.sh
+  error: 
+  Usage: validate-cloudtrail-logs.sh [options] ACCOUNT START_FROM [UP_TO]
+  [64]

--- a/scripts/validate-cloudtrail-logs.sh
+++ b/scripts/validate-cloudtrail-logs.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Usage: validate-cloudtrail-logs.sh [options] ACCOUNT START_FROM [UP_TO]
+#
+# Examples:
+#   validate-cloudtrail-logs.sh main '1 hour ago'
+#   validate-cloudtrail-logs.sh production '2019-04-11T13:13'
+#   validate-cloudtrail-logs.sh --verbose development '3 days ago' '2 days ago'
+#
+# Arguments:
+#   ACCOUNT     The AWS account to validate logs for (e.g. main, development, backups).
+#   START_FROM  A date/time to start validating logs from, can be a date relative to now.
+#   UP_TO       A date/time to start validating logs from, can be a date relative to now. Defaults to now.
+#
+# Options:
+#   --config=FILE  Path to file containing details of trails (default: $DM_CREDENTIALS_REPO/jenkins-vars/cloudtrail.yaml).
+#   -n, --dry-run  Output information on command but do not run.
+#   -q, --quiet    Suppress output of log validation information.
+#   -v, --verbose  Print detailed script debug statements.
+#   -h, --help     Show this message.
+
+set -eo pipefail
+
+source docopts.sh
+
+help=$(docopt_get_help_string "$0")
+eval "$(docopts -h "$help" : "$@")"
+
+VERBOSE="${VERBOSE:-$verbose}"
+$VERBOSE && set -x
+
+[ -n "$config" ] && CONFIG_FILE="$config" || CONFIG_FILE="$DM_CREDENTIALS_REPO/jenkins-vars/cloudtrail.yaml"
+[ -f "$CONFIG_FILE" ] || { echo "error: config file '$CONFIG_FILE' does not exist"; exit 1; }
+
+[ -n "$UP_TO" ] || UP_TO="now"
+START_TIME="$(date --date="$START_FROM" --utc --iso-8601=minutes)" || exit 1
+END_TIME="$(date --date="$UP_TO" --utc --iso-8601=minutes)" || exit 1
+
+export ACCOUNT
+account="$("$DM_CREDENTIALS_REPO"/sops-wrapper -d --extract '["cloudtrail_validate_logs_roles"]' "$CONFIG_FILE" | yq 'map(select(.account == env.ACCOUNT))[0]')"
+
+AWS_PROFILE="$(echo "$account" | yq -r '.profile.name')"
+
+COMMAND="aws cloudtrail validate-logs"
+
+COMMAND+=" --trail-arn $(echo "$account" | yq -r '.trail_arn')"
+COMMAND+=" --start-time $START_TIME"
+[ -n "$END_TIME" ] && COMMAND+=" --end-time $END_TIME"
+
+if ! $QUIET
+then
+  COMMAND+=" --verbose"
+fi
+
+export AWS_PROFILE
+echo AWS_PROFILE="$AWS_PROFILE" $COMMAND
+$dry_run && exit
+
+# run command, echo output to terminal, exit with non-zero status if any logs are invalid
+$COMMAND | tee /dev/stderr | (! grep -q INVALID)


### PR DESCRIPTION
Part of work to add a CloudTrail log validating job to Jenkins (ticket [here](https://trello.com/c/Ijzuk0qY/508-log-file-validation-job)). The script requires the CloudTrail ARNS to be added to the credentials repo alphagov/digitalmarketplace-credentials#221.

Rather than putting the script straight in a job I thought I would make separate PR for it here, so I can add tests and watnots.