### PR TITLE
DOS lot export scripts improvements

### DIFF
--- a/dmscripts/helpers/csv_helpers.py
+++ b/dmscripts/helpers/csv_helpers.py
@@ -3,6 +3,7 @@
 import collections
 import os
 import sys
+from datetime import date
 
 if sys.version_info > (3, 0):
     import csv
@@ -149,7 +150,7 @@ def write_csv(headers, rows_iter, filename):
             writer.writerow(dict(row))
 
 
-def write_csv_with_make_row(records, make_row, filename):
+def write_csv_with_make_row(records, make_row, filename, include_last_updated=True):
     """Write a list of records out to CSV, using a custom make_row method to convert records to rows"""
     def fieldnames(row):
         return [field[0] for field in row]
@@ -165,3 +166,6 @@ def write_csv_with_make_row(records, make_row, filename):
                 writer = csv.DictWriter(f, fieldnames=fieldnames(row))
                 writer.writeheader()
             writer.writerow(dict(row))
+
+        if include_last_updated:
+            f.write("Last updated {}".format(date.today().strftime("%d %B %Y")))

--- a/dmscripts/helpers/csv_helpers.py
+++ b/dmscripts/helpers/csv_helpers.py
@@ -104,7 +104,7 @@ def _make_fields_from_content_question(question, record):
                 make_field_title(question.id, option["label"]),
                 count_field_in_record(question.id, option["label"], record)
             )
-    elif question.fields:
+    elif hasattr(question, 'fields'):
         for field_id in sorted(question.fields.values()):
             # Make a CSV column containing all values
             yield (

--- a/scripts/export-dos-labs.py
+++ b/scripts/export-dos-labs.py
@@ -83,5 +83,5 @@ if __name__ == '__main__':
     logger.info(f"Finding suppliers for Digital Outcomes on {FRAMEWORK_SLUG}")
     write_labs_csv(
         find_all_labs(client, map_impl=pool.imap),
-        os.path.join(OUTPUT_DIR, "{}-labs.csv".format(FRAMEWORK_SLUG))
+        os.path.join(OUTPUT_DIR, "user-research-studios.csv".format(FRAMEWORK_SLUG))
     )

--- a/scripts/export-dos-labs.py
+++ b/scripts/export-dos-labs.py
@@ -4,10 +4,15 @@
 For a DOS-type framework this will export details of all "user-research-studios" services.
 
 Usage:
-    scripts/export-dos-labs.py <stage> <framework_slug> [--verbose]
+    scripts/export-dos-labs.py <stage> <framework_slug> [options]
+
+Options:
+    -v --verbose                Print INFO level messages.
+    --output-dir=<output_dir>   Directory to write csv files to [default: output]
 """
 import itertools
 from multiprocessing.pool import ThreadPool
+import os
 import sys
 sys.path.insert(0, '.')
 
@@ -60,15 +65,23 @@ if __name__ == '__main__':
 
     STAGE = arguments['<stage>']
     FRAMEWORK_SLUG = arguments['<framework_slug>']
+    OUTPUT_DIR = arguments['--output-dir']
     verbose = arguments['--verbose']
 
     logger = logging_helpers.configure_logger(
         {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
     )
 
+    if not os.path.exists(OUTPUT_DIR):
+        logger.info("Creating {} directory".format(OUTPUT_DIR))
+        os.makedirs(OUTPUT_DIR)
+
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))
 
     pool = ThreadPool(3)
 
     logger.info(f"Finding suppliers for Digital Outcomes on {FRAMEWORK_SLUG}")
-    write_labs_csv(find_all_labs(client, map_impl=pool.imap), "output/{}-labs.csv".format(FRAMEWORK_SLUG))
+    write_labs_csv(
+        find_all_labs(client, map_impl=pool.imap),
+        os.path.join(OUTPUT_DIR, "{}-labs.csv".format(FRAMEWORK_SLUG))
+    )

--- a/scripts/export-dos-labs.py
+++ b/scripts/export-dos-labs.py
@@ -4,18 +4,20 @@
 For a DOS-type framework this will export details of all "user-research-studios" services.
 
 Usage:
-    scripts/export-dos-labs.py <stage> <framework_slug>
+    scripts/export-dos-labs.py <stage> <framework_slug> [--verbose]
 """
 import itertools
 from multiprocessing.pool import ThreadPool
 import sys
 sys.path.insert(0, '.')
 
+import logging
 from docopt import docopt
 from dmapiclient import DataAPIClient
 
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.framework_helpers import find_suppliers_with_details_and_draft_services
+from dmscripts.helpers import logging_helpers
 from dmscripts.export_dos_labs import append_contact_information_to_services
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
@@ -58,9 +60,15 @@ if __name__ == '__main__':
 
     STAGE = arguments['<stage>']
     FRAMEWORK_SLUG = arguments['<framework_slug>']
+    verbose = arguments['--verbose']
+
+    logger = logging_helpers.configure_logger(
+        {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
+    )
 
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))
 
     pool = ThreadPool(3)
 
