### PR TITLE
fix brief URL in DOS opportunities CSV

### DIFF
--- a/dmscripts/export_dos_opportunities.py
+++ b/dmscripts/export_dos_opportunities.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from dmutils.formats import DATE_FORMAT, DATETIME_FORMAT
 
 # This URL is framework agnostic
-PUBLIC_BRIEF_URL = "https://digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/{}"
+PUBLIC_BRIEF_URL = "https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/{}"
 
 DOS_OPPORTUNITY_HEADERS = [
     "ID", "Opportunity", "Link", "Framework", "Category", "Specialist",

--- a/tests/test_export_dos_opportunities.py
+++ b/tests/test_export_dos_opportunities.py
@@ -116,7 +116,7 @@ class TestGetBriefData:
             [
                 12345,
                 'My Brilliant Brief',
-                'https://digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/12345',
+                'https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/12345',
                 'digital-outcomes-and-specialists-3',
                 'digital-specialists',
                 'technicalArchitect',


### PR DESCRIPTION
_bug discovered while investigating this card https://trello.com/c/0LD5lLbf/95-1-amend-opportunity-data-report_

The links in the DOS opportunity CSV previously did not resolve as they were missing `www.`
