### PR TITLE
Move script to framework-applications folder and include Supplier ID

### DIFF
--- a/scripts/framework-applications/generate-successful-suppliers-for-framework-csv.py
+++ b/scripts/framework-applications/generate-successful-suppliers-for-framework-csv.py
@@ -2,7 +2,9 @@
 # -*- coding: utf-8 -*-
 """
 Generates a CSV listing all suppliers who have had services published to a framework, and the lots that they were
-successful on. This report is useful for tallying the results of the framework during standstill (i.e. just before the
+successful on, outputs to the current directory.
+
+This report is useful for tallying the results of the framework during standstill (i.e. just before the
 framework goes live).
 
 NOTE: the script does not look at declaration information. If the supplier has had their draft services published, it's

--- a/scripts/framework-applications/generate-successful-suppliers-for-framework-csv.py
+++ b/scripts/framework-applications/generate-successful-suppliers-for-framework-csv.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Generate a CSV listing all suppliers who were successfully awarded onto a framework with the lots that they were
-successful on. This CSV is published as an update communication through the Digital Marketplace when the framework
-is awarded (i.e. when standstill ends).
+Generates a CSV listing all suppliers who have had services published to a framework, and the lots that they were
+successful on. This report is useful for tallying the results of the framework during standstill (i.e. just before the
+framework goes live).
+
+NOTE: the script does not look at declaration information. If the supplier has had their draft services published, it's
+assumed they were successful in their application.
 
 Usage:
-    scripts/generate-successful-suppliers-for-framework-csv.py <framework_slug> <stage> <filename>
+    scripts/framework-applications/generate-successful-suppliers-for-framework-csv.py <framework_slug> <stage>
 
 Example:
-    scripts/generate-successful-suppliers-for-framework-csv.py g-cloud-10 production g-cloud-10-successful-suppliers.csv
+    scripts/framework-applications/generate-successful-suppliers-for-framework-csv.py g-cloud-10 production
 """
 import argparse
 import csv
@@ -48,18 +51,22 @@ if __name__ == "__main__":
     all_framework_services = client.find_services_iter(framework=args.framework_slug)
     for service in all_framework_services:
         if service['supplierId'] not in map_suppliers_to_lots:
-            map_suppliers_to_lots[service['supplierId']] = {'name': service['supplierName'], 'lots': set()}
+            map_suppliers_to_lots[service['supplierId']] = {
+                'name': service['supplierName'],
+                'lots': set(),
+                'supplierId': service['supplierId']
+            }
 
         map_suppliers_to_lots[service['supplierId']]['lots'].add(service['lotName'])
 
     with open(FILENAME, 'w') as csvfile:
         writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
-        writer.writerow(['Supplier'] + all_lot_names)
+        writer.writerow(['Supplier ID', 'Supplier name'] + all_lot_names)
 
         sorted_suppliers = (x for x in sorted(map_suppliers_to_lots.values(), key=lambda x: x['name'].lower()))
         writer.writerows(
             (
-                [x['name']] + ['Yes' if lot_name in x['lots'] else '-' for lot_name in all_lot_names]
+                [x['supplierId'], x['name']] + ['Yes' if lot_name in x['lots'] else '-' for lot_name in all_lot_names]
                 for x in
                 sorted_suppliers
             )


### PR DESCRIPTION
The result of the script is no longer published publicly, but it's very useful when tallying stats of the framework just before it goes live. 

This also means we can include the Supplier ID which is a useful reference for any queries from CCS.

TODO: mention this script in the manual as a useful tool.