### PR TITLE
Explicitly call python3 in hashbang lines

### DIFF
--- a/scripts/api-clients-shell.py
+++ b/scripts/api-clients-shell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Drops you into an IPython shell with the DataAPIClient and SearchAPIClient instantiated and targetting the specified
 stage as `data` and `search` respectively.
 

--- a/scripts/clients.py
+++ b/scripts/clients.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Drops you into an IPython shell with the DataAPIClient and SearchAPIClient instantiated and targetting the specified
 stage as `data` and `search` respectively.
 

--- a/scripts/data-retention-remove-contact-information-data.py
+++ b/scripts/data-retention-remove-contact-information-data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Our data retention policy is that suppliers with no users that still have personal data should have the personal data
 stripped from their contact details.

--- a/scripts/data-retention-remove-failed-suppliers-declarations.py
+++ b/scripts/data-retention-remove-failed-suppliers-declarations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Our data retention policy is that suppliers who fail to be accepted onto the framework have their declarations
 removed immediately. This reduces the likelihood of commercially sensitive data being leaked in the event of a breach

--- a/scripts/data-retention-remove-supplier-declarations.py
+++ b/scripts/data-retention-remove-supplier-declarations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Our data retention policy is that supplier declarations are removed 3 years after a framework's expiry date.
 

--- a/scripts/data-retention-remove-user-data.py
+++ b/scripts/data-retention-remove-user-data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Our data retention policy is that users have accounts deactivated and personal data stripped after 3 years without
 a login. This script not only does that but also removes any such users' email addresses from any of our mailing lists.

--- a/scripts/export-dos-labs.py
+++ b/scripts/export-dos-labs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 
 For a DOS-type framework this will export details of all "user-research-studios" services.

--- a/scripts/export-dos-outcomes.py
+++ b/scripts/export-dos-outcomes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 
 For a DOS-type framework this will export details of all "digital-outcomes" services, including the types

--- a/scripts/export-dos-participants.py
+++ b/scripts/export-dos-participants.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 
 For a DOS-type framework this will export details of all "user-research-participants" services, including the

--- a/scripts/export-dos-specialists.py
+++ b/scripts/export-dos-specialists.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 
 For a DOS-type framework this will export details of all "digital-specialists" services, including the

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python33
 """
 
 PREREQUISITE: You'll need wkhtmltopdf installed for this to work (http://wkhtmltopdf.org/). The `default.nix` in this

--- a/scripts/generate-supplier-user-csv.py
+++ b/scripts/generate-supplier-user-csv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 PREREQUISITE: You'll need AWS credentials set up for the environment that you're uploading to:

--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Generate data export CSVs
 
 Load model data from the API or the existing CSV, process it according

--- a/scripts/get-user.py
+++ b/scripts/get-user.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Outputs details of a random active unlocked user with a given role.
 
 For supplier users, providing additional <framework> and <lot> arguments allows

--- a/scripts/index-to-search-service.py
+++ b/scripts/index-to-search-service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Read services from the API endpoint and write to search-api for indexing.
 
 Usage:

--- a/scripts/notify-buyers-to-award-closed-briefs.py
+++ b/scripts/notify-buyers-to-award-closed-briefs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Send email notifications to buyer users to remind them to award their closed requirements.
 
 Usage:

--- a/scripts/notify-buyers-when-requirements-close.py
+++ b/scripts/notify-buyers-when-requirements-close.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Send email notifications to buyer users about closed requirements.
 

--- a/scripts/notify-suppliers-of-awarded-briefs.py
+++ b/scripts/notify-suppliers-of-awarded-briefs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 If a brief has been awarded suppliers need to be notified. This
 script notifies suppliers of all awarded briefs in the previous day by default.

--- a/scripts/notify-suppliers-of-brief-withdrawal.py
+++ b/scripts/notify-suppliers-of-brief-withdrawal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 If a brief has been withdrawn suppliers need to be notified that their applications have also been cancelled. This
 script notifies suppliers of all briefs withdrawn on a given date. Alternatively, when supplied with a given brief id

--- a/scripts/notify-suppliers-of-new-questions-answers.py
+++ b/scripts/notify-suppliers-of-new-questions-answers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 If a buyer has posted a new question/answer on a brief in the last 24 hours, send an email to any
 suppliers who have started an application, completed an application or asked a question about the

--- a/scripts/notify-suppliers-whether-application-made-for-framework.py
+++ b/scripts/notify-suppliers-whether-application-made-for-framework.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Email all suppliers who registered interest in applying to a framework about whether or not they made an application.
 

--- a/scripts/send-dos-opportunities-email.py
+++ b/scripts/send-dos-opportunities-email.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Description:

--- a/scripts/snapshot-framework-stats.py
+++ b/scripts/snapshot-framework-stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Usage:
     snapshot_framework_stats.py <framework_slug> <stage>
 

--- a/scripts/update-index-alias.py
+++ b/scripts/update-index-alias.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python33
 """
 A script to update the elasticsearch index an alias is associated with.
 

--- a/scripts/upload-counterpart-agreements.py
+++ b/scripts/upload-counterpart-agreements.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 PREREQUISITE: You'll need AWS credentials set up for the environment that you're uploading to:

--- a/scripts/upload-dos-opportunities-email-list.py
+++ b/scripts/upload-dos-opportunities-email-list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Description:

--- a/scripts/upload-file-to-s3.py
+++ b/scripts/upload-file-to-s3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Usage:
     scripts/upload-file-to-s3.py


### PR DESCRIPTION
Our scripts are written against Python 3, we should make sure callers use Python 3.