### PR TITLE
298-include-link-to-admin-view-in-failed-csv-report-we-send-to-ccs

### DIFF
--- a/dmscripts/export_framework_results_reasons.py
+++ b/dmscripts/export_framework_results_reasons.py
@@ -5,6 +5,8 @@ from itertools import chain
 import jsonschema
 import os
 
+from dmutils.env_helpers import get_web_url_from_stage
+
 from dmscripts.helpers.csv_helpers import MultiCSVWriter
 from dmscripts.helpers.framework_helpers import find_suppliers_with_details_and_draft_service_counts
 
@@ -119,6 +121,12 @@ def contact_details(record):
     ]
 
 
+def admin_link(record):
+    base = get_web_url_from_stage('production')
+    admin_path = f"{base}/suppliers/{record['supplier']['id']}/edit/declarations/{record['frameworkSlug']}"
+    return [('admin_link', admin_path)]
+
+
 class SuccessfulHandler(object):
     NAME = 'successful'
     CCS_FILENAME_FORMAT = '{}-automatically-successful-suppliers-{}'
@@ -133,9 +141,10 @@ class SuccessfulHandler(object):
         return True
 
     def create_row(self, record):
-        return \
-            supplier_info(record) + \
+        return (
+            supplier_info(record) +
             contact_details(record)
+        )
 
 
 class FailedHandler(object):
@@ -166,10 +175,12 @@ class FailedHandler(object):
         return True
 
     def create_row(self, record):
-        return \
-            supplier_info(record) + \
-            failed_mandatory_questions(record) + \
-            contact_details(record)
+        return (
+            supplier_info(record) +
+            failed_mandatory_questions(record) +
+            contact_details(record) +
+            admin_link(record)
+        )
 
 
 class DiscretionaryHandler(object):
@@ -186,10 +197,12 @@ class DiscretionaryHandler(object):
         return True
 
     def create_row(self, record):
-        return \
-            supplier_info(record) + \
-            discretionary_questions(record) + \
-            contact_details(record)
+        return (
+            supplier_info(record) +
+            discretionary_questions(record) +
+            contact_details(record) +
+            admin_link(record)
+        )
 
 
 def get_questions_numbers_from_framework(framework_slug, content_loader):

--- a/dmscripts/helpers/framework_helpers.py
+++ b/dmscripts/helpers/framework_helpers.py
@@ -90,6 +90,7 @@ def add_framework_info(client, framework_slug, record):
     supplier_framework = client.get_supplier_framework_info(record['supplier_id'], framework_slug)['frameworkInterest']
     return dict(record,
                 onFramework=supplier_framework['onFramework'],
+                frameworkSlug=supplier_framework['frameworkSlug'],
                 declaration=supplier_framework['declaration'] or {},
                 countersignedPath=supplier_framework['countersignedPath'] or "",
                 countersignedAt=supplier_framework['countersignedAt'] or "",

--- a/tests/helpers/test_framework_helpers.py
+++ b/tests/helpers/test_framework_helpers.py
@@ -83,6 +83,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
             'frameworkInterest': {
                 'declaration': {'status': 'complete'},
                 'onFramework': True,
+                'frameworkSlug': 'g-things-1',
                 'countersignedPath': None,
                 'countersignedAt': None,
             }
@@ -91,6 +92,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
             'frameworkInterest': {
                 'declaration': {'status': 'started'},
                 'onFramework': False,
+                'frameworkSlug': 'g-things-1',
                 'countersignedPath': None,
                 'countersignedAt': None,
             }
@@ -99,6 +101,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
             'frameworkInterest': {
                 'declaration': {'status': 'complete'},
                 'onFramework': True,
+                'frameworkSlug': 'g-things-1',
                 'countersignedPath': 'some/path',
                 'countersignedAt': '2017-01-02T03:04:05.000006Z',
             }
@@ -140,7 +143,8 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
                 'declaration': {'status': 'complete'},
                 'countersignedPath': '',
                 'countersignedAt': '',
-                'onFramework': True
+                'onFramework': True,
+                'frameworkSlug': 'g-things-1',
             },
             {
                 'supplier': 'supplier 3',
@@ -158,7 +162,8 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
                 'declaration': {'status': 'started'},
                 'countersignedPath': '',
                 'countersignedAt': '',
-                'onFramework': False
+                'onFramework': False,
+                'frameworkSlug': 'g-things-1',
             },
             {
                 'supplier': 'supplier 2',
@@ -176,7 +181,9 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
                 'declaration': {'status': 'complete'},
                 'countersignedPath': 'some/path',
                 'countersignedAt': '2017-01-02T03:04:05.000006Z',
-                'onFramework': True}
+                'onFramework': True,
+                'frameworkSlug': 'g-things-1',
+            }
         ]
 
 