+    logger.info(f"Finding suppliers for Digital Outcomes on {FRAMEWORK_SLUG}")
     write_labs_csv(find_all_labs(client, map_impl=pool.imap), "output/{}-labs.csv".format(FRAMEWORK_SLUG))

--- a/scripts/export-dos-labs.py
+++ b/scripts/export-dos-labs.py
@@ -47,9 +47,10 @@ def find_all_labs(client, map_impl=map):
     return services
 
 
-def write_labs_csv(services, filename):
+def write_labs_csv(services, filename, logger=None):
     writer = None
     bad_fields = ['links']
+    logger.info(f"Building CSV for User Research Studios")
 
     with open(filename, "w+") as f:
         for service in services:
@@ -80,8 +81,9 @@ if __name__ == '__main__':
 
     pool = ThreadPool(3)
 
-    logger.info(f"Finding suppliers for Digital Outcomes on {FRAMEWORK_SLUG}")
+    logger.info(f"Finding suppliers for User Research Studios on {FRAMEWORK_SLUG}")
     write_labs_csv(
         find_all_labs(client, map_impl=pool.imap),
-        os.path.join(OUTPUT_DIR, "user-research-studios.csv".format(FRAMEWORK_SLUG))
+        os.path.join(OUTPUT_DIR, "user-research-studios.csv"),
+        logger=logger
     )

--- a/scripts/export-dos-outcomes.py
+++ b/scripts/export-dos-outcomes.py
@@ -101,5 +101,5 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         suppliers,
         make_row(capabilities, locations),
-        os.path.join(OUTPUT_DIR, "{}-outcomes.csv".format(FRAMEWORK_SLUG))
+        os.path.join(OUTPUT_DIR, "digital-outcomes-suppliers.csv".format(FRAMEWORK_SLUG))
     )

--- a/scripts/export-dos-outcomes.py
+++ b/scripts/export-dos-outcomes.py
@@ -101,5 +101,6 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         suppliers,
         make_row(capabilities, locations),
-        os.path.join(OUTPUT_DIR, "digital-outcomes-suppliers.csv".format(FRAMEWORK_SLUG))
+        os.path.join(OUTPUT_DIR, "digital-outcomes-suppliers.csv".format(FRAMEWORK_SLUG)),
+        include_last_updated=True
     )

--- a/scripts/export-dos-outcomes.py
+++ b/scripts/export-dos-outcomes.py
@@ -5,9 +5,14 @@ For a DOS-type framework this will export details of all "digital-outcomes" serv
 of outcome the supplier provides and the locations they can provide them in.
 
 Usage:
