### PR TITLE
Add brief-status option to get-user script

### DIFF
--- a/dmscripts/get_user.py
+++ b/dmscripts/get_user.py
@@ -13,7 +13,7 @@ from dmscripts.helpers.user_helpers import (
 )
 
 
-def get_user(api_url, api_token, stage, role, framework, lot):
+def get_user(api_url, api_token, stage, role, framework, lot, *, brief_status=None):
     if not api_url:
         api_url = get_api_endpoint_from_stage(stage)
 
@@ -32,7 +32,7 @@ def get_user(api_url, api_token, stage, role, framework, lot):
         framework = get_full_framework_slug(framework)
         print('Framework: {}'.format(framework))
         if framework.startswith("digital-outcomes-and-specialists"):
-            print("Has requirements: True")
-            return get_random_buyer_with_brief(api_client, framework, lot)
+            print(f"Has requirements: {brief_status or 'True'}")
+            return get_random_buyer_with_brief(api_client, framework, lot, brief_status=brief_status)
     else:
         return get_random_user(api_client, role)

--- a/dmscripts/helpers/user_helpers.py
+++ b/dmscripts/helpers/user_helpers.py
@@ -19,11 +19,14 @@ def get_supplier_id(api_client, framework, lot):
     return random.choice(services)['supplierId']
 
 
-def get_random_buyer_with_brief(api_client, framework, lot):
+def get_random_buyer_with_brief(api_client, framework, lot, *, brief_status=None):
+    if brief_status is None:
+        brief_status = "live,cancelled,unsuccessful,closed,awarded"
+
     briefs = api_client.find_briefs(
         framework=framework,
         lot=lot,
-        status="live,cancelled,unsuccessful,closed,awarded",
+        status=brief_status,
         with_users=True,
     )["briefs"]
 

--- a/scripts/get-user.py
+++ b/scripts/get-user.py
@@ -5,14 +5,18 @@ For supplier users, providing additional <framework> and <lot> arguments allows
 filtering by suppliers who have published services on the given framewok and lot.
 
 Usage:
-    get-user.py <role> [<framework>] [<lot>] [options]
+    get-user.py [options] <role> [<framework>] [<lot>]
 
     --api-url=<api_url>     API URL (overrides --stage)
     --api-token=<api_token  API Token (overrides --stage)
     --stage=<stage>         Stage to target; automatically derive/decrypt api url and token [default: development]
 
+    --brief-status=<status>  Status can be one of draft,live,withdrawn,
+                             cancelled,unsuccessful,closed,awarded
+
 Example:
     ./get-user.py supplier g9 cloud-hosting
+    ./get-user.py buyer dos4 --brief-status=closed  # get a buyer user with closed briefs on DOS4
     ./get-user.py admin
     ./get-user.py --stage=preview supplier g-cloud-9
     ./get-user.py --stage=staging supplier dos2 digital-outcomes
@@ -34,6 +38,7 @@ if __name__ == "__main__":
         role=arguments['<role>'].lower(),
         framework=arguments['<framework>'].lower() if arguments['<framework>'] else None,
         lot=arguments['<lot>'].lower() if arguments['<lot>'] else None,
+        brief_status=arguments['--brief-status'].lower() if arguments['--brief-status'] else None,
     )
 
     print("\n".join(": ".join(u) for u in [


### PR DESCRIPTION
As a team member testing the Digital Marketplace...
I want to be able to find a user with DOS opportunities in a certain state...
So that I can check different parts of the DOS journey.

This PR adds a command line flag `--brief-status=<status>` that tries to make it easier to do this. The UI is a bit unhelpful and you have to look at the api[[1]] to have an idea of what the different statuses mean, but it's a start?

[1]: https://github.com/alphagov/digitalmarketplace-api/blob/release-1029/app/models/main.py#L1543-L1591