### PR TITLE
Add new DOS4 mailing list IDs

### DIFF
--- a/scripts/send-dos-opportunities-email.py
+++ b/scripts/send-dos-opportunities-email.py
@@ -63,7 +63,12 @@ list_ids = {
         'digital-specialists': "bee802d641",
         'digital-outcomes': "5c92c78a78",
         'user-research-participants': "34ebe0bffa",
-    }
+    },
+    'digital-outcomes-and-specialists-4': {
+        'digital-specialists': "29d06d5201",
+        'digital-outcomes': "4360debc5a",
+        'user-research-participants': "2538f8a0f1",
+    },
 }
 
 if __name__ == "__main__":

--- a/scripts/upload-dos-opportunities-email-list.py
+++ b/scripts/upload-dos-opportunities-email-list.py
@@ -55,7 +55,12 @@ if __name__ == '__main__':
             'digital-specialists': "bee802d641" if stage == "production" else "07c21f0451",
             'digital-outcomes': "5c92c78a78" if stage == "production" else "f0077c516d",
             'user-research-participants': "34ebe0bffa" if stage == "production" else "d35601203b",
-        }
+        },
+        'digital-outcomes-and-specialists-4': {
+            'digital-specialists': "29d06d5201" if stage == "production" else "07c21f0451",
+            'digital-outcomes': "4360debc5a" if stage == "production" else "f0077c516d",
+            'user-research-participants': "2538f8a0f1" if stage == "production" else "d35601203b",
+        },
     }
 
     lots = [


### PR DESCRIPTION
https://trello.com/c/uKsNvFiM/91-set-up-dos4-new-opportunities-supplier-mailing-lists-in-mailchimp

As per ticket:

### What 
These Mailchimp lists receive daily digests of the previous day's published DOS opportunities (depending on what lot the supplier is on) via `send-dos-opportunities-email.py`.

Once the lists are created and their IDs added to the right script (`upload-dos-opportunities-email-list.py`), users get automatically added to the list when Jenkins runs the script. This is normally done daily, to capture new users join an existing supplier account. 

### Why
We have separate lists for each DOS iteration, as suppliers on DOS3 but not DOS4 can't apply to DOS4 opportunities, so we don't want to spam them.

## Out of scope
I have a separate branch-in-progress to refactor the `send-dos-opportunities` script to make the go-live switchover easier.


