### PR TITLE
[WIP] Add Python 3.7 and 3.8 checks to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
 install:
   - make requirements-dev
 script:

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,7 +3,6 @@
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 itsdangerous==0.24 # pyup: ignore
-Werkzeug==0.15.6 # pyup: <0.16.0
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,9 +6,9 @@ itsdangerous==0.24 # pyup: ignore
 Werkzeug==0.15.6 # pyup: <0.16.0
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@49.0.0#egg=digitalmarketplace-utils==49.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.2.0#egg=digitalmarketplace-apiclient==20.2.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.0.0#egg=digitalmarketplace-content-loader==7.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 
 awscli==1.16.272
 backoff==1.8.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ mock==3.0.5
 pytest==4.6.3
 requests-mock==1.6.0
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.5.0#egg=digitalmarketplace-test-utils==2.5.0
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 itsdangerous==0.24 # pyup: ignore
-Werkzeug==0.15.6 # pyup: <0.16.0
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
@@ -71,6 +70,7 @@ rsa==3.4.2
 s3transfer==0.2.1
 six==1.13.0
 urllib3==1.25.7
+Werkzeug==0.16.0
 workdays==1.4
 WTForms==2.2.1
 xmltodict==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ itsdangerous==0.24 # pyup: ignore
 Werkzeug==0.15.6 # pyup: <0.16.0
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==v0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@49.0.0#egg=digitalmarketplace-utils==49.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.2.0#egg=digitalmarketplace-apiclient==20.2.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.0.0#egg=digitalmarketplace-content-loader==7.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 
 awscli==1.16.272
 backoff==1.8.1
@@ -27,7 +27,7 @@ yq==2.8.1
 asn1crypto==1.2.0
 attrs==19.3.0
 blinker==1.4
-boto3==1.10.8
+boto3==1.10.25
 botocore==1.13.8
 certifi==2019.9.11
 cffi==1.13.2
@@ -38,6 +38,7 @@ contextlib2==0.6.0.post1
 cryptography==2.3.1
 defusedxml==0.6.0
 docutils==0.15.2
+Flask-gzip==0.2
 Flask-Login==0.4.1
 Flask-Script==2.0.6
 Flask-WTF==0.14.2
@@ -56,10 +57,10 @@ MarkupSafe==1.1.1
 monotonic==1.5
 more-itertools==7.2.0
 notifications-python-client==5.4.0
-numpy==1.17.3
+numpy==1.17.4
 odfpy==1.4.0
 prometheus-client==0.2.0
-pyasn1==0.4.7
+pyasn1==0.4.8
 pycparser==2.19
 PyJWT==1.7.1
 pyrsistent==0.15.5
@@ -68,8 +69,8 @@ PyYAML==5.1.2
 requests==2.22.0
 rsa==3.4.2
 s3transfer==0.2.1
-six==1.12.0
-urllib3==1.25.6
+six==1.13.0
+urllib3==1.25.7
 workdays==1.4
 WTForms==2.2.1
 xmltodict==0.12.0


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

- Bumps content loader, utils, test utils and API client
- Unpins Werkzeug
- Adds 3.7 and 3.8 to Travis config