### PR TITLE
Fix update-framework-results script example

### DIFF
--- a/scripts/framework-applications/update-framework-results.py
+++ b/scripts/framework-applications/update-framework-results.py
@@ -8,8 +8,7 @@ Usage:
     scripts/framework-applications/update-framework-results.py <framework> <stage> (--pass | --fail) <ids_file>
 
 Example:
-    scripts/framework-applications/update-framework-results.py g-cloud-11 preview --pass --api-token=myToken
-        ../g11-supplier-ids.txt
+    scripts/framework-applications/update-framework-results.py g-cloud-11 preview --pass g11-supplier-ids.txt
 
 """
 


### PR DESCRIPTION
No ticket - just spotted this while setting a test account to 'failed' on DOS4.

The API token doesn't get passed as an argument to this script anymore, so let's take it out of the example.