### PR TITLE
Include unstarted declarations in service count

### DIFF
--- a/scripts/framework-applications/snapshot-framework-stats.py
+++ b/scripts/framework-applications/snapshot-framework-stats.py
@@ -40,7 +40,7 @@ def log_human_readable_stats(stats):
         if stat['has_completed_services']:
             if stat['declaration_status'] == 'complete':
                 completed += stat['count']
-            elif stat['declaration_status'] == 'started':
+            else:
                 added_services += stat['count']
         else:
             if stat['declaration_status'] == 'complete':


### PR DESCRIPTION
https://trello.com/c/huqe0wRJ/1550-whats-going-on-with-current-applications

The human-readable stats output service count is only including suppliers who've started (but not completed) a declaration, and submitted at least one service.

This fix includes any suppliers who haven't completed the declaration (i.e. including those who haven't even started it), but have submitted at least service.