### PR TITLE
Refactor notify-successful-suppliers-for-framework script

### DIFF
--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -68,14 +68,16 @@ class SuccessfulSupplierContextForNotify(SupplierFrameworkData):
 
     STATUS_MAP = {'submitted': 'Successful', 'not-submitted': 'No application', 'failed': 'Unsuccessful'}
 
-    def __init__(self, client, target_framework_slug):
+    def __init__(self, client, target_framework_slug, *, supplier_ids=None):
         """Get the target framework to operate on and list the lots.
 
         :param client: Instantiated api client
         :param target_framework_slug: Framework to fetch data for
+        :param supplier_ids: List of supplier IDs to filter data by
         """
         self.date_today = date.today().strftime(DISPLAY_DATE_FORMAT)
-        super(SuccessfulSupplierContextForNotify, self).__init__(client, target_framework_slug)
+        super(SuccessfulSupplierContextForNotify, self).__init__(
+            client, target_framework_slug, supplier_ids=supplier_ids)
 
         self.framework = client.get_framework(self.target_framework_slug)['frameworks']
         self.framework_lots = [i['name'] for i in self.framework['lots']]

--- a/functional-tests/notify-successful-suppliers-for-framework/setup.sh
+++ b/functional-tests/notify-successful-suppliers-for-framework/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+[ -n "$TESTDIR" ] && . "$TESTDIR"/../setup.sh
+
+# Generally tests will need an API key and a template for GOV.UK Notify
+[ -n "$NOTIFY_API_KEY" ] || NOTIFY_API_KEY="this-is-not-a-real-key-but-notify-api-keys-have-to-be-74-characters-long"
+[ -n "$NOTIFY_TEMPLATE_ID" ] || NOTIFY_TEMPLATE_ID="fake-template-id"

--- a/functional-tests/notify-successful-suppliers-for-framework/suppliers.t
+++ b/functional-tests/notify-successful-suppliers-for-framework/suppliers.t
@@ -1,0 +1,43 @@
+
+  $ . $TESTDIR/setup.sh
+
+Supplier ID from command line
+
+  $ ./scripts/framework-applications/notify-successful-suppliers-for-framework.py --dry-run $DM_ENVIRONMENT g-cloud-10 $NOTIFY_API_KEY $NOTIFY_TEMPLATE_ID --supplier-id=93271
+  * dmapiclient.base INFO API GET request on */frameworks/g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */frameworks/g-cloud-10/suppliers?with_declarations=False finished in * (glob)
+  * dmapiclient.base INFO API GET request on */users/export/g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */draft-services?supplier_id=93271&framework=g-cloud-10 finished in * (glob)
+  * script INFO [Dry Run] Sending email to supplier user '*' (glob)
+
+
+Multiple supplier IDs from command line
+
+  $ ./scripts/framework-applications/notify-successful-suppliers-for-framework.py --dry-run $DM_ENVIRONMENT g-cloud-10 $NOTIFY_API_KEY $NOTIFY_TEMPLATE_ID --supplier-id=92254 --supplier-id=92778
+  * dmapiclient.base INFO API GET request on */frameworks/g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */frameworks/g-cloud-10/suppliers?with_declarations=False finished in * (glob)
+  * dmapiclient.base INFO API GET request on */users/export/g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */draft-services?supplier_id=92254&framework=g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */draft-services?supplier_id=92778&framework=g-cloud-10 finished in * (glob)
+
+  $ ./scripts/framework-applications/notify-successful-suppliers-for-framework.py --dry-run $DM_ENVIRONMENT g-cloud-10 $NOTIFY_API_KEY $NOTIFY_TEMPLATE_ID --supplier-id=92254,92778
+  * dmapiclient.base INFO API GET request on */frameworks/g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */frameworks/g-cloud-10/suppliers?with_declarations=False finished in * (glob)
+  * dmapiclient.base INFO API GET request on */users/export/g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */draft-services?supplier_id=92254&framework=g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */draft-services?supplier_id=92778&framework=g-cloud-10 finished in * (glob)
+
+
+Supplier IDs from file
+
+  $ cat > $TMPDIR/suppliers << EOF
+  > 92254
+  > 93271
+  > EOF
+  $ ./scripts/framework-applications/notify-successful-suppliers-for-framework.py --dry-run $DM_ENVIRONMENT g-cloud-10 $NOTIFY_API_KEY $NOTIFY_TEMPLATE_ID --supplier-ids-from=$TMPDIR/suppliers
+  * dmapiclient.base INFO API GET request on */frameworks/g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */frameworks/g-cloud-10/suppliers?with_declarations=False finished in * (glob)
+  * dmapiclient.base INFO API GET request on */users/export/g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */draft-services?supplier_id=92254&framework=g-cloud-10 finished in * (glob)
+  * dmapiclient.base INFO API GET request on */draft-services?supplier_id=93271&framework=g-cloud-10 finished in * (glob)
+  * script INFO [Dry Run] Sending email to supplier user '*' (glob)

