### PR TITLE
Reinsert missing write option on suspension script

### DIFF
--- a/scripts/framework-applications/suspend-suppliers-without-agreements.py
+++ b/scripts/framework-applications/suspend-suppliers-without-agreements.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
 
     csv_headers = ['Supplier email', 'Supplier ID', "No. of services suspended"]
 
-    with open(output_dir / FILENAME) as csvfile:
+    with open(output_dir / FILENAME, 'w') as csvfile:
         writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
         writer.writerow(csv_headers)
 


### PR DESCRIPTION
https://trello.com/c/naVLGC0L/599-mass-suspension-script

Tested this on staging and realised the `w` was missing following a previous refactor.