-    scripts/export-dos-outcomes.py <stage> <framework_slug> <content_path> [--verbose]
+    scripts/export-dos-outcomes.py <stage> <framework_slug> <content_path> [options]
+
+Options:
+    -v --verbose                Print INFO level messages.
+    --output-dir=<output_dir>   Directory to write csv files to [default: output]
 """
 from multiprocessing.pool import ThreadPool
+import os
 import sys
 sys.path.insert(0, '.')
 
@@ -67,11 +72,16 @@ if __name__ == '__main__':
     STAGE = arguments['<stage>']
     CONTENT_PATH = arguments['<content_path>']
     FRAMEWORK_SLUG = arguments['<framework_slug>']
+    OUTPUT_DIR = arguments['--output-dir']
     verbose = arguments['--verbose']
 
     logger = logging_helpers.configure_logger(
         {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
     )
+
+    if not os.path.exists(OUTPUT_DIR):
+        logger.info("Creating {} directory".format(OUTPUT_DIR))
+        os.makedirs(OUTPUT_DIR)
 
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))
 
@@ -91,5 +101,5 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         suppliers,
         make_row(capabilities, locations),
-        "output/{}-outcomes.csv".format(FRAMEWORK_SLUG)
+        os.path.join(OUTPUT_DIR, "{}-outcomes.csv".format(FRAMEWORK_SLUG))
     )

--- a/scripts/export-dos-outcomes.py
+++ b/scripts/export-dos-outcomes.py
@@ -101,6 +101,6 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         suppliers,
         make_row(capabilities, locations),
-        os.path.join(OUTPUT_DIR, "digital-outcomes-suppliers.csv".format(FRAMEWORK_SLUG)),
+        os.path.join(OUTPUT_DIR, "digital-outcomes-suppliers.csv"),
         include_last_updated=True
     )

--- a/scripts/export-dos-participants.py
+++ b/scripts/export-dos-participants.py
@@ -38,8 +38,7 @@ def find_all_participants(client, map_impl=map):
 def make_row(content_manifest):
     question_ids = ["recruitMethods", "recruitFromList", "locations"]
     questions = [content_manifest.get_question(question_id) for question_id in question_ids]
-    for question in questions:
-        print(question["id"], question.fields, question.id)
+
 
     def inner(record):
         row = [

--- a/scripts/export-dos-participants.py
+++ b/scripts/export-dos-participants.py
@@ -43,7 +43,6 @@ def make_row(content_manifest):
     question_ids = ["recruitMethods", "recruitFromList", "locations"]
     questions = [content_manifest.get_question(question_id) for question_id in question_ids]
 
-
     def inner(record):
         row = [
             ("supplier_id", record["supplier_id"]),

--- a/scripts/export-dos-participants.py
+++ b/scripts/export-dos-participants.py
@@ -87,5 +87,6 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         records,
         make_row(content_manifest),
-        os.path.join(OUTPUT_DIR, "user-research-participants-suppliers.csv".format(FRAMEWORK_SLUG))
+        os.path.join(OUTPUT_DIR, "user-research-participants-suppliers.csv".format(FRAMEWORK_SLUG)),
+        include_last_updated=True
     )

--- a/scripts/export-dos-participants.py
+++ b/scripts/export-dos-participants.py
@@ -5,9 +5,15 @@ For a DOS-type framework this will export details of all "user-research-particip
 recruitment methods the supplier provides and the locations they can provide them in.
 
 Usage:
-    scripts/export-dos-participants.py <stage> <framework_slug> <content_path> [--verbose]
+    scripts/export-dos-participants.py <stage> <framework_slug> <content_path> [options]
+
+Options:
+    -v --verbose                Print INFO level messages.
+    --output-dir=<output_dir>   Directory to write csv files to [default: output]
+
 """
 from multiprocessing.pool import ThreadPool
+import os
 import sys
 sys.path.insert(0, '.')
 
@@ -56,11 +62,16 @@ if __name__ == '__main__':
     STAGE = arguments['<stage>']
     CONTENT_PATH = arguments['<content_path>']
     FRAMEWORK_SLUG = arguments['<framework_slug>']
+    OUTPUT_DIR = arguments['--output-dir']
     verbose = arguments['--verbose']
 
     logger = logging_helpers.configure_logger(
         {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
     )
+
+    if not os.path.exists(OUTPUT_DIR):
+        logger.info("Creating {} directory".format(OUTPUT_DIR))
+        os.makedirs(OUTPUT_DIR)
 
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))
 
@@ -77,5 +88,5 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         records,
         make_row(content_manifest),
-        "output/{}-user-research-participants.csv".format(FRAMEWORK_SLUG)
+        os.path.join(OUTPUT_DIR, "{}-user-research-participants.csv".format(FRAMEWORK_SLUG))
     )

--- a/scripts/export-dos-participants.py
+++ b/scripts/export-dos-participants.py
@@ -5,12 +5,13 @@ For a DOS-type framework this will export details of all "user-research-particip
 recruitment methods the supplier provides and the locations they can provide them in.
 
 Usage:
