### PR TITLE
Indexing script is iteration agnostic for DOS

### DIFF
--- a/dmscripts/index_to_search_service.py
+++ b/dmscripts/index_to_search_service.py
@@ -84,21 +84,24 @@ indexers = {
 
 
 # Hardcoded for now as we are unlikely to add new frameworks in the near future
-FRAMEWORK_MAPPINGS = {
+GCLOUD_MAPPINGS = {
     'g-cloud-9': 'services',
     'g-cloud-10': 'services-g-cloud-10',
-    'g-cloud-11': 'services-g-cloud-11',
-    'digital-outcomes-and-specialists': 'briefs-digital-outcomes-and-specialists-2',
-    'digital-outcomes-and-specialists-2': 'briefs-digital-outcomes-and-specialists-2',
-    'digital-outcomes-and-specialists-3': 'briefs-digital-outcomes-and-specialists-2',
+    'g-cloud-11': 'services-g-cloud-11'
 }
+# All DOS framework iterations use the same mapping, which was last changed for DOS2
+DOS_MAPPING = 'briefs-digital-outcomes-and-specialists-2'
 
 
 def search_mapping_matches_framework(mapping_name, frameworks):
     # Check that the mapping has been generated from at least one of the frameworks given in
     # the comma-separated list
-    if any(mapping_name == FRAMEWORK_MAPPINGS[fw] for fw in frameworks.split(',')):
-        return True
+    framework_list = frameworks.split(',')
+    for fw in framework_list:
+        if 'digital-outcomes-and-specialists' in fw and mapping_name == DOS_MAPPING:
+            return True
+        elif mapping_name == GCLOUD_MAPPINGS.get(fw):
+            return True
     raise ValueError("Incorrect mapping '{}' for the supplied framework(s): {}".format(mapping_name, frameworks))
 
 

--- a/tests/test_index_to_search_service.py
+++ b/tests/test_index_to_search_service.py
@@ -183,8 +183,17 @@ class TestIndexers:
             mock.call(mock.ANY, mapping='services-g-cloud-10')
         ]
 
+    @pytest.mark.parametrize(
+        'framework_list',
+        [
+            "digital-outcomes-and-specialists",
+            "digital-outcomes-and-specialists,digital-outcomes-and-specialists-2",
+            "digital-outcomes-and-specialists,digital-outcomes-and-specialists-99",
+            "digital-outcomes-and-specialists-99",
+        ]
+    )
     @mock.patch.object(BriefIndexer, 'create_index', autospec=True)
-    def test_do_index_creates_new_index_from_briefs_mapping(self, create_index):
+    def test_do_index_creates_new_index_from_briefs_mapping_for_dos_frameworks(self, create_index, framework_list):
         do_index(
             'briefs',
             "http://search-api-url", "mySearchAPIToken",
@@ -192,7 +201,7 @@ class TestIndexers:
             mapping='briefs-digital-outcomes-and-specialists-2',
             serial=True,  # don't run in parallel for testing
             index="my-new-dos-index",
-            frameworks="digital-outcomes-and-specialists,digital-outcomes-and-specialists-2"
+            frameworks=framework_list
         )
 
         assert create_index.call_args_list == [


### PR DESCRIPTION
https://trello.com/c/N3yUHHOe/92-make-dos-outcome-csv-framework-iteration-agnostic

Previously: each DOS iteration had to be added to a list of mappings - even though they're all using the same mapping. 

Now: the script still looks through all the supplied frameworks and checks if the mapping matches for G-Cloud, but if it finds a DOS one it has to match the DOS mapping.