### PR TITLE
Application reminder email includes incomplete service count

### DIFF
--- a/dmscripts/notify_suppliers_with_incomplete_applications.py
+++ b/dmscripts/notify_suppliers_with_incomplete_applications.py
@@ -10,11 +10,13 @@ from dmutils.formats import utctoshorttimelongdateformat
 
 NOTIFY_TEMPLATE_ID = '25c7c763-fe51-418f-8e51-130c391edc35'
 
-MESSAGES = [
-    '* confirm your company details\n',
-    '* finish your supplier declaration\n',
-    '* mark your services as complete\n',
-]
+MESSAGES = {
+    'unconfirmed_company_details': '* confirm your company details\n',
+    'incomplete_declaration': '* finish your supplier declaration\n',
+    'no_services': '* mark at least one of your services as complete\n',
+    'unsubmitted_services': '* check that all services to be submitted have been marked as complete '
+                            '({} currently incomplete)\n'
+}
 
 
 def send_notification(mail_client, message, framework, email, supplier_id, dry_run):
@@ -58,19 +60,20 @@ def notify_suppliers_with_incomplete_applications(framework_slug, stage, notify_
     for sf in data_api_client.find_framework_suppliers_iter(framework_slug):
         message = ''
         if not sf.get('applicationCompanyDetailsConfirmed', None):
-            message += MESSAGES[0]
+            message += MESSAGES['unconfirmed_company_details']
         if not sf.get('declaration', {'status': None}).get('status', None) == 'complete':
-            message += MESSAGES[1]
+            message += MESSAGES['incomplete_declaration']
 
         submitted_draft_services, unsubmitted_draft_services = 0, 0
         for service in data_api_client.find_draft_services_iter(sf['supplierId'], framework=framework_slug):
             if service.get('status') == 'not-submitted':
                 unsubmitted_draft_services += 1
-                break
             if service.get('status') == 'submitted':
                 submitted_draft_services += 1
-        if unsubmitted_draft_services > 0 or submitted_draft_services == 0:
-            message += MESSAGES[2]
+        if submitted_draft_services == 0:
+            message += MESSAGES['no_services']
+        elif unsubmitted_draft_services > 0:
+            message += MESSAGES['unsubmitted_services'].format(unsubmitted_draft_services)
 
         if message:
             primary_email = sf.get('declaration', {'primaryContactEmail': None}).get('primaryContactEmail', None)

--- a/dmscripts/notify_suppliers_with_incomplete_applications.py
+++ b/dmscripts/notify_suppliers_with_incomplete_applications.py
@@ -49,13 +49,16 @@ def send_notification(mail_client, message, framework, email, supplier_id, dry_r
 
 def notify_suppliers_with_incomplete_applications(framework_slug, stage, notify_api_key, dry_run):
     logger = configure_logger({"dmapiclient": logging.INFO})
-    mail_client = scripts_notify_client(notify_api_key, logger=logger)
     data_api_client = DataAPIClient(
         base_url=get_api_endpoint_from_stage(stage), auth_token=get_auth_token('api', stage)
     )
-    error_count = 0
 
     framework = data_api_client.get_framework(framework_slug)['frameworks']
+    if framework['status'] != 'open':
+        raise ValueError("Suppliers cannot amend applications unless the framework is open.")
+
+    mail_client = scripts_notify_client(notify_api_key, logger=logger)
+    error_count = 0
 
     for sf in data_api_client.find_framework_suppliers_iter(framework_slug):
         message = ''

--- a/dmscripts/notify_suppliers_with_incomplete_applications.py
+++ b/dmscripts/notify_suppliers_with_incomplete_applications.py
@@ -12,7 +12,7 @@ NOTIFY_TEMPLATE_ID = '25c7c763-fe51-418f-8e51-130c391edc35'
 MESSAGES = [
     '* confirm your company details\n',
     '* finish your supplier declaration\n',
-    '* mark at least one of your services as complete\n',
+    '* mark your services as complete\n',
 ]
 
 
@@ -50,12 +50,15 @@ def notify_suppliers_with_incomplete_applications(framework, stage, notify_api_k
             message += MESSAGES[0]
         if not sf.get('declaration', {'status': None}).get('status', None) == 'complete':
             message += MESSAGES[1]
-        has_submitted_at_least_one_service = False
+
+        submitted_draft_services, unsubmitted_draft_services = 0, 0
         for service in data_api_client.find_draft_services_iter(sf['supplierId'], framework=framework):
-            if service.get('status') == 'submitted':
-                has_submitted_at_least_one_service = True
+            if service.get('status') == 'not-submitted':
+                unsubmitted_draft_services += 1
                 break
-        if not has_submitted_at_least_one_service:
+            if service.get('status') == 'submitted':
+                submitted_draft_services += 1
+        if unsubmitted_draft_services > 0 or submitted_draft_services == 0:
             message += MESSAGES[2]
 
         if message:

--- a/scripts/notify-suppliers-with-incomplete-applications.py
+++ b/scripts/notify-suppliers-with-incomplete-applications.py
@@ -6,8 +6,8 @@ of the looming deadline.
 The script will notify suppliers that have:
 
 1) unconfirmed company details
-2) incomplete declarations
-3) no completed services
+2) an incomplete declaration
+3) no completed services, or any incomplete services
 
 Uses the Notify API to send emails.
 

