### PR TITLE
Log supplier ID during Notify successful suppliers for framework

### DIFF
--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -68,7 +68,7 @@ class SuccessfulSupplierContextForNotify(SupplierFrameworkData):
 
     STATUS_MAP = {'submitted': 'Successful', 'not-submitted': 'No application', 'failed': 'Unsuccessful'}
 
-    def __init__(self, client, target_framework_slug, *, supplier_ids=None):
+    def __init__(self, client, target_framework_slug, *, supplier_ids=None, logger=None):
         """Get the target framework to operate on and list the lots.
 
         :param client: Instantiated api client
@@ -81,6 +81,7 @@ class SuccessfulSupplierContextForNotify(SupplierFrameworkData):
 
         self.framework = client.get_framework(self.target_framework_slug)['frameworks']
         self.framework_lots = [i['name'] for i in self.framework['lots']]
+        self.logger = logger
 
     def get_users_personalisations(self):
         """Return {email_address: {personalisations}} for users eligible for the
@@ -88,6 +89,10 @@ class SuccessfulSupplierContextForNotify(SupplierFrameworkData):
         """
         output = {}
         for supplier_framework in filter(lambda i: i['onFramework'], self.data):
+            if self.logger:
+                self.logger.info(
+                    'Building user personalisations for supplier {}'.format(supplier_framework['supplierId'])
+                )
             for user in supplier_framework['users']:
                 output.update(self.get_user_personalisation(user, supplier_framework))
         return output

--- a/scripts/framework-applications/notify-successful-suppliers-for-framework.py
+++ b/scripts/framework-applications/notify-successful-suppliers-for-framework.py
@@ -58,7 +58,9 @@ if __name__ == '__main__':
     mail_client = scripts_notify_client(GOVUK_NOTIFY_API_KEY, logger=logger)
     api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(STAGE), auth_token=get_auth_token('api', STAGE))
 
-    context_helper = SuccessfulSupplierContextForNotify(api_client, FRAMEWORK_SLUG, supplier_ids=supplier_ids)
+    context_helper = SuccessfulSupplierContextForNotify(
+        api_client, FRAMEWORK_SLUG, supplier_ids=supplier_ids, logger=logger
+    )
     context_helper.populate_data()
     context_data = context_helper.get_users_personalisations()
 
@@ -73,4 +75,4 @@ if __name__ == '__main__':
         try:
             mail_client.send_email(user_email, GOVUK_NOTIFY_TEMPLATE_ID, personalisation, allow_resend=False)
         except EmailError as e:
-            logger.error(f"Error sending email to suppluer user '{hash_string(user_email)}': {e}")
+            logger.error(f"Error sending email to supplier user '{hash_string(user_email)}': {e}")


### PR DESCRIPTION
https://trello.com/c/22mvlQsh/1061-log-supplier-id-during-notify-successful-suppliers-for-framework-script

This script takes a while to run, and it's hard to determine the progress as we only log the hashes of each emails we're sending.

Logging the supplier ID when building the personalisations for each user will help surface how far down the list of suppliers we've reached.

Also fixes a typo in an existing log statement.