### PR TITLE
add notify_suppliers_of_new_fw_cq_answers script

### DIFF
--- a/dmscripts/notify_suppliers_of_new_fw_cq_answers.py
+++ b/dmscripts/notify_suppliers_of_new_fw_cq_answers.py
@@ -1,0 +1,83 @@
+from logging import Logger
+from typing import Optional
+from uuid import UUID, uuid4
+
+from dmapiclient import DataAPIClient
+
+from dmutils.email import DMNotifyClient
+from dmutils.email.exceptions import EmailError
+from dmutils.email.helpers import hash_string
+from dmutils.env_helpers import get_web_url_from_stage
+
+
+def notify_suppliers_of_new_fw_cq_answers(
+    data_api_client: DataAPIClient,
+    notify_client: DMNotifyClient,
+    notify_template_id: str,
+    framework_slug: str,
+    stage: str,
+    dry_run: bool,
+    logger: Logger,
+    run_id: Optional[UUID] = None,
+) -> int:
+    run_is_new = bool(run_id)
+    run_id = run_id or uuid4()
+    logger.info(f"{'Starting' if run_is_new else 'Resuming'} run id {{run_id}}", extra={"run_id": str(run_id)})
+
+    framework = data_api_client.get_framework(framework_slug)["frameworks"]
+
+    if framework["status"] != "open":
+        raise ValueError(f"Framework {framework_slug!r} is not open (status is {framework['status']!r})")
+
+    failure_count = 0
+
+    for supplier_framework in data_api_client.find_framework_suppliers_iter(framework_slug):
+        for user in data_api_client.find_users_iter(supplier_id=supplier_framework["supplierId"]):
+            if user["active"]:
+                # generating ref separately so we can exclude certain parameters from the personalization dict
+                notify_ref = notify_client.get_reference(
+                    user["emailAddress"],
+                    notify_template_id,
+                    {
+                        "framework_slug": framework["slug"],
+                        "run_id": str(run_id),
+                    },
+                )
+                if dry_run:
+                    if notify_client.has_been_sent(notify_ref):
+                        logger.debug(
+                            "[DRY RUN] Would NOT send notification to {email_hash} (already sent)",
+                            extra={"email_hash": hash_string(user["emailAddress"])},
+                        )
+                    else:
+                        logger.info(
+                            "[DRY RUN] Would send notification to {email_hash}",
+                            extra={"email_hash": hash_string(user["emailAddress"])},
+                        )
+                else:
+                    try:
+                        notify_client.send_email(
+                            user["emailAddress"],
+                            notify_template_id,
+                            {
+                                "framework_name": framework["name"],
+                                "updates_url":
+                                    f"{get_web_url_from_stage(stage)}/suppliers/frameworks/{framework['slug']}/updates",
+                                "clarification_questions_closed": (
+                                    "no" if framework["clarificationQuestionsOpen"] else "yes"
+                                ),
+                            },
+                            allow_resend=False,
+                            reference=notify_ref,
+                        )
+                    except EmailError as e:
+                        failure_count += 1
+                        logger.error(
+                            "Failed sending to {email_hash}: {e}",
+                            extra={
+                                "email_hash": hash_string(user["emailAddress"]),
+                                "e": str(e),
+                            },
+                        )
+
+    return failure_count