--- a/tests/test_notify_suppliers_with_incomplete_applications.py
+++ b/tests/test_notify_suppliers_with_incomplete_applications.py
@@ -70,12 +70,17 @@ DRAFT_SERVICES_TEST_CASES = [
         MESSAGES[2],
     ],
     [
-        [{'status': 'not-submitted', }],
+        [{'status': 'not-submitted'}],
         # output, email message fragment
         MESSAGES[2],
     ],
     [
         [{'status': 'submitted'}, {'status': 'not-submitted'}],
+        # output, email message fragment
+        MESSAGES[2],
+    ],
+    [
+        [{'status': 'submitted'}],
         # output, email message fragment
         '',
     ],

--- a/tests/test_notify_suppliers_with_incomplete_applications.py
+++ b/tests/test_notify_suppliers_with_incomplete_applications.py
@@ -30,7 +30,7 @@ FRAMEWORK_SUPPLIERS_TEST_CASES = [
             'declaration': {'status': 'started', 'primaryContactEmail': 'abc@example.com'}
         }],
         ['abc@example.com', ],  # output, list of email addresses
-        MESSAGES[1],  # output, expected message fragment
+        MESSAGES['incomplete_declaration'],  # output, expected message fragment
     ],
     [
         # input
@@ -40,7 +40,7 @@ FRAMEWORK_SUPPLIERS_TEST_CASES = [
             'declaration': {'status': 'started'}
         }],
         [],  # output, list of email addresses
-        MESSAGES[1],  # output, expected message fragment
+        MESSAGES['incomplete_declaration'],  # output, expected message fragment
     ],
     [
         # input
@@ -50,7 +50,7 @@ FRAMEWORK_SUPPLIERS_TEST_CASES = [
             'declaration': {}
         }],
         [],  # output, list of email addresses
-        MESSAGES[1],  # output, expected message fragment
+        MESSAGES['incomplete_declaration'],  # output, expected message fragment
     ],
     [
         # input
@@ -60,7 +60,8 @@ FRAMEWORK_SUPPLIERS_TEST_CASES = [
             'declaration': {}
         }],
         [],  # output, list of email addresses
-        MESSAGES[0] + MESSAGES[1],  # output, expected message fragment
+        # output, expected message fragment
+        MESSAGES['unconfirmed_company_details'] + MESSAGES['incomplete_declaration'],
     ],
 ]
 
@@ -69,17 +70,17 @@ DRAFT_SERVICES_TEST_CASES = [
         # input
         [],
         # output, email message fragment
-        MESSAGES[2],
+        MESSAGES['no_services'],
     ],
     [
         [{'status': 'not-submitted'}],
         # output, email message fragment
-        MESSAGES[2],
+        MESSAGES['no_services'],
     ],
     [
         [{'status': 'submitted'}, {'status': 'not-submitted'}],
         # output, email message fragment
-        MESSAGES[2],
+        MESSAGES['unsubmitted_services'].format(1),
     ],
     [
         [{'status': 'submitted'}],


### PR DESCRIPTION
https://trello.com/c/AzV9twDI/219-revise-1-week-reminder-email-to-prompt-applicants-with-any-incomplete-draft-services

For DOS4, some suppliers didn't realise they had incomplete services that needed to be submitted. This PR tweaks the reminder script to include a message with the number of incomplete services (unless the supplier hasn't submitted *any* services, in which case the original 'mark at least one of your services as complete' message is shown).

Other changes:
- the script now exits early if the framework is not `open` (the supplier can't make any changes if the framework is in any other state)
- the script is framework-agnostic (the Notify template was previously hardcoded to DOS4). This means formatting the application closing date using our special framework deadline date filter, `utctoshorttimelongdateformat`
- the `MESSAGES` list is now a dict, for better visibility of what message we want to pick in each case

Changes to the Notify template:
![reminder-email-template](https://user-images.githubusercontent.com/3492540/71997385-b59f6880-3235-11ea-8965-bfd15a412ab6.png)

We will need to tweak the first paragraph of the email to take into account suppliers who have technically completed their application, but have some unsubmitted services left over (perhaps intentionally). 
