### PR TITLE
DOS4 opportunity alerts run for all frameworks with live briefs

### DIFF
--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -23,6 +23,11 @@ MAILCHIMP_LIST_IDS = {
         'digital-specialists': "bee802d641",
         'digital-outcomes': "5c92c78a78",
         'user-research-participants': "34ebe0bffa",
+    },
+    'digital-outcomes-and-specialists-4': {
+        'digital-specialists': "29d06d5201",
+        'digital-outcomes': "4360debc5a",
+        'user-research-participants': "2538f8a0f1",
     }
 }
 

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -39,7 +39,7 @@ LOT_NAMES = {
 
 
 def get_live_briefs_between_two_dates(data_api_client, start_date, end_date):
-    """Get all briefs for a lot which were published between 2 dates."""
+    """Get all briefs which were published between 2 dates."""
     return [
         brief for brief in data_api_client.find_briefs_iter(status="live", human=True)
         if datetime.strptime(brief['publishedAt'], DATETIME_FORMAT).date() >= start_date
@@ -165,7 +165,7 @@ def main(data_api_client, mailchimp_client, number_of_days, framework_override, 
         live_briefs_by_framework = {framework_override: live_briefs_by_framework.get(framework_override)}
 
     # If no briefs found, exit early
-    if not live_briefs_by_framework.keys():
+    if not live_briefs_by_framework:
         logger.info(
             "No new briefs found for DOS frameworks in the last {} day(s)".format(number_of_days),
             extra={"number_of_days": number_of_days}
@@ -176,7 +176,7 @@ def main(data_api_client, mailchimp_client, number_of_days, framework_override, 
         for lot_slug, live_briefs in live_briefs_by_framework[framework_slug].items():
 
             if lot_slug_override and lot_slug != lot_slug_override:
-                logger.warning("Skipping campaign for '{0}' lot on {1}".format(lot_slug, framework_slug))
+                logger.info("Skipping campaign for '{0}' lot on {1}".format(lot_slug, framework_slug))
                 continue
 
             logger.info("{0} new briefs found for '{1}' lot on {2}".format(len(live_briefs), lot_slug, framework_slug))

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -157,7 +157,12 @@ def main(data_api_client, mailchimp_client, number_of_days, framework_override, 
 
     # If specific framework script arg supplied, ignore other frameworks
     if framework_override:
-        live_briefs_by_framework = {framework_override: live_briefs_by_framework[framework_override]}
+        if not live_briefs_by_framework.get(framework_override):
+            logger.info(
+                "No new briefs found for {} in the last {} day(s)".format(framework_override, number_of_days)
+            )
+            return True
+        live_briefs_by_framework = {framework_override: live_briefs_by_framework.get(framework_override)}
 
     # If no briefs found, exit early
     if not live_briefs_by_framework.keys():

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -133,7 +133,15 @@ def get_live_briefs_by_framework_and_lot(client, start_date, end_date):
     return briefs_by_fw_and_lot
 
 
-def main(data_api_client, mailchimp_client, number_of_days, framework_override, list_id_override, lot_slug_override):
+def main(
+    data_api_client,
+    mailchimp_client,
+    number_of_days,
+    *,
+    framework_override=None,
+    list_id_override=None,
+    lot_slug_override=None
+):
     """
     Default behaviour is to fetch any briefs (regardless of framework/lot) published in the last N days.
 

--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -8,12 +8,35 @@ from dmutils.formats import DATETIME_FORMAT, DISPLAY_DATE_FORMAT
 logger = logging.getLogger('script')
 
 
-def get_live_briefs_between_two_dates(data_api_client, lot_slug, start_date, end_date, framework_slug):
+MAILCHIMP_LIST_IDS = {
+    'digital-outcomes-and-specialists': {
+        'digital-specialists': None,
+        'digital-outcomes': None,
+        'user-research-participants': None,
+    },
+    'digital-outcomes-and-specialists-2': {
+        'digital-specialists': "30ba9fdf39",
+        'digital-outcomes': "97952fee38",
+        'user-research-participants': "e6b93a3bce",
+    },
+    'digital-outcomes-and-specialists-3': {
+        'digital-specialists': "bee802d641",
+        'digital-outcomes': "5c92c78a78",
+        'user-research-participants': "34ebe0bffa",
+    }
+}
+
+LOT_NAMES = {
+    "digital-specialists": "Digital specialists",
+    "digital-outcomes": "Digital outcomes",
+    "user-research-participants": "User research participants",
+}
+
+
+def get_live_briefs_between_two_dates(data_api_client, start_date, end_date):
     """Get all briefs for a lot which were published between 2 dates."""
     return [
-        brief for brief in data_api_client.find_briefs_iter(
-            status="live", lot=lot_slug, human=True, framework=framework_slug
-        )
+        brief for brief in data_api_client.find_briefs_iter(status="live", human=True)
         if datetime.strptime(brief['publishedAt'], DATETIME_FORMAT).date() >= start_date
         and datetime.strptime(brief['publishedAt'], DATETIME_FORMAT).date() <= end_date
     ]
@@ -67,47 +90,117 @@ def get_html_content(briefs, number_of_days):
     return {"html": html_content}
 
 
-def main(data_api_client, mailchimp_client, lot_data, number_of_days, framework_slug):
-    logger.info(
-        "Begin process to send DOS notification emails for '{0}' lot".format(lot_data["lot_slug"]),
-        extra={"lot_data": lot_data, "number_of_days": number_of_days}
-    )
+def get_live_briefs_by_framework_and_lot(client, start_date, end_date):
+    """
+    Create a map of all live briefs, organised by framework and lot.
+    A framework/lot will only be included if there are live briefs for it in the time range given.
 
+    :param client: Data API client
+    :param start_date: YYYY-MM-DD
+    :param end_date: YYYY-MM-DD
+    :return: dict of live briefs, e.g.
+        {
+            'digital-outcomes-and-specialists-2': {
+                'digital-outcomes': [brief1, brief2, ...],
+                'user-research-participants': [brief3]
+            },
+            'digital-outcomes-and-specialists-3': {
+                'digital-specialists': [brief4, brief5],
+                'digital-outcomes': [brief6, brief7]
+            }
+        }
+    """
+    briefs = get_live_briefs_between_two_dates(client, start_date, end_date)
+    briefs_by_fw_and_lot = {}
+
+    for brief in briefs:
+        brief_fw_slug = brief['frameworkSlug']
+        brief_lot_slug = brief['lotSlug']
+        if brief['frameworkSlug'] in briefs_by_fw_and_lot:
+            if brief_lot_slug in briefs_by_fw_and_lot[brief_fw_slug]:
+                briefs_by_fw_and_lot[brief_fw_slug][brief_lot_slug].append(brief)
+            else:
+                briefs_by_fw_and_lot[brief_fw_slug][brief_lot_slug] = [brief]
+        else:
+            briefs_by_fw_and_lot[brief_fw_slug] = {
+                brief_lot_slug: [brief]
+            }
+    return briefs_by_fw_and_lot
+
+
+def main(data_api_client, mailchimp_client, number_of_days, framework_override, list_id_override, lot_slug_override):
+    """
+    Default behaviour is to fetch any briefs (regardless of framework/lot) published in the last N days.
+
+    The script groups briefs by framework/lot, and for each combination, looks up the Mailchimp list ID, and creates &
+    sends a new campaign.
+    - If a framework_override is supplied, just find briefs for that framework
+    - If a lot_override is supplied, just find briefs for that lot
+    - If a list_id_override is supplied, only send emails to that list ID regardless of lot/framework
+
+    For most of the year, there should only be one framework iteration with live briefs. However during the transition
+    period between DOS framework iterations, we need to support both iterations.
+
+    For example, on the second day of DOS4, any DOS3 briefs created the first day (before the go-live switchover) will
+    still need to be emailed to DOS3 suppliers, as well as the usual DOS4 briefs sent to DOS4 suppliers.
+    """
     start_date = date.today() - timedelta(days=number_of_days)
     end_date = date.today() - timedelta(days=1)
 
-    live_briefs = get_live_briefs_between_two_dates(
-        data_api_client, lot_data["lot_slug"], start_date, end_date, framework_slug
-    )
-    if not live_briefs:
+    # Get all live briefs for each DOS framework on the lot (or a single DOS framework, if supplied as a script arg)
+    live_briefs_by_framework = get_live_briefs_by_framework_and_lot(data_api_client, start_date, end_date)
+
+    # If specific framework script arg supplied, ignore other frameworks
+    if framework_override:
+        live_briefs_by_framework = {framework_override: live_briefs_by_framework[framework_override]}
+
+    # If no briefs found, exit early
+    if not live_briefs_by_framework.keys():
         logger.info(
-            "No new briefs found for '{0}' lot".format(lot_data["lot_slug"]),
+            "No new briefs found for DOS frameworks in the last {} day(s)".format(number_of_days),
             extra={"number_of_days": number_of_days}
         )
         return True
-    logger.info(
-        "{0} new briefs found for '{1}' lot".format(len(live_briefs), lot_data["lot_slug"])
-    )
 
-    campaign_data = get_campaign_data(lot_data["lot_name"], lot_data["list_id"], live_briefs[0]['frameworkName'])
-    logger.info(
-        "Creating campaign for '{0}' lot".format(lot_data["lot_slug"])
-    )
-    campaign_id = mailchimp_client.create_campaign(campaign_data)
-    if not campaign_id:
-        return False
+    for framework_slug in live_briefs_by_framework.keys():
+        for lot_slug, live_briefs in live_briefs_by_framework[framework_slug].items():
 
-    content_data = get_html_content(live_briefs, number_of_days)
-    logger.info(
-        "Setting campaign data for '{0}' lot and '{1}' campaign id".format(lot_data["lot_slug"], campaign_id)
-    )
-    if not mailchimp_client.set_campaign_content(campaign_id, content_data):
-        return False
+            if lot_slug_override and lot_slug != lot_slug_override:
+                logger.warning("Skipping campaign for '{0}' lot on {1}".format(lot_slug, framework_slug))
+                continue
 
-    logger.info(
-        "Sending campaign for '{0}' lot and '{1}' campaign id".format(lot_data["lot_slug"], campaign_id)
-    )
-    if not mailchimp_client.send_campaign(campaign_id):
-        return False
+            logger.info("{0} new briefs found for '{1}' lot on {2}".format(len(live_briefs), lot_slug, framework_slug))
+
+            # Get the list_id for this lot/framework combination (or use list ID override if supplied as script arg)
+            list_id = list_id_override or MAILCHIMP_LIST_IDS[framework_slug][lot_slug]
+
+            # Create a new campaign for today's emails
+            logger.info("Creating campaign for '{0}' lot on {1}".format(lot_slug, framework_slug))
+            campaign_data = get_campaign_data(LOT_NAMES[lot_slug], list_id, live_briefs[0]['frameworkName'])
+            campaign_id = mailchimp_client.create_campaign(campaign_data)
+            if not campaign_id:
+                logger.warning("Unable to create campaign for '{0}' lot on {1}".format(lot_slug, framework_slug))
+                continue
+
+            # Build the email content
+            content_data = get_html_content(live_briefs, number_of_days)
+            logger.info(
+                "Setting campaign data for '{0}' framework, '{1}' lot and '{2}' campaign id".format(
+                    framework_slug, lot_slug, campaign_id
+                )
+            )
+            if not mailchimp_client.set_campaign_content(campaign_id, content_data):
+                logger.warning("Unable to set campaign data for campaign id '{0}'".format(campaign_id))
+                continue
+
+            # Send the emails
+            logger.info(
+                "Sending campaign for '{0}' framework, '{1}' lot and '{2}' campaign id".format(
+                    framework_slug, lot_slug, campaign_id
+                )
+            )
+            if not mailchimp_client.send_campaign(campaign_id):
+                logger.warning("Unable to send campaign for campaign id '{0}'".format(campaign_id))
+                continue
 
     return True

--- a/scripts/send-dos-opportunities-email.py
+++ b/scripts/send-dos-opportunities-email.py
@@ -5,9 +5,9 @@ Default behaviour is to fetch any briefs (regardless of framework/lot) published
 
 The script groups briefs by framework/lot, and for each combination, looks up the Mailchimp list ID, and creates &
 sends a new campaign.
-- If a framework_override is supplied, just find briefs for that framework
-- If a lot_override is supplied, just find briefs for that lot
-- If a list_id_override is supplied, only send emails to that list ID regardless of lot/framework
+- If a framework_slug is supplied, just find briefs for that framework
+- If a lot_slug is supplied, just find briefs for that lot
+- If a list_id is supplied, only send emails to that list ID regardless of lot/framework
 
 For testing purposes, you can override the list ID so you can send it to yourself only (use the sandbox list ID
 "096e52cebb").
@@ -37,7 +37,7 @@ Usage:
 
 Example:
     send-dos-opportunities-email.py
-        preview my.username@example.gov.uk myMailchimpKey digital-outcomes-and-specialists-3
+        preview my.username@example.gov.uk myMailchimpKey --framework_slug=digital-outcomes-and-specialists-3
         --number_of_days=3 --list_id=096e52cebb --lot_slug=digital-outcomes
 """
 

--- a/scripts/send-dos-opportunities-email.py
+++ b/scripts/send-dos-opportunities-email.py
@@ -31,8 +31,9 @@ line. Note, this may come in useful if the script was to fail halfway and you wi
 failed.
 
 Usage:
-    send-dos-opportunities-email.py <stage> <mailchimp_username> <mailchimp_api_key> <framework_slug>
+    send-dos-opportunities-email.py <stage> <mailchimp_username> <mailchimp_api_key>
         [--number_of_days=<number_of_days>] [--list_id=<list_id>] [--lot_slug=<lot_slug>]
+        [--framework_slug=<framework_slug>]
 
 Example:
     send-dos-opportunities-email.py
@@ -68,8 +69,7 @@ if __name__ == "__main__":
     number_of_days = arguments.get("--number_of_days")
     list_id = arguments.get("--list_id")
     lot_slug = arguments.get("--lot_slug")
-
-    framework_slug = arguments['<framework_slug>']
+    framework_slug = arguments.get("--framework_slug")
 
     # Override number of days
     if number_of_days:

--- a/scripts/send-dos-opportunities-email.py
+++ b/scripts/send-dos-opportunities-email.py
@@ -58,24 +58,6 @@ from dmutils.env_helpers import get_api_endpoint_from_stage
 logger = logging_helpers.configure_logger()
 
 
-MAILCHIMP_LIST_IDS = {
-    'digital-outcomes-and-specialists-2': {
-        'digital-specialists': "30ba9fdf39",
-        'digital-outcomes': "97952fee38",
-        'user-research-participants': "e6b93a3bce",
-    },
-    'digital-outcomes-and-specialists-3': {
-        'digital-specialists': "bee802d641",
-        'digital-outcomes': "5c92c78a78",
-        'user-research-participants': "34ebe0bffa",
-    },
-    'digital-outcomes-and-specialists-4': {
-        'digital-specialists': "29d06d5201",
-        'digital-outcomes': "4360debc5a",
-        'user-research-participants': "2538f8a0f1",
-    },
-}
-
 SANDBOX_LIST_ID = "096e52cebb"
 
 

--- a/scripts/send-dos-opportunities-email.py
+++ b/scripts/send-dos-opportunities-email.py
@@ -1,29 +1,34 @@
 #!/usr/bin/env python3
 
 """
-Description:
-    For every lot the script will:
-        - look for latest briefs for Digital Outcomes and Specialists
-        - if there are new briefs on that lot:
-            - it will create a Mailchimp campaign
-            - it will set the content of the campaign to be the briefs found
-            - it will send that campaign to the list_id as referenced in the `lots` variable
-        - if there are no new briefs on that lot no campaign is created or sent
+Default behaviour is to fetch any briefs (regardless of framework/lot) published in the last N days.
 
-    Number of days tells the script for how many days before current date it should include in its search for briefs
-        example:  if you run this script on a Wednesday and set number of days=1,
-                    then it will only include briefs from Tuesday (preceding day).
-        example2: if you run it on Wednesday and set number of days=3,
-                    then it will include all briefs published on Sunday, Monday and Tuesday.
-    By default, the script will send 3 days of briefs on a Monday (briefs from Fri, Sat, Sun) and 1 day on all other
-    days. This can be overrriden as described above.
+The script groups briefs by framework/lot, and for each combination, looks up the Mailchimp list ID, and creates &
+sends a new campaign.
+- If a framework_override is supplied, just find briefs for that framework
+- If a lot_override is supplied, just find briefs for that lot
+- If a list_id_override is supplied, only send emails to that list ID regardless of lot/framework
 
-    For testing purposes, you can override the list ID so you can send it to yourself only as
-    we have set up a testing list with ID "096e52cebb"
+For testing purposes, you can override the list ID so you can send it to yourself only (use the sandbox list ID
+"096e52cebb").
 
-    If you only need to send opportunities for one lot rather than all of them, you can also do this via the command
-    line. Note, this may come in useful if the script was to fail halfway and you wish to continue from the lot which
-    failed.
+For most of the year, there should only be one framework iteration with live briefs. However during the transition
+period between DOS framework iterations, we need to support both iterations.
+
+For example, on the second day of DOS4, any DOS3 briefs created the first day (before the go-live switchover) will
+still need to be emailed to DOS3 suppliers, as well as the usual DOS4 briefs sent to DOS4 suppliers.
+
+Number of days tells the script for how many days before current date it should include in its search for briefs
+    example:  if you run this script on a Wednesday and set number of days=1,
+                then it will only include briefs from Tuesday (preceding day).
+    example2: if you run it on Wednesday and set number of days=3,
+                then it will include all briefs published on Sunday, Monday and Tuesday.
+By default, the script will send 3 days of briefs on a Monday (briefs from Fri, Sat, Sun) and 1 day on all other
+days. This can be overriden as described above.
+
+If you only need to send opportunities for one lot rather than all of them, you can also do this via the command
+line. Note, this may come in useful if the script was to fail halfway and you wish to continue from the lot which
+failed.
 
 Usage:
     send-dos-opportunities-email.py <stage> <mailchimp_username> <mailchimp_api_key> <framework_slug>
@@ -31,8 +36,8 @@ Usage:
 
 Example:
     send-dos-opportunities-email.py
-        preview user@gds.gov.uk 7483crh87h34c3 digital-outcomes-and-specialists-3
-        --number_of_days=3 --list_id=988972hse --lot_slug=digital-outcomes
+        preview my.username@example.gov.uk myMailchimpKey digital-outcomes-and-specialists-3
+        --number_of_days=3 --list_id=096e52cebb --lot_slug=digital-outcomes
 """
 
 import sys
@@ -53,7 +58,7 @@ from dmutils.env_helpers import get_api_endpoint_from_stage
 logger = logging_helpers.configure_logger()
 
 
-list_ids = {
+MAILCHIMP_LIST_IDS = {
     'digital-outcomes-and-specialists-2': {
         'digital-specialists': "30ba9fdf39",
         'digital-outcomes': "97952fee38",
@@ -71,30 +76,22 @@ list_ids = {
     },
 }
 
+SANDBOX_LIST_ID = "096e52cebb"
+
+
 if __name__ == "__main__":
     arguments = docopt(__doc__)
+
+    stage = arguments['<stage>']
+    number_of_days = arguments.get("--number_of_days")
+    list_id = arguments.get("--list_id")
+    lot_slug = arguments.get("--lot_slug")
+
     framework_slug = arguments['<framework_slug>']
-    lots = [
-        {
-            "lot_slug": "digital-specialists",
-            "lot_name": "Digital specialists",
-            "list_id": list_ids[framework_slug]['digital-specialists']
-        },
-        {
-            "lot_slug": "digital-outcomes",
-            "lot_name": "Digital outcomes",
-            "list_id": list_ids[framework_slug]['digital-outcomes']
-        },
-        {
-            "lot_slug": "user-research-participants",
-            "lot_name": "User research participants",
-            "list_id": list_ids[framework_slug]['user-research-participants']
-        }
-    ]
 
     # Override number of days
-    if arguments.get("--number_of_days"):
-        number_of_days = int(arguments['--number_of_days'])
+    if number_of_days:
+        number_of_days = int(number_of_days)
     else:
         day_of_week = date.today().weekday()
         if day_of_week == 0:
@@ -102,35 +99,29 @@ if __name__ == "__main__":
         else:
             number_of_days = 1
 
-    # Override list for non-production environment
-    if arguments['<stage>'] != "production":
-        logger.info(
-            "The environment is not production. Emails will be sent to test list unless you set the list id manually."
-        )
-        for lot in lots:
-            lot.update({"list_id": "096e52cebb"})
+    # Override list IDs if supplied by script arg, or if environment is not production
+    if list_id:
+        logger.info("Sending to list ID {}".format(list_id))
+        list_id_override = list_id
+    elif stage != "production":
+        logger.info("The environment is not production. Emails will be sent to test list.")
+        list_id_override = SANDBOX_LIST_ID
+    else:
+        list_id_override = None
 
-    # Override list id
-    if arguments.get("--list_id"):
-        for lot in lots:
-            lot.update({"list_id": arguments["--list_id"]})
-
-    # Override lot
-    if arguments.get("--lot_slug"):
-        lots = [lot for lot in lots if lot["lot_slug"] == arguments["--lot_slug"]]
-
-    api_url = get_api_endpoint_from_stage(arguments['<stage>'])
-    data_api_client = DataAPIClient(api_url, get_auth_token('api', arguments['<stage>']))
+    api_url = get_api_endpoint_from_stage(stage)
+    data_api_client = DataAPIClient(api_url, get_auth_token('api', stage))
 
     dm_mailchimp_client = DMMailChimpClient(arguments['<mailchimp_username>'], arguments['<mailchimp_api_key>'], logger)
 
-    for lot_data in lots:
-        ok = main(
-            data_api_client=data_api_client,
-            mailchimp_client=dm_mailchimp_client,
-            lot_data=lot_data,
-            number_of_days=number_of_days,
-            framework_slug=framework_slug,
-        )
-        if not ok:
-            sys.exit(1)
+    ok = main(
+
+        data_api_client,
+        dm_mailchimp_client,
+        number_of_days,
+        framework_override=framework_slug,
+        list_id_override=list_id,
+        lot_slug_override=lot_slug
+    )
+    if not ok:
+        sys.exit(1)

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -374,7 +374,7 @@ class TestSendDOSOpportunitiesEmail:
             mock.call(self.data_api_client, date(2017, 4, 7), date(2017, 4, 9))
         ]
         assert logger.info.call_args_list == [
-            mock.call("No new briefs found for DOS frameworks in the last 3 day(s)", extra={"number_of_days": 3})
+            mock.call("No new briefs found for DOS frameworks in the last 3 day(s)")
         ]
 
     @mock.patch('dmscripts.send_dos_opportunities_email.logger', autospec=True)

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -1,7 +1,6 @@
 import mock
 from datetime import date
 
-import pytest
 from freezegun import freeze_time
 from lxml import html
 
@@ -9,20 +8,15 @@ from dmscripts.send_dos_opportunities_email import (
     main,
     get_campaign_data,
     get_live_briefs_between_two_dates,
+    get_live_briefs_by_framework_and_lot,
     get_html_content
 )
 from dmutils.email.dm_mailchimp import DMMailChimpClient
+from dmapiclient import DataAPIClient
 
 
-LOT_DATA = {
-    "lot_slug": "digital-specialists",
-    "lot_name": "Digital specialists",
-    "list_id": "096e52cebb"
-}
+class TestGetLiveBriefsBetweenTwoDates:
 
-
-def test_get_live_briefs_between_two_dates():
-    data_api_client = mock.Mock()
     brief_iter_values = [
         {"publishedAt": "2017-03-24T09:52:17.669156Z"},
         {"publishedAt": "2017-03-23T23:59:59.669156Z"},
@@ -36,187 +30,349 @@ def test_get_live_briefs_between_two_dates():
         {"publishedAt": "2017-02-17T09:52:17.669156Z"}
     ]
 
-    data_api_client.find_briefs_iter.return_value = iter(brief_iter_values)
-    briefs = get_live_briefs_between_two_dates(
-        data_api_client, "digital-specialists", date(2017, 3, 23), date(2017, 3, 23),
-        'digital-outcomes-and-specialists-7',
-    )
-    assert data_api_client.find_briefs_iter.call_args_list == [
-        mock.call(status="live", lot="digital-specialists", human=True, framework='digital-outcomes-and-specialists-7')
-    ]
-    assert briefs == [
-        {"publishedAt": "2017-03-23T23:59:59.669156Z"},
-        {"publishedAt": "2017-03-23T09:52:17.669156Z"},
-        {"publishedAt": "2017-03-23T00:00:00.000000Z"}
-    ]
+    def test_get_live_briefs_between_two_dates_single_day(self):
+        data_api_client = mock.Mock()
 
-    data_api_client.find_briefs_iter.return_value = iter(brief_iter_values)
-    briefs = get_live_briefs_between_two_dates(
-        data_api_client, "digital-specialists", date(2017, 3, 18), date(2017, 3, 20),
-        'digital-outcomes-and-specialists-1',
-    )
-    assert briefs == [
-        {"publishedAt": "2017-03-20T09:52:17.669156Z"},
-        {"publishedAt": "2017-03-19T09:52:17.669156Z"},
-        {"publishedAt": "2017-03-18T09:52:17.669156Z"}
-    ]
+        data_api_client.find_briefs_iter.return_value = iter(self.brief_iter_values)
 
+        briefs = get_live_briefs_between_two_dates(data_api_client, date(2017, 3, 23), date(2017, 3, 23),)
 
-ONE_BRIEF = [
-    {
-        "title": "Brief 1",
-        "organisation": "the big SME",
-        "location": "London",
-        "applicationsClosedAt": "2016-07-05T23:59:59.000000Z",
-        "id": "234",
-        "lotName": "Digital specialists"
-    },
-]
-MANY_BRIEFS = [
-    {
-        "title": "Brief 1",
-        "organisation": "the big SME",
-        "location": "London",
-        "applicationsClosedAt": "2016-07-05T23:59:59.000000Z",
-        "id": "234",
-        "lotName": "Digital specialists"
-    },
-    {
-        "title": "Brief 2",
-        "organisation": "ministry of weird steps",
-        "location": "Manchester",
-        "applicationsClosedAt": "2016-07-07T23:59:59.000000Z",
-        "id": "235",
-        "lotName": "Digital specialists"
-    }
-]
+        assert data_api_client.find_briefs_iter.call_args_list == [
+            mock.call(status="live", human=True)
+        ]
+        assert briefs == [
+            {"publishedAt": "2017-03-23T23:59:59.669156Z"},
+            {"publishedAt": "2017-03-23T09:52:17.669156Z"},
+            {"publishedAt": "2017-03-23T00:00:00.000000Z"}
+        ]
+
+    def test_get_live_briefs_between_two_dates_multi_day(self):
+        data_api_client = mock.Mock()
+        data_api_client.find_briefs_iter.return_value = iter(self.brief_iter_values)
+        briefs = get_live_briefs_between_two_dates(
+            data_api_client, date(2017, 3, 18), date(2017, 3, 20),
+
+        )
+        assert briefs == [
+            {"publishedAt": "2017-03-20T09:52:17.669156Z"},
+            {"publishedAt": "2017-03-19T09:52:17.669156Z"},
+            {"publishedAt": "2017-03-18T09:52:17.669156Z"}
+        ]
 
 
-def test_get_html_content_renders_brief_information():
-    with freeze_time('2017-04-19 08:00:00'):
-        html_content = get_html_content(ONE_BRIEF, 1)["html"]
+BRIEF_1 = {
+    "title": "Brief 1",
+    "organisation": "the big SME",
+    "location": "London",
+    "applicationsClosedAt": "2016-07-05T23:59:59.000000Z",
+    "id": "234",
+    "lotName": "Digital specialists",
+    "lotSlug": "digital-specialists",
+    "frameworkSlug": "digital-outcomes-and-specialists-3",
+    "frameworkName": "Digital Outcomes and Specialists 3"
+}
+
+
+BRIEF_2 = {
+    "title": "Brief 2",
+    "organisation": "ministry of weird steps",
+    "location": "Manchester",
+    "applicationsClosedAt": "2016-07-07T23:59:59.000000Z",
+    "id": "235",
+    "lotName": "Digital specialists",
+    "lotSlug": "digital-specialists",
+    "frameworkSlug": "digital-outcomes-and-specialists-3",
+    "frameworkName": "Digital Outcomes and Specialists 3"
+}
+
+BRIEF_3 = {
+    "title": "Brief 3",
+    "organisation": "ministry of OK steps",
+    "location": "Glasgow",
+    "applicationsClosedAt": "2016-07-08T23:59:59.000000Z",
+    "id": "236",
+    "lotName": "Digital outcomes",
+    "lotSlug": "digital-outcomes",
+    "frameworkSlug": "digital-outcomes-and-specialists-4",
+    "frameworkName": "Digital Outcomes and Specialists 4"
+}
+
+BRIEF_4 = {
+    "title": "Brief 4",
+    "organisation": "ministry of amazing steps",
+    "location": "Truro",
+    "applicationsClosedAt": "2016-07-08T23:59:59.000000Z",
+    "id": "237",
+    "lotName": "User research participants",
+    "lotSlug": "user-research-participants",
+    "frameworkSlug": "digital-outcomes-and-specialists-4",
+    "frameworkName": "Digital Outcomes and Specialists 4"
+}
+
+
+class TestGetHTMLContent:
+
+    def test_get_html_content_renders_brief_information(self):
+        with freeze_time('2017-04-19 08:00:00'):
+            html_content = get_html_content([BRIEF_1], 1)["html"]
+            doc = html.fromstring(html_content)
+
+            assert doc.xpath('//*[@class="opportunity-title"]')[0].text_content() == BRIEF_1["title"]
+            assert doc.xpath('//*[@class="opportunity-organisation"]')[0].text_content() == BRIEF_1["organisation"]
+            assert doc.xpath('//*[@class="opportunity-location"]')[0].text_content() == BRIEF_1["location"]
+            assert doc.xpath('//*[@class="opportunity-closing"]')[0].text_content() == "Closing Tuesday 5 July 2016"
+            assert doc.xpath('//a[@class="opportunity-link"]')[0].text_content() == "https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/234?utm_id=20170419"  # noqa
+
+    def test_get_html_content_renders_multiple_briefs(self):
+        html_content = get_html_content([BRIEF_1, BRIEF_2], 1)["html"]
         doc = html.fromstring(html_content)
+        brief_titles = doc.xpath('//*[@class="opportunity-title"]')
 
-        assert doc.xpath('//*[@class="opportunity-title"]')[0].text_content() == ONE_BRIEF[0]["title"]
-        assert doc.xpath('//*[@class="opportunity-organisation"]')[0].text_content() == ONE_BRIEF[0]["organisation"]
-        assert doc.xpath('//*[@class="opportunity-location"]')[0].text_content() == ONE_BRIEF[0]["location"]
-        assert doc.xpath('//*[@class="opportunity-closing"]')[0].text_content() == "Closing Tuesday 5 July 2016"
-        assert doc.xpath('//a[@class="opportunity-link"]')[0].text_content() == "https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/234?utm_id=20170419"  # noqa
+        assert "2 new digital specialists opportunities were published" in html_content
+        assert "View and apply for these opportunities:" in html_content
 
+        assert len(brief_titles) == 2
+        assert brief_titles[0].text_content() == "Brief 1"
+        assert brief_titles[1].text_content() == "Brief 2"
 
-def test_get_html_content_renders_multiple_briefs():
-    html_content = get_html_content(MANY_BRIEFS, 1)["html"]
-    doc = html.fromstring(html_content)
-    brief_titles = doc.xpath('//*[@class="opportunity-title"]')
+    def test_get_html_content_renders_singular_for_single_brief(self):
+        html_content = get_html_content([BRIEF_1], 1)["html"]
+        doc = html.fromstring(html_content)
+        brief_titles = doc.xpath('//*[@class="opportunity-title"]')
 
-    assert "2 new digital specialists opportunities were published" in html_content
-    assert "View and apply for these opportunities:" in html_content
+        assert "1 new digital specialists opportunity was published" in html_content
+        assert "View and apply for this opportunity:" in html_content
 
-    assert len(brief_titles) == 2
-    assert brief_titles[0].text_content() == "Brief 1"
-    assert brief_titles[1].text_content() == "Brief 2"
+        assert len(brief_titles) == 1
+        assert brief_titles[0].text_content() == "Brief 1"
 
+    def test_get_html_content_with_briefs_from_last_day(self):
+        html_content = get_html_content([BRIEF_1], 1)["html"]
+        assert "In the last day" in html_content
 
-def test_get_html_content_renders_singular_for_single_brief():
-    html_content = get_html_content(ONE_BRIEF, 1)["html"]
-    doc = html.fromstring(html_content)
-    brief_titles = doc.xpath('//*[@class="opportunity-title"]')
-
-    assert "1 new digital specialists opportunity was published" in html_content
-    assert "View and apply for this opportunity:" in html_content
-
-    assert len(brief_titles) == 1
-    assert brief_titles[0].text_content() == "Brief 1"
+    def test_get_html_content_with_briefs_from_several_days(self):
+        with freeze_time('2017-04-17 08:00:00'):
+            html_content = get_html_content([BRIEF_1], 3)["html"]
+            assert "Since Friday" in html_content
 
 
-def test_get_html_content_with_briefs_from_last_day():
-    html_content = get_html_content(ONE_BRIEF, 1)["html"]
-    assert "In the last day" in html_content
+class TestGetCampaignData:
+
+    def test_get_campaign_data(self):
+        framework_name = "Digit Outcomes and Specialists Two"
+        lot_name = "Digital Somethings"
+        list_id = "1111111"
+
+        with freeze_time('2017-04-19 08:00:00'):
+            campaign_data = get_campaign_data(lot_name, list_id, framework_name)
+            assert campaign_data["recipients"]["list_id"] == list_id
+            assert campaign_data["settings"]["subject_line"] == f"New opportunities for {lot_name}: {framework_name}"
+            assert campaign_data["settings"]["title"] == f"DOS Suppliers: {lot_name} [19 April]"
+            assert campaign_data["settings"]["from_name"] == "Digital Marketplace Team"
+            assert campaign_data["settings"]["reply_to"] == "do-not-reply@digitalmarketplace.service.gov.uk"
 
 
-def test_get_html_content_with_briefs_from_several_days():
-    with freeze_time('2017-04-17 08:00:00'):
-        html_content = get_html_content(ONE_BRIEF, 3)["html"]
-        assert "Since Friday" in html_content
+class TestGetLiveBriefsByFrameworkAndLot:
+
+    @mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates', autospec=True)
+    def test_get_live_briefs_by_framework_and_lot_groups_briefs_by_framework(self, get_live_briefs_between_two_dates):
+        client = mock.Mock(spec=DataAPIClient)
+        get_live_briefs_between_two_dates.return_value = [BRIEF_1, BRIEF_2, BRIEF_3, BRIEF_4]
+
+        result = get_live_briefs_by_framework_and_lot(client, date(2017, 4, 18), date(2017, 4, 18))
+        assert result == {
+            'digital-outcomes-and-specialists-3': {
+                'digital-specialists': [BRIEF_1, BRIEF_2]
+            },
+            'digital-outcomes-and-specialists-4': {
+                'digital-outcomes': [BRIEF_3],
+                'user-research-participants': [BRIEF_4],
+            }
+        }
+        assert get_live_briefs_between_two_dates.call_args_list == [
+            mock.call(client, date(2017, 4, 18), date(2017, 4, 18))
+        ]
 
 
-def test_get_campaign_data():
-    framework_name = "Digit Outcomes and Specialists Two"
-    lot_name = "Digital Somethings"
-    list_id = "1111111"
+@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_by_framework_and_lot', autospec=True)
+class TestSendDOSOpportunitiesEmail:
 
-    with freeze_time('2017-04-19 08:00:00'):
-        campaign_data = get_campaign_data(lot_name, list_id, framework_name)
-        assert campaign_data["recipients"]["list_id"] == list_id
-        assert campaign_data["settings"]["subject_line"] == f"New opportunities for {lot_name}: {framework_name}"
-        assert campaign_data["settings"]["title"] == f"DOS Suppliers: {lot_name} [19 April]"
-        assert campaign_data["settings"]["from_name"] == "Digital Marketplace Team"
-        assert campaign_data["settings"]["reply_to"] == "do-not-reply@digitalmarketplace.service.gov.uk"
+    def setup_method(self):
+        self.data_api_client = mock.Mock(spec=DataAPIClient)
+        self.dm_mailchimp_client = mock.Mock(spec=DMMailChimpClient)
 
+    @mock.patch('dmscripts.send_dos_opportunities_email.get_html_content', autospec=True)
+    @mock.patch('dmscripts.send_dos_opportunities_email.get_campaign_data', autospec=True)
+    def test_main_creates_campaign_sets_content_and_sends_campaign_for_all_frameworks_and_lots(
+        self, get_campaign_data, get_html_content, get_live_briefs_by_framework_and_lot
+    ):
+        get_live_briefs_by_framework_and_lot.return_value = {
+            'digital-outcomes-and-specialists-3': {
+                'digital-specialists': [BRIEF_1, BRIEF_2]
+            },
+            'digital-outcomes-and-specialists-4': {
+                'digital-outcomes': [BRIEF_3],
+                'user-research-participants': [BRIEF_4],
+            }
+        }
+        get_campaign_data.return_value = {"created": "campaign"}
+        get_html_content.return_value = {"first": "content"}
+        self.dm_mailchimp_client.create_campaign.return_value = "1"
 
-@pytest.mark.parametrize(
-    ('framework_name'), ('Digital Outcomes and Specialists 2', 'Digital Outcomes and Specialists 3')
-)
-@mock.patch('dmscripts.send_dos_opportunities_email.get_html_content', autospec=True)
-@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates', autospec=True)
-@mock.patch('dmscripts.send_dos_opportunities_email.get_campaign_data', autospec=True)
-def test_main_creates_campaign_sets_content_and_sends_campaign(
-    get_campaign_data, get_live_briefs_between_two_dates, get_html_content, framework_name
-):
-    live_briefs = [
-        {"brief": "yaytest", "frameworkName": framework_name},
-    ]
-    get_live_briefs_between_two_dates.return_value = live_briefs
-    get_campaign_data.return_value = {"created": "campaign"}
-    get_html_content.return_value = {"first": "content"}
-
-    dm_mailchimp_client = mock.MagicMock(spec=DMMailChimpClient)
-    dm_mailchimp_client.create_campaign.return_value = "1"
-    main(mock.MagicMock(), dm_mailchimp_client, LOT_DATA, 1, framework_name)
-
-    # Creates campaign
-    get_campaign_data.assert_called_once_with("Digital specialists", "096e52cebb", framework_name)
-    dm_mailchimp_client.create_campaign.assert_called_once_with({"created": "campaign"})
-
-    # Sets campaign content
-    get_html_content.assert_called_once_with(live_briefs, 1)
-    dm_mailchimp_client.set_campaign_content.assert_called_once_with("1", {"first": "content"})
-
-    # Sends campaign
-    dm_mailchimp_client.send_campaign.assert_called_once_with("1")
-
-
-@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates', autospec=True)
-def test_main_gets_live_briefs_for_one_day(get_live_briefs_between_two_dates):
-    with freeze_time('2017-04-19 08:00:00'):
-        main(mock.MagicMock(), mock.MagicMock(), LOT_DATA, 1, 'Digital Outcomes and Specialists')
-        get_live_briefs_between_two_dates.assert_called_once_with(
-            mock.ANY, "digital-specialists", date(2017, 4, 18), date(2017, 4, 18), 'Digital Outcomes and Specialists'
+        assert main(
+            self.data_api_client,
+            self.dm_mailchimp_client,
+            1,
+            framework_override=None,
+            list_id_override="096e52cebb",
+            lot_slug_override=None
         )
 
+        # Creates 3 campaigns
+        assert get_campaign_data.call_args_list == [
+            mock.call("Digital specialists", "096e52cebb", 'Digital Outcomes and Specialists 3'),
+            mock.call("Digital outcomes", "096e52cebb", 'Digital Outcomes and Specialists 4'),
+            mock.call("User research participants", "096e52cebb", 'Digital Outcomes and Specialists 4')
+        ]
+        assert self.dm_mailchimp_client.create_campaign.call_args_list == [
+            mock.call({"created": "campaign"}),
+            mock.call({"created": "campaign"}),
+            mock.call({"created": "campaign"})
+        ]
 
-@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates', autospec=True)
-def test_main_gets_live_briefs_for_three_days(get_live_briefs_between_two_dates):
-    with freeze_time('2017-04-10 08:00:00'):
-        main(mock.MagicMock(), mock.MagicMock(), LOT_DATA, 3, 'Digital Outcomes and Specialists')
-        get_live_briefs_between_two_dates.assert_called_once_with(
-            mock.ANY, "digital-specialists", date(2017, 4, 7), date(2017, 4, 9), 'Digital Outcomes and Specialists'
+        # Sets campaign content
+        assert get_html_content.call_args_list == [
+            mock.call([BRIEF_1, BRIEF_2], 1),
+            mock.call([BRIEF_3], 1),
+            mock.call([BRIEF_4], 1),
+        ]
+        assert self.dm_mailchimp_client.set_campaign_content.call_args_list == [
+            mock.call("1", {"first": "content"}),
+            mock.call("1", {"first": "content"}),
+            mock.call("1", {"first": "content"})
+        ]
+
+        # Sends campaign
+        assert self.dm_mailchimp_client.send_campaign.call_args_list == [
+            mock.call("1"),
+            mock.call("1"),
+            mock.call("1")
+        ]
+
+    def test_main_gets_live_briefs_for_one_day_by_default(self, get_live_briefs_by_framework_and_lot):
+        with freeze_time('2017-04-19 08:00:00'):
+            main(
+                self.data_api_client,
+                self.dm_mailchimp_client,
+                1,
+                framework_override=None,
+                list_id_override=None,
+                lot_slug_override=None
+            )
+        assert get_live_briefs_by_framework_and_lot.call_args_list == [
+            mock.call(mock.ANY, date(2017, 4, 18), date(2017, 4, 18))
+        ]
+
+    def test_main_can_get_live_briefs_for_three_days(self, get_live_briefs_by_framework_and_lot):
+        with freeze_time('2017-04-10 08:00:00'):
+            main(
+                self.data_api_client,
+                self.dm_mailchimp_client,
+                number_of_days=3,
+                framework_override=None,
+                list_id_override=None,
+                lot_slug_override=None
+            )
+        assert get_live_briefs_by_framework_and_lot.call_args_list == [
+            mock.call(mock.ANY, date(2017, 4, 7), date(2017, 4, 9))
+        ]
+
+    @mock.patch('dmscripts.send_dos_opportunities_email.get_html_content', autospec=True)
+    @mock.patch('dmscripts.send_dos_opportunities_email.get_campaign_data', autospec=True)
+    def test_override_framework_only_sends_for_that_framework(
+            self, get_campaign_data, get_html_content, get_live_briefs_by_framework_and_lot):
+        get_live_briefs_by_framework_and_lot.return_value = {
+            'digital-outcomes-and-specialists-3': {
+                'digital-specialists': [BRIEF_1, BRIEF_2]
+            },
+            'digital-outcomes-and-specialists-4': {
+                'digital-outcomes': [BRIEF_3],
+                'user-research-participants': [BRIEF_4],
+            }
+        }
+        get_campaign_data.return_value = {"created": "campaign"}
+        get_html_content.return_value = {"first": "content"}
+        self.dm_mailchimp_client.create_campaign.return_value = "1"
+
+        assert main(
+            self.data_api_client,
+            self.dm_mailchimp_client,
+            1,
+            framework_override="digital-outcomes-and-specialists-3",
+            list_id_override="096e52cebb",
+            lot_slug_override=None
         )
 
+        # Creates 1 campaign for Briefs 1 and 2
+        assert get_campaign_data.call_args_list == [
+            mock.call("Digital specialists", "096e52cebb", 'Digital Outcomes and Specialists 3'),
+        ]
+        assert get_html_content.call_args_list == [mock.call([BRIEF_1, BRIEF_2], 1)]
 
-@mock.patch('dmscripts.send_dos_opportunities_email.logger', autospec=True)
-@mock.patch('dmscripts.send_dos_opportunities_email.get_live_briefs_between_two_dates', autospec=True)
-def test_if_no_briefs_then_no_campaign_created_nor_sent(get_live_briefs_between_two_dates, logger):
-    get_live_briefs_between_two_dates.return_value = []
+    @mock.patch('dmscripts.send_dos_opportunities_email.get_html_content', autospec=True)
+    @mock.patch('dmscripts.send_dos_opportunities_email.get_campaign_data', autospec=True)
+    def test_override_lot_only_sends_for_that_lot(
+            self, get_campaign_data, get_html_content, get_live_briefs_by_framework_and_lot):
+        get_live_briefs_by_framework_and_lot.return_value = {
+            'digital-outcomes-and-specialists-3': {
+                'digital-specialists': [BRIEF_1, BRIEF_2]
+            },
+            'digital-outcomes-and-specialists-4': {
+                'digital-outcomes': [BRIEF_3],
+                'user-research-participants': [BRIEF_4],
+            }
+        }
+        get_campaign_data.return_value = {"created": "campaign"}
+        get_html_content.return_value = {"first": "content"}
+        self.dm_mailchimp_client.create_campaign.return_value = "1"
 
-    dm_mailchimp_client = mock.MagicMock(DMMailChimpClient)
-    result = main(mock.MagicMock(), dm_mailchimp_client, LOT_DATA, 3, 'Digital Outcomes and Specialists')
+        assert main(
+            self.data_api_client,
+            self.dm_mailchimp_client,
+            1,
+            framework_override=None,
+            list_id_override="096e52cebb",
+            lot_slug_override='digital-outcomes'
+        )
 
-    assert result is True
-    assert dm_mailchimp_client.create_campaign.call_count == 0
-    assert dm_mailchimp_client.set_campaign_content.call_count == 0
-    assert dm_mailchimp_client.send_campaign.call_count == 0
+        # Creates 1 campaign for Brief 3
+        assert get_campaign_data.call_args_list == [
+            mock.call("Digital outcomes", "096e52cebb", 'Digital Outcomes and Specialists 4'),
+        ]
+        assert get_html_content.call_args_list == [mock.call([BRIEF_3], 1)]
 
-    logger.info.assert_called_with(
-        "No new briefs found for 'digital-specialists' lot", extra={"number_of_days": 3}
-    )
+    @mock.patch('dmscripts.send_dos_opportunities_email.logger', autospec=True)
+    def test_if_no_briefs_then_no_campaign_created_nor_sent(self, logger, get_live_briefs_by_framework_and_lot):
+        get_live_briefs_by_framework_and_lot.return_value = {}
+
+        with freeze_time('2017-04-10 08:00:00'):
+            result = main(
+                self.data_api_client,
+                self.dm_mailchimp_client,
+                number_of_days=3,
+                framework_override=None,
+                list_id_override=None,
+                lot_slug_override=None
+            )
+
+        assert result is True
+        assert self.dm_mailchimp_client.create_campaign.call_count == 0
+        assert self.dm_mailchimp_client.set_campaign_content.call_count == 0
+        assert self.dm_mailchimp_client.send_campaign.call_count == 0
+
+        assert get_live_briefs_by_framework_and_lot.call_args_list == [
+            mock.call(self.data_api_client, date(2017, 4, 7), date(2017, 4, 9))
+        ]
+        assert logger.info.call_args_list == [
+            mock.call("No new briefs found for DOS frameworks in the last 3 day(s)", extra={"number_of_days": 3})
+        ]

--- a/tests/test_send_dos_opportunities_email.py
+++ b/tests/test_send_dos_opportunities_email.py
@@ -219,20 +219,13 @@ class TestSendDOSOpportunitiesEmail:
         get_html_content.return_value = {"first": "content"}
         self.dm_mailchimp_client.create_campaign.return_value = "1"
 
-        assert main(
-            self.data_api_client,
-            self.dm_mailchimp_client,
-            1,
-            framework_override=None,
-            list_id_override="096e52cebb",
-            lot_slug_override=None
-        )
+        assert main(self.data_api_client, self.dm_mailchimp_client, number_of_days=1)
 
         # Creates 3 campaigns
         assert get_campaign_data.call_args_list == [
-            mock.call("Digital specialists", "096e52cebb", 'Digital Outcomes and Specialists 3'),
-            mock.call("Digital outcomes", "096e52cebb", 'Digital Outcomes and Specialists 4'),
-            mock.call("User research participants", "096e52cebb", 'Digital Outcomes and Specialists 4')
+            mock.call("Digital specialists", "bee802d641", 'Digital Outcomes and Specialists 3'),
+            mock.call("Digital outcomes", "4360debc5a", 'Digital Outcomes and Specialists 4'),
+            mock.call("User research participants", "2538f8a0f1", 'Digital Outcomes and Specialists 4')
         ]
         assert self.dm_mailchimp_client.create_campaign.call_args_list == [
             mock.call({"created": "campaign"}),
@@ -261,28 +254,16 @@ class TestSendDOSOpportunitiesEmail:
 
     def test_main_gets_live_briefs_for_one_day_by_default(self, get_live_briefs_by_framework_and_lot):
         with freeze_time('2017-04-19 08:00:00'):
-            main(
-                self.data_api_client,
-                self.dm_mailchimp_client,
-                1,
-                framework_override=None,
-                list_id_override=None,
-                lot_slug_override=None
-            )
+            main(self.data_api_client, self.dm_mailchimp_client, number_of_days=1)
+
         assert get_live_briefs_by_framework_and_lot.call_args_list == [
             mock.call(mock.ANY, date(2017, 4, 18), date(2017, 4, 18))
         ]
 
     def test_main_can_get_live_briefs_for_three_days(self, get_live_briefs_by_framework_and_lot):
         with freeze_time('2017-04-10 08:00:00'):
-            main(
-                self.data_api_client,
-                self.dm_mailchimp_client,
-                number_of_days=3,
-                framework_override=None,
-                list_id_override=None,
-                lot_slug_override=None
-            )
+            main(self.data_api_client, self.dm_mailchimp_client, number_of_days=3)
+
         assert get_live_briefs_by_framework_and_lot.call_args_list == [
             mock.call(mock.ANY, date(2017, 4, 7), date(2017, 4, 9))
         ]
@@ -307,15 +288,13 @@ class TestSendDOSOpportunitiesEmail:
         assert main(
             self.data_api_client,
             self.dm_mailchimp_client,
-            1,
-            framework_override="digital-outcomes-and-specialists-3",
-            list_id_override="096e52cebb",
-            lot_slug_override=None
+            number_of_days=1,
+            framework_override="digital-outcomes-and-specialists-3"
         )
 
         # Creates 1 campaign for Briefs 1 and 2
         assert get_campaign_data.call_args_list == [
-            mock.call("Digital specialists", "096e52cebb", 'Digital Outcomes and Specialists 3'),
+            mock.call("Digital specialists", "bee802d641", 'Digital Outcomes and Specialists 3'),
         ]
         assert get_html_content.call_args_list == [mock.call([BRIEF_1, BRIEF_2], 1)]
 
@@ -339,15 +318,13 @@ class TestSendDOSOpportunitiesEmail:
         assert main(
             self.data_api_client,
             self.dm_mailchimp_client,
-            1,
-            framework_override=None,
-            list_id_override="096e52cebb",
+            number_of_days=1,
             lot_slug_override='digital-outcomes'
         )
 
         # Creates 1 campaign for Brief 3
         assert get_campaign_data.call_args_list == [
-            mock.call("Digital outcomes", "096e52cebb", 'Digital Outcomes and Specialists 4'),
+            mock.call("Digital outcomes", "4360debc5a", 'Digital Outcomes and Specialists 4'),
         ]
         assert get_html_content.call_args_list == [mock.call([BRIEF_3], 1)]
 
@@ -356,14 +333,7 @@ class TestSendDOSOpportunitiesEmail:
         get_live_briefs_by_framework_and_lot.return_value = {}
 
         with freeze_time('2017-04-10 08:00:00'):
-            result = main(
-                self.data_api_client,
-                self.dm_mailchimp_client,
-                number_of_days=3,
-                framework_override=None,
-                list_id_override=None,
-                lot_slug_override=None
-            )
+            result = main(self.data_api_client, self.dm_mailchimp_client, number_of_days=3)
 
         assert result is True
         assert self.dm_mailchimp_client.create_campaign.call_count == 0
@@ -392,9 +362,7 @@ class TestSendDOSOpportunitiesEmail:
                 self.data_api_client,
                 self.dm_mailchimp_client,
                 number_of_days=1,
-                framework_override='digital-outcomes-and-specialists-4',
-                list_id_override=None,
-                lot_slug_override=None
+                framework_override='digital-outcomes-and-specialists-4'
             )
 
         assert result is True


### PR DESCRIPTION
https://trello.com/c/58q6lRKF/33-update-dos4-regular-email-jobs

Basically a total rewrite of the DOS opportunities email script, that we send via Mailchimp. Previously the script took a `framework` arg, and could only be run for that framework. That meant that on the day after go-live, we'd have to manually run a catchup script to 'catch' the previous iteration's briefs that had been created before the switchover. 

The docstring has a thorough description of what's meant to be happening but the tl;dr is that the script should get all live briefs, sort them into framework/lot lists, and create/send the campaigns for each list. 

Comments very welcome. 

Changes to the equivalent Jenkins job: https://github.com/alphagov/digitalmarketplace-jenkins/pull/268