### PR TITLE
New DOS opportunities export script

### DIFF
--- a/dmscripts/export_dos_opportunities.py
+++ b/dmscripts/export_dos_opportunities.py
@@ -1,0 +1,91 @@
+import csv
+from dmscripts.models.process_rules import remove_username_from_email_address, format_datetime_string_as_date
+
+# This URL is framework agnostic
+PUBLIC_BRIEF_URL = "https://digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/{}"
+
+DOS_OPPORTUNITY_HEADERS = [
+    "ID", "Opportunity", "Link", "Framework", "Category", "Specialist",
+    "Organisation Name", "Buyer Domain", "Location Of The Work",
+    "Published At", "Open For", "Expected Contract Length", "Applications from SMEs",
+    "Applications from Large Organisations", "Total Organisations", "Status", "Winning supplier",
+    "Size of supplier", "Contract amount", "Contract start date"
+]
+
+
+def _build_row(brief, brief_responses):
+    winner = None
+    applications_from_sme_suppliers = 0
+    applications_from_large_suppliers = 0
+
+    for brief_response in brief_responses:
+        if brief_response['supplierOrganisationSize'] == 'large':
+            applications_from_large_suppliers += 1
+        else:
+            applications_from_sme_suppliers += 1
+
+        if brief_response['status'] == 'awarded':
+            winner = brief_response
+
+    return [
+        brief['id'],
+        brief['title'],
+        PUBLIC_BRIEF_URL.format(brief['id']),
+        brief['frameworkSlug'],
+        brief['lotSlug'],
+        brief.get('specialist', ""),
+        brief['organisation'],
+        remove_username_from_email_address(brief['users'][0]['emailAddress']),
+        brief['location'],
+        format_datetime_string_as_date(brief['publishedAt']),
+        brief.get('requirementsLength', '2 weeks'),  # only briefs on the specialists lot include 'requirementsLength'
+        brief.get('contractLength', ''),
+        applications_from_sme_suppliers,
+        applications_from_large_suppliers,
+        applications_from_sme_suppliers + applications_from_large_suppliers,
+        brief['status'],
+        winner['supplierName'] if winner else '',
+        winner['supplierOrganisationSize'] if winner else '',
+        winner['awardDetails']['awardedContractValue'] if winner else '',
+        winner['awardDetails']['awardedContractStartDate'] if winner else ''
+    ]
+
+
+def get_latest_dos_framework(client):
+    frameworks = client.find_frameworks()['frameworks']
+    for framework in frameworks:
+        # Should be maximum of 1 live DOS framework
+        if framework['family'] == 'digital-outcomes-and-specialists' and framework['status'] == 'live':
+            return framework['slug']
+    return 'digital-outcomes-and-specialists'
+
+
+def get_brief_data(client):
+    briefs = client.find_briefs_iter(status="closed,awarded,unsuccessful,cancelled", with_users=True)
+    rows = []
+    for brief in briefs:
+        brief_responses = client.find_brief_responses_iter(brief_id=brief['id'])
+        rows.append(_build_row(brief, brief_responses))
+    return rows
+
+
+def write_rows_to_csv(rows, file_path):
+    with open(file_path, 'w') as csv_file:
+        writer = csv.writer(csv_file, delimiter=',', quotechar='"')
+        writer.writerow(DOS_OPPORTUNITY_HEADERS)
+        for row in rows:
+            writer.writerow(row)
+
+
+def upload_file_to_s3(file_path, bucket, remote_key_name, download_name, dry_run, logger):
+    with open(file_path, 'br') as source_file:
+        logger.info("{}UPLOAD: {} to {}::{}".format(
+            '[Dry-run]' if dry_run else '',
+            file_path,
+            bucket.bucket_name,
+            download_name
+        ))
+
+        if not dry_run:
+            # Save file
+            bucket.save(remote_key_name, source_file, acl='public-read', download_filename=download_name)