--- a/scripts/notify-suppliers-of-new-fw-cq-answers.py
+++ b/scripts/notify-suppliers-of-new-fw-cq-answers.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Notify all users of all suppliers that have any interest in the framework identified by <framework_slug> that new
+clarification question answers have been published.
+
+Usage: notify-suppliers-of-new_clarification-questions.py <stage> <framework_slug> <govuk_notify_api_key>
+    <govuk_notify_template_id> [--dry-run] [--verbose]
+
+Options:
+    --stage=<stage>                                       Stage to target
+    --govuk_notify_api_key=<govuk_notify_api_key>         Notify API Token
+    --govuk_notify_template_id=<govuk_notify_template_id> Notify template id on account corresponding to token provided
+    --resume-run-id=<run_id>                              UUID of a previously failed run to use for notify ref
+                                                          generation: useful to prevent emails being re-sent to those
+                                                          users the previous run was already successful for
+    --dry-run                                             List notifications that would be sent without sending emails
+    -h, --help                                            Show this screen
+
+Examples:
+    ./scripts/notify-suppliers-of-new-clarification-questions.py preview g-cloud-99 notifyToken t3mp1at3id
+    ./scripts/notify-suppliers-of-new-clarification-questions.py preview g-cloud-99 notifyToken t3mp1at3id --dry-run \
+       --verbose --resume-run-id=00010203-0405-0607-0809-0a0b0c0d0e0f
+
+"""
+
+import logging
+import sys
+from uuid import UUID
+
+from docopt import docopt
+
+from dmapiclient import DataAPIClient
+from dmutils.env_helpers import get_api_endpoint_from_stage
+
+sys.path.insert(0, '.')
+from dmscripts.helpers.email_helpers import scripts_notify_client
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers import logging_helpers
+from dmscripts.notify_suppliers_of_new_fw_cq_answers import \
+    notify_suppliers_of_new_fw_cq_answers
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    logger = logging_helpers.configure_logger({"dmapiclient": logging.INFO})
+
+    run_id = None if not arguments.get("<run_id>") else UUID(arguments["<run_id>"])
+
+    failure_count = notify_suppliers_of_new_fw_cq_answers(
+        data_api_client=DataAPIClient(
+            base_url=get_api_endpoint_from_stage(arguments["<stage>"], "api"),
+            auth_token=get_auth_token("api", arguments["<stage>"]),
+        ),
+        notify_client=scripts_notify_client(arguments['<govuk_notify_api_key>'], logger=logger),
+        notify_template_id=arguments['<govuk_notify_template_id>'],
+        framework_slug=arguments["<framework_slug>"],
+        stage=arguments["<stage>"],
+        dry_run=arguments["--dry-run"],
+        logger=logger,
+        run_id=run_id,
+    )
+
+    if failure_count:
+        logger.error("Failed sending {failure_count} messages", extra={"failure_count": failure_count})
+
+    sys.exit(failure_count)

--- a/tests/test_notify_suppliers_of_new_fw_cq_answers.py
+++ b/tests/test_notify_suppliers_of_new_fw_cq_answers.py
@@ -1,0 +1,271 @@
+import pytest
+import logging
+import mock
+import uuid
+
+from dmapiclient import DataAPIClient
+from dmtestutils.api_model_stubs import FrameworkStub, SupplierFrameworkStub
+from dmtestutils.comparisons import AnyStringMatching
+from dmutils.email import DMNotifyClient, EmailError
+
+from dmscripts.notify_suppliers_of_new_fw_cq_answers import \
+    notify_suppliers_of_new_fw_cq_answers
+
+
+_supplier_frameworks = (
+    SupplierFrameworkStub(supplier_id=303132, framework_slug="g-cloud-99").response(),
+    SupplierFrameworkStub(supplier_id=303233, framework_slug="g-cloud-99").response(),
+    SupplierFrameworkStub(supplier_id=303133, framework_slug="g-cloud-99").response(),
+    SupplierFrameworkStub(supplier_id=313233, framework_slug="g-cloud-99").response(),
+)
+
+
+_supplier_users_by_supplier = {
+    supplier_id: tuple({"supplierId": supplier_id, **supplier} for supplier in suppliers)
+    for supplier_id, suppliers in (
+        (303132, (
+            {
+                "id": 56,
+                "emailAddress": "one@peasoup.net",
+                "active": True,
+            },
+            {
+                "id": 57,
+                "emailAddress": "two@peasoup.net",
+                "active": True,
+            },
+        )),
+        (303233, ()),
+        (303133, (
+            {
+                "id": 58,
+                "emailAddress": "one@bubbling-suds.org",
+                "active": False,
+            },
+        )),
+        (313233, (
+            {
+                "id": 59,
+                "emailAddress": "one@shirts.co.ua",
+                "active": False,
+            },
+            {
+                "id": 60,
+                "emailAddress": "two@shirts.co.ua",
+                "active": True,
+            },
+            {
+                "id": 61,
+                "emailAddress": "three@shirts.co.ua",
+                "active": True,
+            },
+        )),
+    )
+}
+
+
+@pytest.mark.parametrize("framework_status", ("coming", "pending", "live", "standstill",))
+def test_non_open_framework(framework_status):
+    mock_data_api_client = mock.create_autospec(DataAPIClient, instance=True)
+    mock_data_api_client.get_framework.return_value = FrameworkStub(
+        slug="g-cloud-99",
+        status=framework_status,
+    ).single_result_response()
+    mock_notify_client = mock.create_autospec(DMNotifyClient, instance=True)
+    mock_logger = mock.create_autospec(logging.Logger, instance=True)
+
+    with pytest.raises(ValueError, match=r"\bopen\b"):
+        notify_suppliers_of_new_fw_cq_answers(
+            data_api_client=mock_data_api_client,
+            notify_client=mock_notify_client,
+            notify_template_id="8877eeff",
+            framework_slug="g-cloud-99",
+            dry_run=False,
+            stage="production",
+            logger=mock_logger,
+        )
+
+    assert mock_data_api_client.mock_calls == [
+        mock.call.get_framework("g-cloud-99")
+    ]
+
+    assert mock_notify_client.mock_calls == []
+
+
+@pytest.mark.parametrize("dry_run", (False, True))
+@pytest.mark.parametrize("run_id", (None, uuid.UUID("00010203-0405-0607-0809-0a0b0c0d0e0f")))
+@mock.patch("dmscripts.notify_suppliers_of_new_fw_cq_answers.uuid4")
+def test_happy_paths(mock_uuid4, run_id, dry_run):
+    mock_uuid4.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+    mock_data_api_client = mock.create_autospec(DataAPIClient, instance=True)
+    mock_data_api_client.get_framework.return_value = FrameworkStub(
+        slug="g-cloud-99",
+        status="open",
+    ).single_result_response()
+    mock_data_api_client.find_framework_suppliers_iter.side_effect = lambda *a, **k: iter(_supplier_frameworks)
+    mock_data_api_client.find_users_iter.side_effect = lambda *a, **k: iter(
+        _supplier_users_by_supplier[k["supplier_id"]]
+    )
+
+    mock_notify_client = mock.create_autospec(DMNotifyClient, instance=True)
+    mock_notify_client.get_reference.side_effect = lambda *a: ",".join(str(x) for x in a)
+    mock_notify_client.has_been_sent.side_effect = (
+        # this one ref is considered to be already sent
+        lambda reference: reference == (
+            "two@shirts.co.ua,8877eeff,{'framework_slug': 'g-cloud-99', 'run_id': "
+            "'00010203-0405-0607-0809-0a0b0c0d0e0f'}"
+        )
+    )
+
+    mock_logger = mock.create_autospec(logging.Logger, instance=True)
+
+    assert notify_suppliers_of_new_fw_cq_answers(
+        data_api_client=mock_data_api_client,
+        notify_client=mock_notify_client,
+        notify_template_id="8877eeff",
+        framework_slug="g-cloud-99",
+        dry_run=dry_run,
+        stage="production",
+        logger=mock_logger,
+        run_id=run_id,
+    ) == 0
+
+    expected_run_id = str(run_id or "12345678-1234-5678-1234-567812345678")
+
+    assert mock_uuid4.mock_calls == ([mock.call()] if run_id is None else [])
+    assert mock_data_api_client.mock_calls == [
+        mock.call.get_framework("g-cloud-99"),
+        mock.call.find_framework_suppliers_iter("g-cloud-99"),
+        mock.call.find_users_iter(supplier_id=303132),
+        mock.call.find_users_iter(supplier_id=303233),
+        mock.call.find_users_iter(supplier_id=303133),
+        mock.call.find_users_iter(supplier_id=313233),
+    ]
+    assert mock_notify_client.mock_calls == [
+        mock.call.get_reference("one@peasoup.net", "8877eeff", {
+            'framework_slug': 'g-cloud-99',
+            'run_id': expected_run_id,
+        }),
+        (mock.call.has_been_sent(
+            f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
+        ) if dry_run else mock.call.send_email(
+            'one@peasoup.net',
+            '8877eeff',
+            {
+                'framework_name': 'G-Cloud 99',
+                'updates_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/updates',
+                'clarification_questions_closed': "no",
+            },
+            allow_resend=False,
+            reference=f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        )),
+        mock.call.get_reference("two@peasoup.net", "8877eeff", {
+            'framework_slug': 'g-cloud-99',
+            'run_id': expected_run_id,
+        }),
+        (mock.call.has_been_sent(
+            f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        ) if dry_run else mock.call.send_email(
+            'two@peasoup.net',
+            '8877eeff',
+            {
+                'framework_name': 'G-Cloud 99',
+                'updates_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/updates',
+                'clarification_questions_closed': "no",
+            },
+            allow_resend=False,
+            reference=f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        )),
+        mock.call.get_reference("two@shirts.co.ua", "8877eeff", {
+            'framework_slug': 'g-cloud-99',
+            'run_id': expected_run_id,
+        }),
+        (mock.call.has_been_sent(
+            f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        ) if dry_run else mock.call.send_email(
+            'two@shirts.co.ua',
+            '8877eeff',
+            {
+                'framework_name': 'G-Cloud 99',
+                'updates_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/updates',
+                'clarification_questions_closed': "no",
+            },
+            allow_resend=False,
+            reference=f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        )),
+        mock.call.get_reference("three@shirts.co.ua", "8877eeff", {
+            'framework_slug': 'g-cloud-99',
+            'run_id': expected_run_id,
+        }),
+        (mock.call.has_been_sent(
+            f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        ) if dry_run else mock.call.send_email(
+            'three@shirts.co.ua',
+            '8877eeff',
+            {
+                'framework_name': 'G-Cloud 99',
+                'updates_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/updates',
+                'clarification_questions_closed': "no",
+            },
+            allow_resend=False,
+            reference=f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        )),
+    ]
+
+    assert (dry_run and run_id == uuid.UUID("00010203-0405-0607-0809-0a0b0c0d0e0f")) == (
+        mock.call.debug(
+            "[DRY RUN] Would NOT send notification to {email_hash} (already sent)",
+            extra=mock.ANY,
+        ) in mock_logger.mock_calls
+    )
+
+
+def test_sending_failure_continues():
+    mock_data_api_client = mock.create_autospec(DataAPIClient, instance=True)
+    mock_data_api_client.get_framework.return_value = FrameworkStub(
+        slug="g-cloud-99",
+        status="open",
+    ).single_result_response()
+    mock_data_api_client.find_framework_suppliers_iter.side_effect = lambda *a, **k: iter(_supplier_frameworks)
+    mock_data_api_client.find_users_iter.side_effect = lambda *a, **k: iter(
+        _supplier_users_by_supplier[k["supplier_id"]]
+    )
+
+    def _send_email_side_effect(email_address, *args, **kwargs):
+        if email_address == "two@peasoup.net":
+            raise EmailError("foo")
+        return {}
+
+    mock_notify_client = mock.create_autospec(DMNotifyClient, instance=True)
+    mock_notify_client.get_reference.side_effect = lambda *a: ",".join(str(x) for x in a)
+    mock_notify_client.send_email.side_effect = _send_email_side_effect
+
+    mock_logger = mock.create_autospec(logging.Logger, instance=True)
+
+    assert notify_suppliers_of_new_fw_cq_answers(
+        data_api_client=mock_data_api_client,
+        notify_client=mock_notify_client,
+        notify_template_id="8877eeff",
+        framework_slug="g-cloud-99",
+        dry_run=False,
+        stage="production",
+        logger=mock_logger,
+        run_id=uuid.UUID("12345678-1234-5678-1234-567812345678"),
+    ) == 1
+
+    assert mock.call.error(
+        "Failed sending to {email_hash}: {e}",
+        extra={
+            "email_hash": mock.ANY,
+            "e": AnyStringMatching("foo"),
+        },
+    ) in mock_logger.mock_calls
+
+    # check that we do actually end up trying to send all emails instead of giving up after error
+    assert tuple(call[0][0] for call in mock_notify_client.send_email.call_args_list) == (
+        "one@peasoup.net",
+        "two@peasoup.net",
+        "two@shirts.co.ua",
+        "three@shirts.co.ua",
+    )


### PR DESCRIPTION
Originally https://trello.com/c/xbqxyfNV/ but has rather morphed into a separate script.

We can start off running this script when asked by CCS. It could be extended to run as a periodic job if this was found to be too much hassle, possibly detecting when to fire based on the etag of the most recent clarification question answers document found in the S3 bucket.