-    scripts/export-dos-participants.py <stage> <framework_slug> <content_path>
+    scripts/export-dos-participants.py <stage> <framework_slug> <content_path> [--verbose]
 """
 from multiprocessing.pool import ThreadPool
 import sys
 sys.path.insert(0, '.')
 
+import logging
 from dmscripts.helpers.csv_helpers import make_fields_from_content_questions
 from dmscripts.helpers.framework_helpers import find_suppliers_with_details_and_draft_services
 
@@ -20,10 +21,7 @@ from dmscripts.helpers.auth_helpers import get_auth_token
 from dmapiclient import DataAPIClient
 from dmcontent.content_loader import ContentLoader
 from dmscripts.helpers import logging_helpers
-from dmscripts.helpers.logging_helpers import logging
 from dmutils.env_helpers import get_api_endpoint_from_stage
-
-logger = logging_helpers.configure_logger({"dmapiclient": logging.WARNING})
 
 
 def find_all_participants(client, map_impl=map):
@@ -58,6 +56,11 @@ if __name__ == '__main__':
     STAGE = arguments['<stage>']
     CONTENT_PATH = arguments['<content_path>']
     FRAMEWORK_SLUG = arguments['<framework_slug>']
+    verbose = arguments['--verbose']
+
+    logger = logging_helpers.configure_logger(
+        {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
+    )
 
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))
 
@@ -67,8 +70,10 @@ if __name__ == '__main__':
 
     pool = ThreadPool(3)
 
+    logger.info(f'Finding User Research Participants suppliers for {FRAMEWORK_SLUG}')
     records = find_all_participants(client, map_impl=pool.imap)
 
+    logger.info(f"Building CSV for {len(records)} User Research Participants suppliers")
     write_csv_with_make_row(
         records,
         make_row(content_manifest),

--- a/scripts/export-dos-participants.py
+++ b/scripts/export-dos-participants.py
@@ -88,5 +88,5 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         records,
         make_row(content_manifest),
-        os.path.join(OUTPUT_DIR, "{}-user-research-participants.csv".format(FRAMEWORK_SLUG))
+        os.path.join(OUTPUT_DIR, "user-research-participants-suppliers.csv".format(FRAMEWORK_SLUG))
     )

--- a/scripts/export-dos-participants.py
+++ b/scripts/export-dos-participants.py
@@ -87,6 +87,6 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         records,
         make_row(content_manifest),
-        os.path.join(OUTPUT_DIR, "user-research-participants-suppliers.csv".format(FRAMEWORK_SLUG)),
+        os.path.join(OUTPUT_DIR, "user-research-participants-suppliers.csv"),
         include_last_updated=True
     )

--- a/scripts/export-dos-specialists.py
+++ b/scripts/export-dos-specialists.py
@@ -92,5 +92,6 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         suppliers,
         make_row(content_manifest),
-        os.path.join(OUTPUT_DIR, "digital-specialists-suppliers.csv".format(FRAMEWORK_SLUG))
+        os.path.join(OUTPUT_DIR, "digital-specialists-suppliers.csv".format(FRAMEWORK_SLUG)),
+        include_last_updated=True
     )

--- a/scripts/export-dos-specialists.py
+++ b/scripts/export-dos-specialists.py
@@ -5,9 +5,14 @@ For a DOS-type framework this will export details of all "digital-specialists" s
 specialist roles the supplier provides, the locations they can provide them in and the min and max prices per role.
 
 Usage:
-    scripts/export-dos-specialists.py <stage> <framework_slug> <content_path> [--verbose]
+    scripts/export-dos-specialists.py <stage> <framework_slug> <content_path> [options]
+
+Options:
+    -v --verbose                Print INFO level messages.
+    --output-dir=<output_dir>   Directory to write csv files to [default: output]
 """
 from multiprocessing.pool import ThreadPool
+import os
 import sys
 sys.path.insert(0, '.')
 
@@ -61,11 +66,16 @@ if __name__ == '__main__':
     STAGE = arguments['<stage>']
     CONTENT_PATH = arguments['<content_path>']
     FRAMEWORK_SLUG = arguments['<framework_slug>']
+    OUTPUT_DIR = arguments['--output-dir']
     verbose = arguments['--verbose']
 
     logger = logging_helpers.configure_logger(
         {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
     )
+
+    if not os.path.exists(OUTPUT_DIR):
+        logger.info("Creating {} directory".format(OUTPUT_DIR))
+        os.makedirs(OUTPUT_DIR)
 
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))
 