--- a/functional-tests/notify-successful-suppliers-for-framework/usage.t
+++ b/functional-tests/notify-successful-suppliers-for-framework/usage.t
@@ -1,0 +1,48 @@
+
+  $ cd $TESTDIR/../..
+
+Usage:
+
+  $ ./scripts/framework-applications/notify-successful-suppliers-for-framework.py
+  Usage:
+      scripts/framework-applications/notify-successful-suppliers-for-framework.py [options]
+           [--supplier-id=<id> ... | --supplier-ids-from=<file>]
+           <stage> <framework> <notify_api_key> <notify_template_id>
+  [1]
+
+
+Invalid arguments:
+
+  $ ./scripts/framework-applications/notify-successful-suppliers-for-framework.py --do-the-thing garbage
+  Usage:
+      scripts/framework-applications/notify-successful-suppliers-for-framework.py [options]
+           [--supplier-id=<id> ... | --supplier-ids-from=<file>]
+           <stage> <framework> <notify_api_key> <notify_template_id>
+  [1]
+
+Detailed help:
+
+  $ ./scripts/framework-applications/notify-successful-suppliers-for-framework.py -h
+  Email suppliers who have at least one successful lot entry on the given framework.
+  
+  Uses the Notify API to inform suppliers of success result. This script *should not* resend emails.
+  
+  Usage:
+      scripts/framework-applications/notify-successful-suppliers-for-framework.py [options]
+           [--supplier-id=<id> ... | --supplier-ids-from=<file>]
+           <stage> <framework> <notify_api_key> <notify_template_id>
+  
+  Example:
+      scripts/framework-applications/notify-successful-suppliers-for-framework.py preview g-cloud-11 api-key template-id
+  
+  Options:
+      <stage>                     Environment to run script against.
+      <framework>                 Slug of framework to run script against.
+      <notify_api_key>            API key for GOV.UK Notify.
+  
+      --supplier-id=<id>          ID(s) of supplier(s) to email.
+      --supplier-ids-from=<file>  Path to file containing supplier ID(s), one per line.
+  
+      -n, --dry-run               Run script without sending emails.
+  
+      -h, --help                  Show this screen.

--- a/scripts/framework-applications/notify-successful-suppliers-for-framework.py
+++ b/scripts/framework-applications/notify-successful-suppliers-for-framework.py
@@ -1,17 +1,28 @@
 #!/usr/bin/env python
-"""Email suppliers who have at least one successful lot entry on the given framework.
-Uses the Notify API to inform suppliers of success result.
+"""
+Email suppliers who have at least one successful lot entry on the given framework.
+
+Uses the Notify API to inform suppliers of success result. This script *should not* resend emails.
 
 Usage:
