### PR TITLE
Add logging for DOS opportunities export

### DIFF
--- a/dmscripts/export_dos_opportunities.py
+++ b/dmscripts/export_dos_opportunities.py
@@ -60,16 +60,19 @@ def get_latest_dos_framework(client):
     return 'digital-outcomes-and-specialists'
 
 
-def get_brief_data(client):
+def get_brief_data(client, logger):
+    logger.info("Fetching closed briefs from API")
     briefs = client.find_briefs_iter(status="closed,awarded,unsuccessful,cancelled", with_users=True)
     rows = []
     for brief in briefs:
+        logger.info(f"Fetching brief responses for Brief ID {brief['id']}")
         brief_responses = client.find_brief_responses_iter(brief_id=brief['id'])
         rows.append(_build_row(brief, brief_responses))
     return rows
 
 
-def write_rows_to_csv(rows, file_path):
+def write_rows_to_csv(rows, file_path, logger):
+    logger.info(f"Writing rows to {file_path}")
     with open(file_path, 'w') as csv_file:
         writer = csv.writer(csv_file, delimiter=',', quotechar='"')
         writer.writerow(DOS_OPPORTUNITY_HEADERS)

--- a/scripts/export-dos-opportunities.py
+++ b/scripts/export-dos-opportunities.py
@@ -23,6 +23,7 @@ from dmapiclient import DataAPIClient
 
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.logging_helpers import logging, configure_logger
+from dmscripts.helpers.s3_helpers import get_bucket_name
 from dmscripts.export_dos_opportunities import (
     get_latest_dos_framework, get_brief_data, write_rows_to_csv, upload_file_to_s3
 )
@@ -52,7 +53,7 @@ if __name__ == '__main__':
 
     DOWNLOAD_FILE_NAME = 'opportunity-data.csv'
     file_path = os.path.join(OUTPUT_DIR, DOWNLOAD_FILE_NAME)
-    bucket_name = 'digitalmarketplace-communications-{}-{}'.format(STAGE, STAGE)
+    bucket_name = get_bucket_name(STAGE, 'communications')
     key_name = '{}/communications/data/{}'.format(latest_framework_slug, DOWNLOAD_FILE_NAME)
 
     logger.info('Exporting DOS opportunity data to CSV')

--- a/scripts/export-dos-opportunities.py
+++ b/scripts/export-dos-opportunities.py
@@ -58,10 +58,10 @@ if __name__ == '__main__':
     logger.info('Exporting DOS opportunity data to CSV')
 
     # Get the data
-    rows = get_brief_data(client)
+    rows = get_brief_data(client, logger)
 
     # Construct CSV
-    write_rows_to_csv(rows, file_path)
+    write_rows_to_csv(rows, file_path, logger)
 
     # Grab bucket
     bucket = S3(bucket_name)

--- a/tests/test_export_dos_opportunities.py
+++ b/tests/test_export_dos_opportunities.py
@@ -70,7 +70,9 @@ def test_get_brief_data():
         BriefResponseStub().response()
     ]
 
-    rows = get_brief_data(client)
+    logger = mock.Mock()
+
+    rows = get_brief_data(client, logger)
 
     assert rows == [
         [
@@ -102,6 +104,10 @@ def test_get_brief_data():
     ]
     assert client.find_brief_responses_iter.call_args_list == [
         mock.call(brief_id=12345)
+    ]
+    assert logger.info.call_args_list == [
+        mock.call('Fetching closed briefs from API'),
+        mock.call('Fetching brief responses for Brief ID 12345')
     ]
 
 


### PR DESCRIPTION
https://trello.com/c/AuySMUcb/1559-add-more-logging-to-export-dos-opportunities-script

This job has been failing more than usual recently.

- Adds some logging so we can see the in-progress API calls
- Fixes a small bug when running the script locally (we aren't using the S3 helper function, so instead of uploading to the dev bucket, it attempts to upload to a non-existent bucket).