@@ -82,5 +92,5 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         suppliers,
         make_row(content_manifest),
-        "output/{}-specialists.csv".format(FRAMEWORK_SLUG)
+        os.path.join(OUTPUT_DIR, "{}-specialists.csv".format(FRAMEWORK_SLUG))
     )

--- a/scripts/export-dos-specialists.py
+++ b/scripts/export-dos-specialists.py
@@ -92,5 +92,5 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         suppliers,
         make_row(content_manifest),
-        os.path.join(OUTPUT_DIR, "{}-specialists.csv".format(FRAMEWORK_SLUG))
+        os.path.join(OUTPUT_DIR, "digital-specialists-suppliers.csv".format(FRAMEWORK_SLUG))
     )

--- a/scripts/export-dos-specialists.py
+++ b/scripts/export-dos-specialists.py
@@ -92,6 +92,6 @@ if __name__ == '__main__':
     write_csv_with_make_row(
         suppliers,
         make_row(content_manifest),
-        os.path.join(OUTPUT_DIR, "digital-specialists-suppliers.csv".format(FRAMEWORK_SLUG)),
+        os.path.join(OUTPUT_DIR, "digital-specialists-suppliers.csv"),
         include_last_updated=True
     )

--- a/tests/fixtures/content/frameworks/dos/manifests/edit_submission.yml
+++ b/tests/fixtures/content/frameworks/dos/manifests/edit_submission.yml
@@ -1,0 +1,17 @@
+- name: Service essentials
+  editable: True
+  description: >
+    You must be able to truthfully answer ‘yes’ to every question  for your
+    bid to be considered eligible. If you can’t answer ‘yes’ to every question
+    in this section, it’s very unlikely that your bid will be accepted.
+  questions:
+    - helpGovernmentImproveServices
+    - bespokeSystemInformation
+    - dataProtocols
+    - openStandardsPrinciples
+    - accessibleApplicationsOutcomes
+
+- name: Outcomes locations
+  editable: true
+  questions:
+    - outcomesLocations

