### PR TITLE
Script to bulk-suspend supplier services

### DIFF
--- a/dmscripts/suspend_suppliers_without_agreements.py
+++ b/dmscripts/suspend_suppliers_without_agreements.py
@@ -22,7 +22,8 @@ def suspend_supplier_services(client, logger, framework_slug, supplier_id, frame
     :param client: API client instance
     :param framework_info: JSON
     :param dry_run: don't suspend if True
-    :return: suspended_service_count: int
+    :return: suspended_service_count
+    :rtype: int
     """
     suspended_service_count = 0
 

--- a/dmscripts/suspend_suppliers_without_agreements.py
+++ b/dmscripts/suspend_suppliers_without_agreements.py
@@ -13,7 +13,7 @@ def get_all_email_addresses_for_supplier(client, supplier_framework):
     ))
 
 
-def suspend_supplier_services(client, logger, framework_slug, supplier_id, framework_info):
+def suspend_supplier_services(client, logger, framework_slug, supplier_id, framework_info, dry_run):
     """
     The supplier ID list should have been flagged by CCS as requiring action, but double check that the supplier:
       - has some services on the framework
@@ -21,6 +21,7 @@ def suspend_supplier_services(client, logger, framework_slug, supplier_id, frame
       - has not `agreementReturned: on-hold
     :param client: API client instance
     :param framework_info: JSON
+    :param dry_run: don't suspend if True
     :return: suspended_service_count: int
     """
     suspended_service_count = 0
@@ -51,7 +52,10 @@ def suspend_supplier_services(client, logger, framework_slug, supplier_id, frame
         f"Setting {services['meta']['total']} services to '{new_service_status}' for supplier {supplier_id}."
     )
     for service in services['services']:
-        client.update_service_status(service['id'], new_service_status, "Suspend services script")
+        if dry_run:
+            logger.info(f"[DRY RUN] Would suspend service {service['id']} for supplier {supplier_id}")
+        else:
+            client.update_service_status(service['id'], new_service_status, "Suspend services script")
         suspended_service_count += 1
 
     # Return suspended service count (i.e. if > 0, some emails need to be sent)

--- a/dmscripts/suspend_suppliers_without_agreements.py
+++ b/dmscripts/suspend_suppliers_without_agreements.py
@@ -1,0 +1,58 @@
+from itertools import chain
+
+
+def get_all_email_addresses_for_supplier(client, supplier_framework):
+    # Combine the framework application contact email with all the active user emails
+    return frozenset(chain(
+        (supplier_framework["frameworkInterest"]["declaration"]["primaryContactEmail"],),
+        (
+            user["emailAddress"] for user in client.find_users_iter(
+                supplier_id=int(supplier_framework['frameworkInterest']['supplierId'])
+            ) if user["active"]
+        ),
+    ))
+
+
+def suspend_supplier_services(client, logger, framework_slug, supplier_id, framework_info):
+    """
+    The supplier ID list should have been flagged by CCS as requiring action, but double check that the supplier:
+      - has some services on the framework
+      - has `agreementReturned: false`
+      - has not `agreementReturned: on-hold
+    :param client: API client instance
+    :param framework_info: JSON
+    :return: suspended_service_count: int
+    """
+    suspended_service_count = 0
+
+    # Ignore any 'private' services that the suppliers have removed themselves
+    new_service_status, old_service_status = 'disabled', 'published'
+
+    if not framework_info['frameworkInterest']['onFramework']:
+        logger.error(f'Supplier {supplier_id} is not on the framework.')
+        return suspended_service_count
+    if framework_info['frameworkInterest']['agreementReturned']:
+        logger.error(f'Supplier {supplier_id} has returned their framework agreement.')
+        return suspended_service_count
+    if framework_info['frameworkInterest']['agreementStatus'] == 'on-hold':
+        logger.error(f"Supplier {supplier_id}'s framework agreement is on hold.")
+        return suspended_service_count
+
+    # Find the supplier's non-private services on this framework
+    services = client.find_services(
+        supplier_id=supplier_id, framework=framework_slug, status=old_service_status
+    )
+    if not services['services']:
+        logger.error(f'Supplier {supplier_id} has no {old_service_status} services on the framework.')
+        return suspended_service_count
+
+    # Suspend all services for each supplier (the API will de-index the services from search results)
+    logger.info(
+        f"Setting {services['meta']['total']} services to '{new_service_status}' for supplier {supplier_id}."
+    )
+    for service in services['services']:
+        client.update_service_status(service['id'], new_service_status, "Suspend services script")
+        suspended_service_count += 1
+
+    # Return suspended service count (i.e. if > 0, some emails need to be sent)
+    return suspended_service_count

--- a/scripts/framework-applications/suspend-suppliers-without-agreements.py
+++ b/scripts/framework-applications/suspend-suppliers-without-agreements.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
 
             # Do the suspending
             suspended_service_count = suspend_supplier_services(
-                client, logger, framework_slug, supplier_id, framework_info
+                client, logger, framework_slug, supplier_id, framework_info, dry_run
             )
 
             if suspended_service_count == 0:

--- a/scripts/framework-applications/suspend-suppliers-without-agreements.py
+++ b/scripts/framework-applications/suspend-suppliers-without-agreements.py
@@ -35,7 +35,6 @@ Options:
 """
 import csv
 import sys
-import os
 import pathlib
 
 from docopt import docopt
@@ -47,7 +46,7 @@ from dmscripts.helpers.logging_helpers import (
     configure_logger,
     logging,
 )
-from dmscripts.helpers.supplier_data_helpers import get_supplier_ids_from_file
+from dmscripts.helpers.supplier_data_helpers import get_supplier_ids_from_args
 
 from dmapiclient import DataAPIClient
 from dmutils.env_helpers import get_api_endpoint_from_stage
@@ -73,17 +72,7 @@ if __name__ == "__main__":
         "script": logging.DEBUG if verbose else logging.INFO,
     })
 