@@ -190,6 +197,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
         (4, 'framework-slug'): {
             'frameworkInterest': {
                 'declaration': {'status': 'complete'},
+                'frameworkSlug': 'g-things-1',
                 'onFramework': True,
                 'countersignedPath': None,
                 'countersignedAt': None,
@@ -198,6 +206,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
         (3, 'framework-slug'): {
             'frameworkInterest': {
                 'declaration': {'status': 'started'},
+                'frameworkSlug': 'g-things-1',
                 'onFramework': False,
                 'countersignedPath': None,
                 'countersignedAt': None,
@@ -206,6 +215,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
         (2, 'framework-slug'): {
             'frameworkInterest': {
                 'declaration': {'status': 'complete'},
+                'frameworkSlug': 'g-things-1',
                 'onFramework': True,
                 'countersignedPath': 'some/path',
                 'countersignedAt': '2017-01-02T03:04:05.000006Z',
@@ -241,7 +251,8 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
                     ('saas', 'not-submitted'): 1}
             ),
             'countersignedAt': '',
-            'onFramework': True
+            'onFramework': True,
+            'frameworkSlug': 'g-things-1',
         },
         {
             'supplier': {'id': 3, 'name': 'supplier 3'},
@@ -257,7 +268,8 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
                     ('saas', 'not-submitted'): 1}
             ),
             'countersignedAt': '',
-            'onFramework': False
+            'onFramework': False,
+            'frameworkSlug': 'g-things-1',
         },
         {
             'supplier': {'id': 2, 'name': 'supplier 2'},
@@ -273,7 +285,8 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
                     ('saas', 'not-submitted'): 1}
             ),
             'countersignedAt': '2017-01-02T03:04:05.000006Z',
-            'onFramework': True
+            'onFramework': True,
+            'frameworkSlug': 'g-things-1',
         }
     ]
 
