### PR TITLE
Add human-readable log output to Jenkins console

### DIFF
--- a/scripts/snapshot-framework-stats.py
+++ b/scripts/snapshot-framework-stats.py
@@ -26,6 +26,33 @@ def get_stats(data_client, framework_slug):
     return data_client.get_framework_stats(framework_slug)
 
 
+def log_human_readable_stats(stats):
+    total_applications = 0
+    made_declaration = 0
+    added_services = 0
+    completed = 0
+    started = 0
+
+    for stat in stats['interested_suppliers']:
+        total_applications += stat['count']
+        if stat['has_completed_services']:
+            if stat['declaration_status'] == 'complete':
+                completed += stat['count']
+            elif stat['declaration_status'] == 'started':
+                added_services += stat['count']
+        else:
+            if stat['declaration_status'] == 'complete':
+                made_declaration += stat['count']
+            else:
+                started += stat['count']
+
+    logger.info(f"Started: {started}")
+    logger.info(f"Made declaration: {made_declaration}")
+    logger.info(f"Added services: {added_services}")
+    logger.info(f"Completed: {completed}")
+    logger.info(f"Total applications: {total_applications}")
+
+
 def snapshot_framework_stats(api_endpoint, api_token, framework_slug):
     data_client = dmapiclient.DataAPIClient(api_endpoint, api_token)
 
@@ -36,6 +63,7 @@ def snapshot_framework_stats(api_endpoint, api_token, framework_slug):
         object_type='frameworks',
         object_id=framework_slug
     )
+    log_human_readable_stats(stats)
 
     logger.info("Framework stats snapshot saved")
 

--- a/scripts/snapshot-framework-stats.py
+++ b/scripts/snapshot-framework-stats.py
@@ -46,11 +46,13 @@ def log_human_readable_stats(stats):
             else:
                 started += stat['count']
 
+    logger.info("*********** STATS ***********")
     logger.info(f"Started: {started}")
     logger.info(f"Made declaration: {made_declaration}")
     logger.info(f"Added services: {added_services}")
     logger.info(f"Completed: {completed}")
     logger.info(f"Total applications: {total_applications}")
+    logger.info("*****************************")
 
 
 def snapshot_framework_stats(api_endpoint, api_token, framework_slug):


### PR DESCRIPTION
https://trello.com/c/AnvspHsL/1526-log-human-readable-stats-on-jenkins-framework-stats-output

Quick and dirty way to get a copy-and-pastable equivalent of the current framework application stats (see last year's performance platform https://www.gov.uk/performance/g-cloud-11-supplier-applications/applications-by-stage-tab/applications-by-stage-tab-applications-by-stage-day), as the current API JSON output is not the easiest to parse!

This way a developer can at least grab the latest Jenkins console output and easily share it with a Product Manager.