--- a/scripts/export-dos-opportunities.py
+++ b/scripts/export-dos-opportunities.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Generate DOS opportunity data export CSV
+
+Loads data from the Brief and BriefResponse API models, filters for closed/awarded briefs and stores the output
+in the CSV.
+
+Usage:
+    scripts/export-dos-opportunities.py [options] <stage>
+
+Options:
+    -h --help       Show this screen.
+    -v --verbose    Print apiclient INFO messages.
+    --dry-run       Generate the file but do not upload to S3
+    --output-dir=<output_dir>  Directory to write csv files to [default: data]
+"""
+import os
+import sys
+sys.path.insert(0, '.')
+
+from docopt import docopt
+
+from dmapiclient import DataAPIClient
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.logging_helpers import logging, configure_logger
+from dmscripts.export_dos_opportunities import (
+    get_latest_dos_framework, get_brief_data, write_rows_to_csv, upload_file_to_s3
+)
+from dmutils.env_helpers import get_api_endpoint_from_stage
+from dmutils.s3 import S3
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    STAGE = arguments['<stage>']
+    OUTPUT_DIR = arguments['--output-dir']
+    DRY_RUN = arguments['--dry-run']
+
+    logging_config = {'dmapiclient': logging.INFO} if bool(arguments.get('--verbose')) \
+        else {'dmapiclient': logging.WARNING}
+    logger = configure_logger(logging_config)
+
+    # TODO: use pathlib
+    if not os.path.exists(OUTPUT_DIR):
+        logger.info("Creating {} directory".format(OUTPUT_DIR))
+        os.makedirs(OUTPUT_DIR)
+
+    client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))
+
+    latest_framework_slug = get_latest_dos_framework(client)
+
+    DOWNLOAD_FILE_NAME = 'opportunity-data.csv'
+    file_path = os.path.join(OUTPUT_DIR, DOWNLOAD_FILE_NAME)
+    bucket_name = 'digital-marketplace-communications-{}-{}'.format(STAGE, STAGE)
+    key_name = '{}/communications/data/{}'.format(latest_framework_slug, DOWNLOAD_FILE_NAME)
+
+    logger.info('Exporting DOS opportunity data to CSV')
+
+    # Get the data
+    rows = get_brief_data(client)
+
+    # Construct CSV
+    write_rows_to_csv(rows, file_path)
+
+    # Grab bucket
+    bucket = S3(bucket_name)
+
+    # Upload to S3
+    upload_file_to_s3(
+        file_path,
+        bucket,
+        key_name,
+        DOWNLOAD_FILE_NAME,
+        dry_run=DRY_RUN,
+        logger=logger
+    )

--- a/scripts/get-model-data.py
+++ b/scripts/get-model-data.py
@@ -42,7 +42,7 @@ from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.logging_helpers import logging, configure_logger
 from dmscripts.models import queries
 from dmscripts.models.process_rules import (
-    format_datetime_string_as_date, remove_username_from_email_address, construct_brief_url, extract_id_from_user_info
+    format_datetime_string_as_date, remove_username_from_email_address, extract_id_from_user_info
 )
 from dmscripts.models.writecsv import csv_path
 from dmutils.env_helpers import get_api_endpoint_from_stage
@@ -272,94 +272,6 @@ CONFIGS = [
             'supplierOrganisationSize': 'awarded_supplierOrganisationSize',
             'supplierName': 'awarded_supplierName'
         }
-    },
-    {
-        'name': 'opportunity-data',
-        'model': 'briefs',
-        'filter_query': 'status_data in ["closed", "cancelled", "unsuccessful", "awarded"]',
-        'joins': [
-            {
-                'model_name': 'awarded_brief_responses',
-                'left_on': 'id',
-                'right_on': 'briefId',
-                'data_duplicate_suffix': '_awarded_brief_responses'
-            }, {
-                'model_name': 'brief_responses',
-                'left_on': 'id',
-                'right_on': 'briefId',
-                'data_duplicate_suffix': '_data'
-            },
-
-        ],
-        'keys': (
-            'brief_id_copy',
-            'title',
-            'id_data',
-            'frameworkSlug',
-            'lot',
-            'specialistRole',
-            'organisation',
-            'users.0.emailAddress',
-            'location',
-            'publishedAt',
-            'requirementsLength',
-            'contractLength',
-            'applicationsFromSMEs',
-            'applicationsFromLargeOrganisations',
-            'totalApplications',
-            'status_data',
-            'awarded_supplierName',
-            'awarded_supplierOrganisationSize',
-            'awarded_awardedContractValue',
-            'awarded_awardedContractStartDate',
-        ),
-        'aggregation_counts': [
-            {
-                'group_by': 'id_data',
-                'join': ('id_data', 'id_data'),
-                'count_name': 'totalApplications',
-                'query': 'id_brief_responses != ""',
-            }, {
-                'group_by': 'id_data',
-                'join': ('id_data', 'id_data'),
-                'count_name': 'applicationsFromSMEs',
-                'query': 'supplierOrganisationSize in ["micro", "small", "medium"]',
-            }, {
-                'group_by': 'id_data',
-                'join': ('id_data', 'id_data'),
-                'count_name': 'applicationsFromLargeOrganisations',
-                'query': 'supplierOrganisationSize == "large"',
-            },
-        ],
-        'duplicate_fields': [('id_data', 'brief_id_copy')],
-        'process_fields': {
-            'id_data': construct_brief_url,
-            'users.0.emailAddress': remove_username_from_email_address,
-            'requirementsLength': lambda i: i or '2 weeks',
-        },
-        'rename_fields': {
-            'brief_id_copy': 'ID',
-            'title': 'Opportunity',
-            'id_data': 'Link',
-            'frameworkSlug': 'Framework',
-            'lot': 'Category',
-            'specialistRole': 'Specialist',
-            'organisation': 'Organisation Name',
-            'users.0.emailAddress': 'Buyer Domain',
-            'location': 'Location Of The Work',
-            'publishedAt': 'Published At',
-            'requirementsLength': 'Open For',
-            'contractLength': 'Expected Contract Length',
-            'applicationsFromSMEs': 'Applications from SMEs',
-            'applicationsFromLargeOrganisations': 'Applications from Large Organisations',
-            'totalApplications': 'Total Organisations',
-            'status_data': 'Status',
-            'awarded_supplierName': 'Winning supplier',
-            'awarded_supplierOrganisationSize': 'Size of supplier',
-            'awarded_awardedContractValue': 'Contract amount',
-            'awarded_awardedContractStartDate': 'Contract start date'
-        },
-        'drop_duplicates': True,
     },
     {
         'name': 'direct_award_projects',

--- a/tests/test_export_dos_opportunities.py
+++ b/tests/test_export_dos_opportunities.py
@@ -1,0 +1,127 @@
+import builtins
+import mock
+import pytest
+from dmapiclient import DataAPIClient
+from dmtestutils.api_model_stubs import BriefResponseStub, FrameworkStub
+
+from dmscripts.export_dos_opportunities import get_brief_data, get_latest_dos_framework, upload_file_to_s3
+
+
+example_brief = {
+    "id": 12345,
+    "title": "My Brilliant Brief",
+    "frameworkSlug": "digital-outcomes-and-specialists-3",
+    "lotSlug": "digital-specialists",
+    "specialist": "technicalArchitect",
+    "organisation": "HM Dept of Doing Stuff",
+    "location": "London",
+    "publishedAt": "2019-01-01T00:00:00.123456Z",
+    "contractLength": "6 months",
+    "status": "awarded",
+    "users": [
+        {"emailAddress": "shouldnt-be-visible@example.gov.uk"}
+    ]
+}
+
+
+# TODO: replace with BriefResponseStub once awardedContractStartDate format is fixed
+example_winning_brief_response = {
+    "briefId": 12345,
+    "supplierName": "Foo Inc",
+    "supplierOrganisationSize": "small",
+    "status": "awarded",
+    "awardDetails": {
+        "awardedContractValue": "2345678",
+        "awardedContractStartDate": "2019-06-02"
+    }
+}
+
+
+def test_get_latest_dos_framework():
+    client = mock.Mock(spec=DataAPIClient)
+    client.find_frameworks.return_value = {
+        'frameworks': [
+            FrameworkStub(status='expired', slug='g-cloud-10', family='g-cloud').response(),
+            FrameworkStub(status='live', slug='g-cloud-11', family='g-cloud').response(),
+            FrameworkStub(
+                status='expired',
+                slug='digital-outcomes-and-specialists-2',
+                family='digital-outcomes-and-specialists'
+            ).response(),
+            FrameworkStub(
+                status='live',
+                slug='digital-outcomes-and-specialists-3',
+                family='digital-outcomes-and-specialists'
+            ).response(),
+        ]
+    }
+
+    assert get_latest_dos_framework(client) == 'digital-outcomes-and-specialists-3'
+    assert client.find_frameworks.call_args_list == [
+        mock.call()
+    ]
+
+
+def test_get_brief_data():
+    client = mock.Mock(spec=DataAPIClient)
+    client.find_briefs_iter.return_value = [example_brief]
+    client.find_brief_responses_iter.return_value = [
+        example_winning_brief_response,
+        BriefResponseStub().response()
+    ]
+
+    rows = get_brief_data(client)
+
+    assert rows == [
+        [
+            12345,
+            'My Brilliant Brief',
+            'https://digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/12345',
+            'digital-outcomes-and-specialists-3',
+            'digital-specialists',
+            'technicalArchitect',
+            "HM Dept of Doing Stuff",
+            "example.gov.uk",
+            "London",
+            "2019-01-01",
+            "2 weeks",
+            "6 months",
+            2,
+            0,
+            2,
+            "awarded",
+            "Foo Inc",
+            "small",
+            "2345678",
+            "2019-06-02"
+        ]
+    ]
+
+    assert client.find_briefs_iter.call_args_list == [
+        mock.call(status="closed,awarded,unsuccessful,cancelled", with_users=True)
+    ]
+    assert client.find_brief_responses_iter.call_args_list == [
+        mock.call(brief_id=12345)
+    ]
+
+
+@pytest.mark.parametrize('dry_run', ['True', 'False'])
+def test_upload_file_to_s3(dry_run):
+    bucket = mock.Mock()
+    bucket.bucket_name = 'mybucket'
+    logger = mock.Mock()
+
+    with mock.patch.object(builtins, 'open', mock.mock_open()) as mock_open:
+        upload_file_to_s3(
+            "local/path", bucket, "remote/key/name", "opportunity-data.csv", dry_run, logger
+        )
+
+    assert mock_open.called is True
+    assert bucket.save.call_args_list == ([] if dry_run else [
+        mock.call("remote/key/name", "local/path", acl='public-read', download_filename="opportunity-data.csv")
+    ])
+    assert logger.info.call_args_list == ([
+        mock.call("[Dry-run]UPLOAD: local/path to mybucket::opportunity-data.csv")
+    ] if dry_run else [
+        mock.call("UPLOAD: local/path to mybucket::opportunity-data.csv")
+    ])


### PR DESCRIPTION
https://trello.com/c/N3yUHHOe/92-make-dos-outcome-csv-framework-iteration-agnostic

- Splits out the public DOS opportunities CSV export from the mega `get-model-data` export (that exports a subset of model data to a private folder for internal use).
- Also adds tests & `--dry-run` functionality 🎉 

Currently, the Jenkins job doing the overnight export is also responsible for uploading this file to S3. This responsibility is now self contained within the script. (Updating the Jenkins job is next on my list - I won't merge this until that's ready).

This change should make the DOS opportunity export framework iteration agnostic - the file will be uploaded to the S3 bucket for latest live DOS framework. 

Having to fetch the brief responses for each brief via the API is a bit time consuming, but without changes to the API views I think it's the simplest way to get the data. This is a downside of splitting this out from the existing mega-export (which relies on `pandas` to join data from pre-existing csv files), but I think the benefits of visibility/maintainability make up for it. I could potentially add in `ThreadPool` (as per some of our other scripts) if people are keen, not sure how much it would help.

There are a few minor TODOs that aren't blockers.