--- a/tests/fixtures/content/frameworks/dos/questions/services/accessibleApplicationsOutcomes.yml
+++ b/tests/fixtures/content/frameworks/dos/questions/services/accessibleApplicationsOutcomes.yml
@@ -1,0 +1,15 @@
+name: Designing and building accessible applications
+question: Will you design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+required_value: true
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/tests/fixtures/content/frameworks/dos/questions/services/bespokeSystemInformation.yml
+++ b/tests/fixtures/content/frameworks/dos/questions/services/bespokeSystemInformation.yml
@@ -1,0 +1,14 @@
+name: Share systems information
+question: Will you share bespoke system information from the service you’re working on, eg software performance data, to help the government continuously improve its services?
+type: boolean
+required_value: true
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/tests/fixtures/content/frameworks/dos/questions/services/dataProtocols.yml
+++ b/tests/fixtures/content/frameworks/dos/questions/services/dataProtocols.yml
@@ -1,0 +1,14 @@
+name: Standard data protocols
+question: Will you use standard, accessible data protocols to ensure interoperability across government services?
+type: boolean
+required_value: true
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/tests/fixtures/content/frameworks/dos/questions/services/helpGovernmentImproveServices.yml
+++ b/tests/fixtures/content/frameworks/dos/questions/services/helpGovernmentImproveServices.yml
@@ -1,0 +1,14 @@
+name: Share non-personal data
+question: Will you share non-personal user and service data to help the government continuously improve its services?
+type: boolean
+required_value: true
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/tests/fixtures/content/frameworks/dos/questions/services/openStandardsPrinciples.yml
+++ b/tests/fixtures/content/frameworks/dos/questions/services/openStandardsPrinciples.yml
@@ -1,0 +1,16 @@
+name: Use of open standards
+question: |
+  Will you work according to the government’s [Open Standards Principles](https://www.gov.uk/government/publications/open-standards-principles/open-standards-principles) and use the [open standards selected for use across government](http://standards.data.gov.uk/challenges/adopted)?
+hint: This includes publishing any software you build for the government under the appropriate open source licence.
+type: boolean
+required_value: true
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/tests/fixtures/content/frameworks/dos/questions/services/outcomesLocations.yml
+++ b/tests/fixtures/content/frameworks/dos/questions/services/outcomesLocations.yml
@@ -1,0 +1,34 @@
+id: locations
+name: Where can you work on digital outcomes?
+question: |
+  Where can you work on digital outcomes?
+
+  Choose all the locations where you can work at buyers’ sites, and whether you can work offsite.
+
+  You can update the locations where you can provide services when the framework is live.
+hint: >
+    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites.
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/tests/helpers/test_csv_helpers.py
+++ b/tests/helpers/test_csv_helpers.py
@@ -1,6 +1,7 @@
 import pytest
 
 import dmscripts.helpers.csv_helpers as csv_helpers
+from dmcontent.content_loader import ContentLoader
 
 
 @pytest.mark.parametrize('record,count', [
@@ -26,3 +27,57 @@ def test_read_csv():
         ['Company Name', 'Supplier Name', 'pass'],
         ['678', 'Supplier Name', 'PasS'],
     ]
+
+
+class TestMakeFieldsFromContentQuestions:
+
+    def setup(self):
+        content_loader = ContentLoader('tests/fixtures/content')
+        content_loader.load_manifest('dos', "services", "edit_submission")
+        self.content_manifest = content_loader.get_manifest('dos', "edit_submission")
+
+        self.record = {
+            "supplier": {
+                "name": "ACME INC"
+            },
+            "declaration": {
+                "supplierRegisteredName": "ACME Ltd"
+            },
+            "supplier_id": 34567,
+            "onFramework": True,
+            "services": [
+                {
+                    "locations": [
+                        "Offsite",
+                        "Scotland",
+                        "North East England"
+                    ],
+                    "accessibleApplicationsOutcomes": True
+                }
+            ]
+        }
+
+    def test_make_fields_from_content_questions_with_checkbox_questions(self):
+        locations_question = self.content_manifest.get_question("locations")
+        assert csv_helpers.make_fields_from_content_questions([locations_question], self.record) == [
+            ('locations Offsite', 1),
+            ('locations Scotland', 1),
+            ('locations North East England', 1),
+            ('locations North West England', 0),
+            ('locations Yorkshire and the Humber', 0),
+            ('locations East Midlands', 0),
+            ('locations West Midlands', 0),
+            ('locations East of England', 0),
+            ('locations Wales', 0),
+            ('locations London', 0),
+            ('locations South East England', 0),
+            ('locations South West England', 0),
+            ('locations Northern Ireland', 0)
+        ]
+
+    def test_make_fields_from_content_questions_with_boolean(self):
+        locations_question = self.content_manifest.get_question("accessibleApplicationsOutcomes")
+
+        assert csv_helpers.make_fields_from_content_questions([locations_question], self.record) == [
+            ('accessibleApplicationsOutcomes', 'True'),
+        ]


### PR DESCRIPTION
https://trello.com/c/bNJt7mYX/324-dos-lot-exports-are-not-in-the-right-format-and-have-extra-fields

Addresses some problems with the DOS export scripts:
- Fixes bug where `question.fields` was being called for question types that didn't have that attribute, and adds a couple of tests to check this (a `checkbox` type question previously worked fine, but a `boolean` type question would have failed)
- Adds DOS service fixtures to support the tests above. Mocking the content loader is a bit of a nightmare, so I thought we might as well use the real one, but feed it a tiny subset of our content to keep things speedy.
- Makes logging consistent across the four scripts
- Allows the user to specify an `output-dir` rather than hardcoding to 'output'
- Exports the actual expected filenames for each lot (i.e. don't include framework slug) so we don't have to rename them before uploading to S3
- Adds 'last updated' row to the end of each file. Currently we add this manually to the top of each file, but I'm not sure how useful it is, given last year we updated the files precisely 0 times after initially generating them! Rather than prepend the date in a horribly inefficient way, I thought I'd stick it on the end for now. A dev can always manually insert it at the top as well if it's required.

Not done due to time/complexity:
- optionally filtering out suppliers that 'failed' (i.e. `onFramework = False`)
- re-ordering/relabelling columns
- general speed improvements
- combining the 4 scripts into one mega-script (the dream)