### PR TITLE
including the primary email in the success notification

### DIFF
--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -97,7 +97,9 @@ class SuccessfulSupplierContextForNotify(SupplierFrameworkData):
                 output.update(self.get_user_personalisation(user, supplier_framework))
             primary_email_address = supplier_framework.get('declaration', {}).get('primaryContactEmail')
             if primary_email_address and primary_email_address not in output:
-                supplier_framework['users'].append({'email address': primary_email_address})
+                output.update(
+                    self.get_user_personalisation({'email address': primary_email_address}, supplier_framework)
+                )
         return output
 
     def get_lot_dict(self, supplier_framework):

--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -93,7 +93,13 @@ class SuccessfulSupplierContextForNotify(SupplierFrameworkData):
                 self.logger.info(
                     'Building user personalisations for supplier {}'.format(supplier_framework['supplierId'])
                 )
-            for user in supplier_framework['users']:
+            primary_email_address = supplier_framework.get('declaration', {}).get('primaryContactEmail')
+            if primary_email_address:  # if the primary email is also a user it will be overwritten in the output dict
+                if 'users' in supplier_framework:
+                    supplier_framework['users'].append({'email address': primary_email_address})
+                else:
+                    supplier_framework['users'] = [{'email address': primary_email_address}, ]
+            for user in supplier_framework.get('users', []):
                 output.update(self.get_user_personalisation(user, supplier_framework))
         return output
 

--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -93,14 +93,11 @@ class SuccessfulSupplierContextForNotify(SupplierFrameworkData):
                 self.logger.info(
                     'Building user personalisations for supplier {}'.format(supplier_framework['supplierId'])
                 )
-            primary_email_address = supplier_framework.get('declaration', {}).get('primaryContactEmail')
-            if primary_email_address:  # if the primary email is also a user it will be overwritten in the output dict
-                if 'users' in supplier_framework:
-                    supplier_framework['users'].append({'email address': primary_email_address})
-                else:
-                    supplier_framework['users'] = [{'email address': primary_email_address}, ]
-            for user in supplier_framework.get('users', []):
+            for user in supplier_framework['users']:
                 output.update(self.get_user_personalisation(user, supplier_framework))
+            primary_email_address = supplier_framework.get('declaration', {}).get('primaryContactEmail')
+            if primary_email_address and primary_email_address not in output:
+                supplier_framework['users'].append({'email address': primary_email_address})
         return output
 
     def get_lot_dict(self, supplier_framework):


### PR DESCRIPTION
trello: https://trello.com/c/nmGTH8zd/111-1-notify-successful-suppliers-for-framework-script-doesnt-email-primary-contact

Tested on g-cloud and got 11937 instead of 10619 emails, I will keep the data sources and dumps for the reviewer(s).