### PR TITLE
rotate-api-tokens.sh: add new commands change-ft-account-passwords and sync-ft-account-passwords

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,7 @@ in (with args; {
       pkgs.openssl
       pkgs.cacert
       pkgs.sops
+      pkgs.jq
       ((import ./aws-auth.nix) (with pkgs; { inherit stdenv fetchFromGitHub makeWrapper jq awscli openssl; }))
     ] ++ pkgs.stdenv.lib.optionals (!pkgs.stdenv.isDarwin) [
       # package not available on darwin for now - sorry you're on your own...

--- a/scripts/rotate-api-tokens.sh
+++ b/scripts/rotate-api-tokens.sh
@@ -8,7 +8,7 @@
 # If running locally through Docker, you will probably also need to mount your ~/.aws folder at `/root/.aws` for SOPS to be able to decrypt credentials. But be careful with this due to file permissions.
 # If running on Jenkins, AWS allows SOPS to decrypt credentials using its EC2 instance profile - even within Docker.
 #
-# Syntax: ./scripts/rotate-api-tokens.sh [add-new|remove-old] [preview|staging|production]
+# Syntax: ./scripts/rotate-api-tokens.sh [add-new|remove-old|add-new-callback|remove-old-callback] [preview|staging|production]
 
 set -e
 
@@ -23,7 +23,7 @@ if [ -z "${GITHUB_ACCESS_TOKEN}" ]; then
 fi
 
 if [[ "${STAGE}" != "PREVIEW" && "${STAGE}" != "STAGING" && "${STAGE}" != "PRODUCTION" ]]; then
-  echo "Syntax: ./scripts/rotate-api-tokens.sh [add-new|remove-old] [preview|staging|production]"
+  echo "Syntax: ./scripts/rotate-api-tokens.sh [add-new|remove-old|add-new-callback|remove-old-callback] [preview|staging|production]"
   exit 2
 fi
 

--- a/scripts/set-user-password-by-email-address.py
+++ b/scripts/set-user-password-by-email-address.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+    This script isn't really intended to be run on its own, instead being called from rotate-api-tokens.sh.
+    If you are going to run it on its own, it expects the following environment variables to be set:
+     - STAGE: preview, staging or production
+     - ACCOUNT_EMAIL: the email address of the DMP account whose password is to be changed
+     - ACCOUNT_PASSWORD: the new password for the DMP account
+
+    DM_CREDENTIALS_REPO may also be needed to retrieve the required API tokens
+"""
+
+import sys
+
+sys.path.insert(0, '.')
+
+from os import environ
+from sys import exit
+
+from dmapiclient import DataAPIClient
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmutils.env_helpers import get_api_endpoint_from_stage
+
+if __name__ == "__main__":
+    data_api_client = DataAPIClient(
+        get_api_endpoint_from_stage(environ["STAGE"].lower()),
+        get_auth_token('api', environ["STAGE"].lower()),
+    )
+
+    email_address = environ["ACCOUNT_EMAIL"]
+    user = data_api_client.get_user(email_address=email_address)
+    if not user:
+        print(f"User {email_address!r} not found")
+        exit(2)
+
+    if not data_api_client.update_user_password(
+        user["users"]["id"],
+        environ["ACCOUNT_PASSWORD"],
+        "set-dm-password-by-email.py",
+    ):
+        print(f"Failed to set password for {email_address!r}")
+        exit(3)


### PR DESCRIPTION
https://trello.com/c/AOxxcCSy

This was far more involved than I expected it to be, but doing it manually is annoying and error prone, so I wouldn't be beat.

`change-ft-account-passwords` will "detect" email/password combinations in a set of FT variables by looking for matching pairs of settings ending in `_email` and `_password`. It will then generate a new password for each account, separate accounts being determined by unique email address. A
github PR will then be created to apply these changes.

`sync-ft-account-passwords` will use the API to set the account passwords for any accounts found in a set of FT variables (detected in the same way).

Doing it this way allows separate accounts to be used for the different test variants, new classes of accounts could be added, or some accounts could be omitted entirely for certain variants and the scripts should continue to operate robustly & agnostically.

Coming soon - a basic jenkins job for driving this.