### PR TITLE
notify_suppliers_of_new_fw_cq_answers: fix inversion of run_is_new determination

### DIFF
--- a/dmscripts/notify_suppliers_of_new_fw_cq_answers.py
+++ b/dmscripts/notify_suppliers_of_new_fw_cq_answers.py
@@ -20,7 +20,7 @@ def notify_suppliers_of_new_fw_cq_answers(
     logger: Logger,
     run_id: Optional[UUID] = None,
 ) -> int:
-    run_is_new = bool(run_id)
+    run_is_new = not run_id
     run_id = run_id or uuid4()
     logger.info(f"{'Starting' if run_is_new else 'Resuming'} run id {{run_id}}", extra={"run_id": str(run_id)})
 


### PR DESCRIPTION
Stupid mistake - was simply causing logging output to be wrong.