### PR TITLE
Add tests for Python 3.7 and 3.8 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - make requirements-dev
 script:

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -12,4 +12,4 @@ mock<4.0.0
 pytest
 requests-mock
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.5.0#egg=digitalmarketplace-test-utils
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,12 +12,11 @@ chardet==3.0.4            # via -c requirements.txt, requests
 click==7.0                # via -c requirements.txt, pip-tools
 cram==0.7                 # via -r requirements-dev.in
 decorator==4.4.1          # via ipython, traitlets
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.5.0#egg=digitalmarketplace-test-utils  # via -r requirements-dev.in
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2  # via -r requirements-dev.in
 entrypoints==0.3          # via flake8
 flake8==3.7.9             # via -r requirements-dev.in
 freezegun==0.3.15         # via -r requirements-dev.in
 idna==2.9                 # via -c requirements.txt, requests
-importlib-metadata==1.5.0  # via -c requirements.txt, pluggy, pytest
 ipython-genutils==0.2.0   # via -r requirements-dev.in, traitlets
 ipython==7.12.0           # via -r requirements-dev.in
 jedi==0.16.0              # via ipython
@@ -46,7 +45,6 @@ six==1.14.0               # via -c requirements.txt, freezegun, mock, packaging,
 traitlets==4.3.3          # via ipython
 urllib3==1.25.8           # via -c requirements.txt, requests
 wcwidth==0.1.8            # via prompt-toolkit, pytest
-zipp==3.0.0               # via -c requirements.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ itsdangerous==0.24 # pyup: ignore
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.6.0#egg=digitalmarketplace-utils==51.6.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.5.0#egg=digitalmarketplace-apiclient==21.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
 
 awscli==1.18.41

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ colorama==0.4.3           # via awscli
 contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.5.0#egg=digitalmarketplace-apiclient==21.5.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.6.0#egg=digitalmarketplace-utils==51.6.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via -r requirements.in, notifications-python-client


### PR DESCRIPTION
Now that pandas is gone (thanks to #491) the tests for Python 3.8 work :D

I also had to update some dm dependencies (thanks for flagging this up @domoscargin).