-    scripts/framework-applications/notify-successful-suppliers-for-framework.py <stage> <framework_slug>
-        <govuk_notify_api_key> <govuk_notify_template_id>
+    scripts/framework-applications/notify-successful-suppliers-for-framework.py [options]
+         [--supplier-id=<id> ... | --supplier-ids-from=<file>]
+         <stage> <framework> <notify_api_key> <notify_template_id>
 
 Example:
-    scripts/framework-applications/notify-successful-suppliers-for-framework.py preview g-cloud-11
-        my-awesome-key govuk_notify_template_id
+    scripts/framework-applications/notify-successful-suppliers-for-framework.py preview g-cloud-11 api-key template-id
 
 Options:
-    -h, --help  Show this screen
+    <stage>                     Environment to run script against.
+    <framework>                 Slug of framework to run script against.
+    <notify_api_key>            API key for GOV.UK Notify.
+
+    --supplier-id=<id>          ID(s) of supplier(s) to email.
+    --supplier-ids-from=<file>  Path to file containing supplier ID(s), one per line.
+
+    -n, --dry-run               Run script without sending emails.
+
+    -h, --help                  Show this screen.
 """
 import sys
 
@@ -19,11 +30,16 @@ sys.path.insert(0, '.')
 from docopt import docopt
 
 from dmapiclient import DataAPIClient
+from dmutils.email.exceptions import EmailError
+from dmutils.email.helpers import hash_string
 from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
-from dmscripts.helpers.supplier_data_helpers import SuccessfulSupplierContextForNotify
+from dmscripts.helpers.supplier_data_helpers import (
+    SuccessfulSupplierContextForNotify,
+    get_supplier_ids_from_args,
+)
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
 logger = logging_helpers.configure_logger({"dmapiclient": logging.INFO})
@@ -31,19 +47,30 @@ logger = logging_helpers.configure_logger({"dmapiclient": logging.INFO})
 
 if __name__ == '__main__':
     arguments = docopt(__doc__)
+    supplier_ids = get_supplier_ids_from_args(arguments)
 
     STAGE = arguments['<stage>']
-    FRAMEWORK_SLUG = arguments['<framework_slug>']
-    GOVUK_NOTIFY_API_KEY = arguments['<govuk_notify_api_key>']
-    GOVUK_NOTIFY_TEMPLATE_ID = arguments['<govuk_notify_template_id>']
+    FRAMEWORK_SLUG = arguments['<framework>']
+    GOVUK_NOTIFY_API_KEY = arguments['<notify_api_key>']
+    GOVUK_NOTIFY_TEMPLATE_ID = arguments['<notify_template_id>']
+    DRY_RUN = arguments['--dry-run']
 
     mail_client = scripts_notify_client(GOVUK_NOTIFY_API_KEY, logger=logger)
     api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(STAGE), auth_token=get_auth_token('api', STAGE))
 
-    context_helper = SuccessfulSupplierContextForNotify(api_client, FRAMEWORK_SLUG)
+    context_helper = SuccessfulSupplierContextForNotify(api_client, FRAMEWORK_SLUG, supplier_ids=supplier_ids)
     context_helper.populate_data()
     context_data = context_helper.get_users_personalisations()
 
+    prefix = "[Dry Run] " if DRY_RUN else ""
+
     for user_email, personalisation in context_data.items():
-        logger.info(user_email)
-        mail_client.send_email(user_email, GOVUK_NOTIFY_TEMPLATE_ID, personalisation, allow_resend=False)
+        logger.info(f"{prefix}Sending email to supplier user '{hash_string(user_email)}'")
+
+        if DRY_RUN:
+            continue
+
+        try:
+            mail_client.send_email(user_email, GOVUK_NOTIFY_TEMPLATE_ID, personalisation, allow_resend=False)
+        except EmailError as e:
+            logger.error(f"Error sending email to suppluer user '{hash_string(user_email)}': {e}")


### PR DESCRIPTION
I made a few changes based on what I would liked to have had when running this recently:

- Reorganise usage string
- Add dry-run flag
- Allow filtering supplier ids
- Add functional tests
- Hash email addresses in logs to prevent leaking PII