-    # Get all suppliers from the supplied IDs list
-    if args["--supplier-ids-from"]:
-        supplier_ids = get_supplier_ids_from_file(args["--supplier-ids-from"])
-    elif args["--supplier-id"]:
-        try:
-            supplier_ids = tuple(map(int, args["--supplier-id"]))
-        except ValueError:
-            raise TypeError("argument to --supplier-id should be an integer")
-    else:
-        logger.error("At least one supplier ID must be provided.")
-        exit(1)
+    supplier_ids = get_supplier_ids_from_args(args)
 
     client = DataAPIClient(
         get_api_endpoint_from_stage(args["<stage>"]),
@@ -98,7 +87,7 @@ if __name__ == "__main__":
 
     csv_headers = ['Supplier email', 'Supplier ID', "No. of services suspended"]
 
-    with open(os.path.join(output_dir, FILENAME), 'w') as csvfile:
+    with open(output_dir / FILENAME) as csvfile:
         writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
         writer.writerow(csv_headers)
 

--- a/scripts/framework-applications/suspend-suppliers-without-agreements.py
+++ b/scripts/framework-applications/suspend-suppliers-without-agreements.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+After a framework goes live, suppliers have a short period (usually 2 weeks) within which they must return their
+signed framework agreement. If they have not returned their agreement, it cannot be countersigned by CCS and the
+supplier will be unable to sell their services. We should therefore temporarily suspend the supplier's services
+so that buyers won't see them in search results (G-Cloud) or the supplier cannot apply to an opportunity (DOS).
+Suppliers who have returned an incorrect agreement file ('on-hold') should not be suspended.
+
+This script carries out the same action that a CCS Category user could perform in the admin, but in bulk.
+CCS will provide a list of supplier IDs that should be suspended.
+
+Usage:
+    scripts/framework-applications/suspend-suppliers-without-agreements.py
+        [-v...] [options]
+        <stage> <framework> <output_dir>
+        [--supplier-id=<id>... | --supplier-ids-from=<file>]
+    scripts/framework-applications/suspend-suppliers-without-agreements.py (-h | --help)
+
+Options:
+    <stage>                     Environment to run script against.
+    <framework>                 Slug of framework to generate agreements for.
+    <output_dir>                Output folder for list of email addresses to send notifications to.
+
+    --supplier-id=<id>          ID of supplier to generate agreement page for.
+    --supplier-ids-from=<file>  Path to file containing supplier IDs, one per line.
+
+    -h, --help                  Show this help message
+
+    -n, --dry-run               Run script without generating files.
+    -v, --verbose               Show debug log messages.
+
+    If neither `--supplier-ids-from` or `--supplier-id` are provided then
+    framework agreements will be generated for all valid suppliers.
+"""
+import csv
+import sys
+import os
+import pathlib
+
+from docopt import docopt
+
+sys.path.insert(0, '.')
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.logging_helpers import (
+    configure_logger,
+    logging,
+)
+from dmscripts.helpers.supplier_data_helpers import get_supplier_ids_from_file
+
+from dmapiclient import DataAPIClient
+from dmutils.env_helpers import get_api_endpoint_from_stage
+from dmscripts.suspend_suppliers_without_agreements import (
+    suspend_supplier_services, get_all_email_addresses_for_supplier
+)
+
+
+if __name__ == "__main__":
+    args = docopt(__doc__)
+
+    stage = args["<stage>"]
+    framework_slug = args["<framework>"]
+
+    dry_run = args["--dry-run"]
+    verbose = args["--verbose"]
+    output_dir = pathlib.Path(args["<output_dir>"])
+    FILENAME = f'{framework_slug}-suspended-suppliers.csv'
+
+    logger = configure_logger({
+        "dmapiclient.base": logging.WARNING,
+        "framework_helpers": logging.DEBUG if verbose >= 2 else logging.WARNING,
+        "script": logging.DEBUG if verbose else logging.INFO,
+    })
+
+    # Get all suppliers from the supplied IDs list
+    if args["--supplier-ids-from"]:
+        supplier_ids = get_supplier_ids_from_file(args["--supplier-ids-from"])
+    elif args["--supplier-id"]:
+        try:
+            supplier_ids = tuple(map(int, args["--supplier-id"]))
+        except ValueError:
+            raise TypeError("argument to --supplier-id should be an integer")
+    else:
+        logger.error("At least one supplier ID must be provided.")
+        exit(1)
+
+    client = DataAPIClient(
+        get_api_endpoint_from_stage(args["<stage>"]),
+        get_auth_token("api", args["<stage>"]),
+    )
+
+    framework = client.get_framework(framework_slug)["frameworks"]
+    # Check that the framework is live
+    if framework['status'] != 'live':
+        logger.error(f"Cannot suspend services for '{framework_slug}' with status {framework['status']}")
+        exit(1)
+
+    csv_headers = ['Supplier email', 'Supplier ID', "No. of services suspended"]
+
+    with open(os.path.join(output_dir, FILENAME), 'w') as csvfile:
+        writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
+        writer.writerow(csv_headers)
+
+        for supplier_id in supplier_ids:
+            framework_info = client.get_supplier_framework_info(supplier_id, framework_slug)
+
+            # Do the suspending
+            suspended_service_count = suspend_supplier_services(
+                client, logger, framework_slug, supplier_id, framework_info
+            )
+
+            if suspended_service_count == 0:
+                # We should have logged why already
+                continue
+
+            # Compile a list of email addresses for the supplier (to be sent via Notify) and add to the CSV
+            for supplier_email in get_all_email_addresses_for_supplier(client, framework_info):
+                writer.writerow([supplier_email, supplier_id, suspended_service_count])

--- a/tests/test_suspend_suppliers_without_agreements.py
+++ b/tests/test_suspend_suppliers_without_agreements.py
@@ -1,0 +1,150 @@
+import builtins
+import mock
+import pytest
+from dmapiclient.errors import HTTPError
+
+from dmscripts.suspend_suppliers_without_agreements import (
+    suspend_supplier_services, get_all_email_addresses_for_supplier
+)
+
+
+class TestSuspendSupplierServices:
+
+    def setup(self):
+        self.data_api_client = mock.Mock()
+        self.data_api_client.find_services.return_value = {
+            'services': [
+                {'id': 1},
+                {'id': 2}
+            ],
+            "meta": {
+                "total": 2
+            }
+        }
+        self.logger = mock.Mock()
+
+    def test_suspend_supplier_services_updates_services_and_returns_count(self):
+        framework_interest = {
+            "frameworkInterest": {
+                "onFramework": True,
+                "agreementReturned": False,
+                "agreementStatus": None
+            }
+        }
+
+        assert suspend_supplier_services(
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest) == 2
+
+        assert self.data_api_client.find_services.call_args_list == [
+            mock.call(supplier_id=12345, framework='g-cloud-11', status='published')
+        ]
+        assert self.data_api_client.update_service_status.call_args_list == [
+            mock.call(1, 'disabled', "Suspend services script"),
+            mock.call(2, 'disabled', "Suspend services script"),
+        ]
+        assert self.logger.info.call_args_list == [
+            mock.call("Setting 2 services to 'disabled' for supplier 12345.")
+        ]
+
+    def test_suspend_supplier_services_skips_if_no_services(self):
+        framework_interest = {
+            "frameworkInterest": {
+                "onFramework": True,
+                "agreementReturned": False,
+                "agreementStatus": None
+            }
+        }
+        self.data_api_client.find_services.return_value = {'services': []}
+
+        assert suspend_supplier_services(
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest) == 0
+
+        assert self.data_api_client.find_services.call_args_list == [
+            mock.call(supplier_id=12345, framework='g-cloud-11', status='published')
+        ]
+        assert self.data_api_client.update_service_status.call_args_list == []
+        assert self.logger.error.call_args_list == [
+            mock.call("Supplier 12345 has no published services on the framework.")
+        ]
+
+    def test_suspend_supplier_services_skips_if_not_on_framework(self):
+        framework_interest = {
+            "frameworkInterest": {
+                "onFramework": False,
+                "agreementReturned": False,
+                "agreementStatus": None
+            }
+        }
+
+        assert suspend_supplier_services(
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest) == 0
+
+        assert self.data_api_client.find_services.call_args_list == []
+        assert self.data_api_client.update_service_status.call_args_list == []
+        assert self.logger.error.call_args_list == [
+            mock.call("Supplier 12345 is not on the framework.")
+        ]
+
+    def test_suspend_supplier_services_skips_if_agreement_returned(self):
+        framework_interest = {
+            "frameworkInterest": {
+                "onFramework": True,
+                "agreementReturned": True,
+                "agreementStatus": None
+            }
+        }
+
+        assert suspend_supplier_services(
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest) == 0
+
+        assert self.data_api_client.find_services.call_args_list == []
+        assert self.data_api_client.update_service_status.call_args_list == []
+        assert self.logger.error.call_args_list == [
+            mock.call("Supplier 12345 has returned their framework agreement.")
+        ]
+
+    def test_suspend_supplier_services_skips_if_agreement_on_hold(self):
+        framework_interest = {
+            "frameworkInterest": {
+                "onFramework": True,
+                "agreementReturned": False,
+                "agreementStatus": "on-hold"
+            }
+        }
+
+        assert suspend_supplier_services(
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest) == 0
+
+        assert self.data_api_client.find_services.call_args_list == []
+        assert self.data_api_client.update_service_status.call_args_list == []
+        assert self.logger.error.call_args_list == [
+            mock.call("Supplier 12345's framework agreement is on hold.")
+        ]
+
+
+class TestGetAllEmailAddressesForSupplier:
+
+    def test_get_all_email_addresses_for_supplier(self):
+        data_api_client = mock.Mock()
+        data_api_client.find_users_iter.return_value = [
+            {"emailAddress": "one_inch_nail@example.com", "active": True},
+            {"emailAddress": "two_inch_nails@example.com", "active": True},
+            {"emailAddress": "three_inch_nails@example.com", "active": False},
+        ]
+        framework_interest = {
+            "frameworkInterest": {
+                "supplierId": 12345,
+                "declaration": {
+                    "primaryContactEmail": "trent.reznor@example.com"
+                }
+            }
+        }
+
+        assert get_all_email_addresses_for_supplier(data_api_client, framework_interest) == {
+            "trent.reznor@example.com",
+            "one_inch_nail@example.com",
+            "two_inch_nails@example.com"
+        }
+        assert data_api_client.find_users_iter.call_args_list == [
+            mock.call(supplier_id=12345)
+        ]

--- a/tests/test_suspend_suppliers_without_agreements.py
+++ b/tests/test_suspend_suppliers_without_agreements.py
@@ -1,7 +1,4 @@
-import builtins
 import mock
-import pytest
-from dmapiclient.errors import HTTPError
 
 from dmscripts.suspend_suppliers_without_agreements import (
     suspend_supplier_services, get_all_email_addresses_for_supplier

--- a/tests/test_suspend_suppliers_without_agreements.py
+++ b/tests/test_suspend_suppliers_without_agreements.py
@@ -30,7 +30,7 @@ class TestSuspendSupplierServices:
         }
 
         assert suspend_supplier_services(
-            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest) == 2
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest, None) == 2
 
         assert self.data_api_client.find_services.call_args_list == [
             mock.call(supplier_id=12345, framework='g-cloud-11', status='published')
@@ -54,7 +54,7 @@ class TestSuspendSupplierServices:
         self.data_api_client.find_services.return_value = {'services': []}
 
         assert suspend_supplier_services(
-            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest) == 0
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest, None) == 0
 
         assert self.data_api_client.find_services.call_args_list == [
             mock.call(supplier_id=12345, framework='g-cloud-11', status='published')
@@ -74,7 +74,7 @@ class TestSuspendSupplierServices:
         }
 
         assert suspend_supplier_services(
-            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest) == 0
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest, None) == 0
 
         assert self.data_api_client.find_services.call_args_list == []
         assert self.data_api_client.update_service_status.call_args_list == []
@@ -92,7 +92,7 @@ class TestSuspendSupplierServices:
         }
 
         assert suspend_supplier_services(
-            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest) == 0
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest, None) == 0
 
         assert self.data_api_client.find_services.call_args_list == []
         assert self.data_api_client.update_service_status.call_args_list == []
@@ -110,12 +110,34 @@ class TestSuspendSupplierServices:
         }
 
         assert suspend_supplier_services(
-            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest) == 0
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest, None) == 0
 
         assert self.data_api_client.find_services.call_args_list == []
         assert self.data_api_client.update_service_status.call_args_list == []
         assert self.logger.error.call_args_list == [
             mock.call("Supplier 12345's framework agreement is on hold.")
+        ]
+
+    def test_suspend_supplier_services_logs_instead_of_suspending_for_dry_run(self):
+        framework_interest = {
+            "frameworkInterest": {
+                "onFramework": True,
+                "agreementReturned": False,
+                "agreementStatus": None
+            }
+        }
+
+        assert suspend_supplier_services(
+            self.data_api_client, self.logger, 'g-cloud-11', 12345, framework_interest, True) == 2
+
+        assert self.data_api_client.find_services.call_args_list == [
+            mock.call(supplier_id=12345, framework='g-cloud-11', status='published')
+        ]
+        assert self.data_api_client.update_service_status.call_args_list == []
+        assert self.logger.info.call_args_list == [
+            mock.call("Setting 2 services to 'disabled' for supplier 12345."),
+            mock.call("[DRY RUN] Would suspend service 1 for supplier 12345"),
+            mock.call("[DRY RUN] Would suspend service 2 for supplier 12345")
         ]
 
 


### PR DESCRIPTION
https://trello.com/c/naVLGC0L/599-mass-suspension-script

Script to bulk-suspend services for suppliers who have not returned their framework agreement. Admins can do this already for individual suppliers, but when there's 400+ suppliers to suspend, it can get tedious. 

~TODO: tests~ Tests now included!

~TODO: Make `--dry-run` do something~ `--dry-run` now does something 👍 