@@ -319,6 +332,7 @@ def test_add_framework_info(mock_data_client, on_framework):
     mock_data_client.get_supplier_framework_info.return_value = {
         'frameworkInterest': {
             'declaration': {'status': 'complete'},
+            'frameworkSlug': 'g-things-1',
             'onFramework': on_framework,
             'countersignedPath': None,
             'countersignedAt': None,
@@ -331,6 +345,7 @@ def test_add_framework_info(mock_data_client, on_framework):
     assert record == {
         'supplier_id': 123,
         'foo': 'bar',
+        'frameworkSlug': 'g-things-1',
         'onFramework': on_framework,
         'declaration': {
             'status': 'complete',

--- a/tests/test_export_framework_results_reasons.py
+++ b/tests/test_export_framework_results_reasons.py
@@ -70,6 +70,7 @@ class _BaseExportTest(_BaseExportFrameworkResultsReasonsTest):
                 "failed_mandatory",
                 "contact_name",
                 "contact_email",
+                "admin_link",
             ]
             assert sorted(lines[1:]) == sorted(expected_failed)
 
@@ -85,6 +86,7 @@ class _BaseExportTest(_BaseExportFrameworkResultsReasonsTest):
                 "mitigating factors 3",
                 "contact_name",
                 "contact_email",
+                "admin_link",
             ]
             assert sorted(lines[1:]) == sorted(expected_discretionary)
 
@@ -115,6 +117,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Q1 - shouldBeFalseStrict",
                     u"Supplier 2345 Empl\u00f6yee 123",
                     "supplier.2345.h-cloud-99@example.com",
+                    'https://www.digitalmarketplace.service.gov.uk/suppliers/2345/edit/declarations/h-cloud-99',
                 ],
                 [
                     "Supplier 3456 generic name",
@@ -122,6 +125,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "No passed lot",
                     u"Supplier 3456 Empl\u00f6yee 123",
                     "supplier.3456.h-cloud-99@example.com",
+                    'https://www.digitalmarketplace.service.gov.uk/suppliers/3456/edit/declarations/h-cloud-99',
                 ],
             ),
             (
@@ -134,6 +138,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Supplier 1234's dog ate their homework",
                     u"Supplier 1234 Empl\u00f6yee 123",
                     "supplier.1234.h-cloud-99@example.com",
+                    'https://www.digitalmarketplace.service.gov.uk/suppliers/1234/edit/declarations/h-cloud-99',
                 ],
                 [
                     "Supplier 7654 generic name",
@@ -144,6 +149,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Supplier 7654's dog ate their homework",
                     u"Supplier 7654 Empl\u00f6yee 123",
                     "supplier.7654.h-cloud-99@example.com",
+                    'https://www.digitalmarketplace.service.gov.uk/suppliers/7654/edit/declarations/h-cloud-99',
                 ],
             ),
             (
@@ -177,6 +183,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Q1 - shouldBeFalseStrict",
                     u"Supplier 2345 Empl\u00f6yee 123",
                     "supplier.2345.h-cloud-99@example.com",
+                    'https://www.digitalmarketplace.service.gov.uk/suppliers/2345/edit/declarations/h-cloud-99',
                 ],
                 [
                     "Supplier 3456 generic name",
@@ -184,6 +191,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "No passed lot",
                     u"Supplier 3456 Empl\u00f6yee 123",
                     "supplier.3456.h-cloud-99@example.com",
+                    'https://www.digitalmarketplace.service.gov.uk/suppliers/3456/edit/declarations/h-cloud-99',
                 ],
             ),
             (
@@ -196,6 +204,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Supplier 1234's dog ate their homework",
                     u"Supplier 1234 Empl\u00f6yee 123",
                     "supplier.1234.h-cloud-99@example.com",
+                    'https://www.digitalmarketplace.service.gov.uk/suppliers/1234/edit/declarations/h-cloud-99',
                 ],
                 [
                     "Supplier 7654 generic name",
@@ -206,6 +215,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Supplier 7654's dog ate their homework",
                     u"Supplier 7654 Empl\u00f6yee 123",
                     "supplier.7654.h-cloud-99@example.com",
+                    'https://www.digitalmarketplace.service.gov.uk/suppliers/7654/edit/declarations/h-cloud-99',
                 ],
             ),
             (
@@ -256,6 +266,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "No passed lot",
                     u"Supplier 3456 Empl\u00f6yee 123",
                     "supplier.3456.h-cloud-99@example.com",
+                    "https://www.digitalmarketplace.service.gov.uk/suppliers/3456/edit/declarations/h-cloud-99"
                 ],
             ),
             (
@@ -268,6 +279,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 1234's dog ate their homework",
                     u"Supplier 1234 Empl\u00f6yee 123",
                     "supplier.1234.h-cloud-99@example.com",
+                    "https://www.digitalmarketplace.service.gov.uk/suppliers/1234/edit/declarations/h-cloud-99",
                 ],
                 [
                     "Supplier 2345 generic name",
@@ -278,6 +290,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 2345's dog ate their homework",
                     u"Supplier 2345 Empl\u00f6yee 123",
                     "supplier.2345.h-cloud-99@example.com",
+                    "https://www.digitalmarketplace.service.gov.uk/suppliers/2345/edit/declarations/h-cloud-99",
                 ],
                 [
                     "Supplier 7654 generic name",
@@ -288,6 +301,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 7654's dog ate their homework",
                     u"Supplier 7654 Empl\u00f6yee 123",
                     "supplier.7654.h-cloud-99@example.com",
+                    "https://www.digitalmarketplace.service.gov.uk/suppliers/7654/edit/declarations/h-cloud-99",
                 ],
             ),
             (
@@ -320,6 +334,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "No passed lot",
                     u"Supplier 3456 Empl\u00f6yee 123",
                     "supplier.3456.h-cloud-99@example.com",
+                    "https://www.digitalmarketplace.service.gov.uk/suppliers/3456/edit/declarations/h-cloud-99",
                 ],
             ),
             (
@@ -332,6 +347,8 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 1234's dog ate their homework",
                     u"Supplier 1234 Empl\u00f6yee 123",
                     "supplier.1234.h-cloud-99@example.com",
+                    "https://www.digitalmarketplace.service.gov.uk/suppliers/1234/edit/declarations/h-cloud-99",
+
                 ],
                 [
                     "Supplier 2345 generic name",
@@ -342,6 +359,8 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 2345's dog ate their homework",
                     u"Supplier 2345 Empl\u00f6yee 123",
                     "supplier.2345.h-cloud-99@example.com",
+                    "https://www.digitalmarketplace.service.gov.uk/suppliers/2345/edit/declarations/h-cloud-99",
+
                 ],
                 [
                     "Supplier 7654 generic name",
@@ -352,6 +371,8 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 7654's dog ate their homework",
                     u"Supplier 7654 Empl\u00f6yee 123",
                     "supplier.7654.h-cloud-99@example.com",
+                    "https://www.digitalmarketplace.service.gov.uk/suppliers/7654/edit/declarations/h-cloud-99",
+
                 ],
             ),
             (


### PR DESCRIPTION
298-include-link-to-admin-view-in-failed-csv-report-we-send-to-ccs

https://trello.com/c/6ug1H0As/298-include-link-to-admin-view-in-failed-csv-report-we-send-to-ccs

Make 'frameworkSlug' available on record from client.get_supplier_framework_info response
Use record['frameworkSlug'] to create link to declaration in admin (with supplier id and stage hard coded to production)

* Add link to failed/ discresionary declaration in output csv for quick access by ccs
  * Make frameworkSlug available in supplier info
* Update tests
