### PR TITLE
Use central supplier details for framework agreement PDFs

### DIFF
--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -149,16 +149,17 @@ def get_csv_rows(
     include_central_supplier_details=False,
 ):
     """
-    :param count_statuses:  tuple of draft service statuses that should be
-                            counted. The default ("submitted", "failed") gives
-                            a count of all drafts that were originally
-                            submitted.
-    :param dry_run:         if True the records will be returned without
-                            declaration information.
+    :param count_statuses:                      tuple of draft service statuses that should be
+                                                counted. The default ("submitted", "failed") gives
+                                                a count of all drafts that were originally
+                                                submitted.
+    :param dry_run:                             if True the records will be returned without
+                                                declaration information.
+    :param include_central_supplier_details:    include contact info from supplier account (i.e. not the declaration)
 
-    :returns:               row headers and rows as a sequence of dictionaries
-                            with the headers as keys.
-    :rtype:                 tuple[tuple[str], iterable[dict]]
+    :returns:                                   row headers and rows as a sequence of dictionaries
+                                                with the headers as keys.
+    :rtype:                                     tuple[tuple[str], iterable[dict]]
     """
     headers = tuple(chain(
         (
@@ -220,7 +221,8 @@ def _create_row(
 ):
     """
     Fetch supplier data from central details, contact information and declaration
-    :param dry_run:     if True return row without declaration information
+    :param dry_run:                             if True return row without declaration information
+    :param include_central_supplier_details:    include contact info from supplier account (i.e. not the declaration)
     """
     row = dict()
     row.update((

--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -139,6 +139,14 @@ DECLARATION_FIELDS = {
     ),
 }
 
+SUPPLIER_ACCOUNT_FIELDS = (
+    'supplier_registered_name',
+    'supplier_registration_number',
+    'supplier_contact_address1',
+    'supplier_contact_city',
+    'supplier_contact_postcode'
+)
+
 
 def get_csv_rows(
     records,
@@ -173,6 +181,10 @@ def get_csv_rows(
         ),
         (lot_slug for lot_slug in framework_lot_slugs),
         DECLARATION_FIELDS[framework_slug],
+        (
+            supplier_account_field for supplier_account_field in SUPPLIER_ACCOUNT_FIELDS
+            if include_central_supplier_details
+        )
     ))
 
     # filter records eagerly

--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -236,16 +236,15 @@ def _create_row(
     :param dry_run:                             if True return row without declaration information
     :param include_central_supplier_details:    include contact info from supplier account (i.e. not the declaration)
     """
-    row = dict()
-    row.update((
-        ("supplier_id", record["supplier"]["id"]),
-        ("supplier_name", record["supplier"]["name"]),
-        ("supplier_contact_name", record["supplier"]["contactInformation"][0]['contactName']),
-        ("supplier_email", record["supplier"]["contactInformation"][0]['email']),
-        ("pass_fail", _pass_fail_from_record(record)),
-        ("countersigned_at", record["countersignedAt"]),
-        ("countersigned_path", record["countersignedPath"]),
-    ))
+    row = {
+        "supplier_id": record["supplier"]["id"],
+        "supplier_name": record["supplier"]["name"],
+        "supplier_contact_name": record["supplier"]["contactInformation"][0]['contactName'],
+        "supplier_email": record["supplier"]["contactInformation"][0]['email'],
+        "pass_fail": _pass_fail_from_record(record),
+        "countersigned_at": record["countersignedAt"],
+        "countersigned_path": record["countersignedPath"],
+    }
     row.update(
         (lot, sum(record["counts"][(lot, status)] for status in count_statuses))
         for lot in framework_lot_slugs
@@ -261,19 +260,16 @@ def _create_row(
 
     # For regenerating framework agreements with updated information (instead of the declaration details)
     if include_central_supplier_details:
-        row.update((
-            ("supplier_registered_name", record["supplier"]["registeredName"]),
-            (
-                "supplier_registration_number",
-                record["supplier"].get(
-                    'companiesHouseNumber',
-                    record["supplier"].get('otherCompanyRegistrationNumber', "")
-                )
+        row.update({
+            "supplier_registered_name": record["supplier"]["registeredName"],
+            "supplier_registration_number": record["supplier"].get(
+                'companiesHouseNumber',
+                record["supplier"].get('otherCompanyRegistrationNumber', "")
             ),
-            ("supplier_contact_address1", record["supplier"]["contactInformation"][0]['address1']),
-            ("supplier_contact_city", record["supplier"]["contactInformation"][0]['city']),
-            ("supplier_contact_postcode", record["supplier"]["contactInformation"][0]['postcode']),
-        ))
+            "supplier_contact_address1": record["supplier"]["contactInformation"][0]['address1'],
+            "supplier_contact_city": record["supplier"]["contactInformation"][0]['city'],
+            "supplier_contact_postcode": record["supplier"]["contactInformation"][0]['postcode'],
+        })
 
     return row
 

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -40,6 +40,7 @@ def find_suppliers(client, framework, supplier_ids=None, map_impl=map, dry_run=F
         framework_lot_slugs=tuple([lot["slug"] for lot in framework["lots"]]),
         count_statuses=("submitted",),
         dry_run=dry_run,
+        include_central_supplier_details=True
     )
     return rows
 

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -70,7 +70,10 @@ if __name__ == '__main__':
     html_dir = tempfile.mkdtemp()
 
     records = find_suppliers_with_details_and_draft_service_counts(client, framework_slug, supplier_ids)
-    headers, rows = get_csv_rows(records, framework_slug, framework_lot_slugs, count_statuses=("submitted",))
+    headers, rows = get_csv_rows(
+        records, framework_slug, framework_lot_slugs, count_statuses=("submitted",),
+        include_central_supplier_details=True
+    )
     render_html_for_suppliers_awaiting_countersignature(
         rows, framework, os.path.join(args['<path_to_agreements_repo>'], 'documents', framework['slug']), html_dir
     )


### PR DESCRIPTION
https://trello.com/c/skEefuVb/893-regenerate-fwas-for-suppliers

Spoiler: I already used this script to regenerate the PDFs needed for the support request (see ticket).

We don't seem to use Country in the PDF at all so I left that out.

No tests yet - comments on the general approach v welcome.

The corresponding PR for the agreements repo: https://github.com/alphagov/digitalmarketplace-agreements/pull/6