### PR TITLE
 export_framework_results_reasons: fail more obviously when we get unexpected validation errors

### DIFF
--- a/dmscripts/export_framework_results_reasons.py
+++ b/dmscripts/export_framework_results_reasons.py
@@ -16,10 +16,17 @@ DRAFT_STATUSES = [
 ]
 
 
+def get_error_key(error):
+    try:
+        return error.path[0]
+    except (AttributeError, TypeError, IndexError):
+        raise ValueError(f"Unexpected validation error: {error!r}")
+
+
 def get_validation_errors(candidate, schema):
     validator = jsonschema.Draft4Validator(schema)
     errors = validator.iter_errors(candidate)
-    error_keys = [error.path[0] for error in errors]
+    error_keys = [get_error_key(error) for error in errors]
     return error_keys
 
 

--- a/tests/assessment_helpers.py
+++ b/tests/assessment_helpers.py
@@ -24,16 +24,21 @@ class BaseAssessmentTest(object):
             ],
             "definitions": {
                 "baseline": {
-                    "$schema": "http://json-schema.org/draft-04/schema#",
-                    "type": "object",
-                    "properties": {
-                        "shouldBeFalseStrict": {"enum": [False]},
-                        "shouldBeTrueStrict": {"enum": [True]},
-                        "shouldMatchPatternStrict": {
-                            "type": "string",
-                            "pattern": "^H\\.? *E\\.? *L\\.? *Y\\.? *S?",
+                    "allOf": [
+                        {
+                            "$schema": "http://json-schema.org/draft-04/schema#",
+                            "type": "object",
+                            "properties": {
+                                "shouldBeFalseStrict": {"enum": [False]},
+                                "shouldBeTrueStrict": {"enum": [True]},
+                                "shouldMatchPatternStrict": {
+                                    "type": "string",
+                                    "pattern": "^H\\.? *E\\.? *L\\.? *Y\\.? *S?",
+                                },
+                            },
+                            "required": ["omnipresent"],
                         },
-                    },
+                    ],
                 },
             },
         }
@@ -125,6 +130,7 @@ class BaseAssessmentTest(object):
                         "shouldBeTrueStrict": True,
                         "shouldMatchPatternStrict": "HE L Y   S",
                         "irrelevantQuestion": "Irrelevant answer",
+                        "omnipresent": "ether",
                     },
                 },
                 2345: {
@@ -134,12 +140,14 @@ class BaseAssessmentTest(object):
                         "shouldBeTrueLax": True,
                         "shouldMatchPatternLax": "Good pattern",
                         "shouldBeFalseStrict": None,  # <- subtle but important test here
+                        "omnipresent": "ether",
                     },
                 },
                 3456: {
                     "onFramework": False,
                     "declaration": {
                         "status": "complete",
+                        "omnipresent": "ether",
                     },
                 },
                 4321: {
@@ -150,6 +158,7 @@ class BaseAssessmentTest(object):
                         "shouldMatchPatternLax": "Good   Pattern",
                         "shouldMatchPatternStrict": "H.E. L.  Y",
                         "irrelevantStupidQuestion": "Irrelevant stupid answer",
+                        "omnipresent": "ether",
                     },
                 },
                 4567: {
@@ -165,6 +174,7 @@ class BaseAssessmentTest(object):
                         "status": "complete",
                         "shouldBeFalseLax": True,
                         "shouldMatchPatternStrict": "HEL Y...",
+                        "omnipresent": "ether",
                     },
                 },
                 6543: {
@@ -172,6 +182,7 @@ class BaseAssessmentTest(object):
                     "declaration": {
                         "status": "complete",
                         "shouldBeTrueStrict": True,
+                        "omnipresent": "ether",
                     },
                 },
                 7654: {
@@ -179,6 +190,7 @@ class BaseAssessmentTest(object):
                     "declaration": {
                         "status": "complete",
                         "shouldBeFalseLax": True,
+                        "omnipresent": "ether",
                     },
                 },
                 8765: {
@@ -188,6 +200,7 @@ class BaseAssessmentTest(object):
                         "shouldBeFalseLax": False,
                         "shouldBeTrueStrict": True,
                         "shouldMatchPatternLax": "Good    pattern",
+                        "omnipresent": "ether",
                     },
                 },
             }.items()

--- a/tests/test_export_framework_results_reasons.py
+++ b/tests/test_export_framework_results_reasons.py
@@ -384,3 +384,21 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
             expected_discretionary,
             expected_successful,
         )
+
+
+class TestExportUnexpectedValidationError(_BaseExportTest):
+    def _get_supplier_frameworks(self):
+        sfs = super()._get_supplier_frameworks()
+        del sfs[1234]["declaration"]["omnipresent"]
+        return sfs
+
+    @pytest.mark.parametrize("use_baseline_schema", (False, True,))
+    def test_failed_export(self, tmpdir, use_baseline_schema):
+        with pytest.raises(ValueError, match=r".*Unexpected validation error.*omnipresent.*"):
+            return self._test_export_inner(
+                tmpdir,
+                use_baseline_schema,
+                [],
+                [],
+                [],
+            )


### PR DESCRIPTION
To supplement https://github.com/alphagov/digitalmarketplace-frameworks/pull/603 and https://trello.com/c/kbTzccXb

We're adding extra constraints to the assessment schemas, constraints which in normal use we shouldn't expect to be broken. But if they are broken for some reason, we'll end up with a validation error that doesn't look as we expect it to, leading to problems when we try to run the "reasons" script.

This change just makes such errors less puzzling if they occur and adds a test for these cases.