### PR TITLE
fix specialist field in CSV

### DIFF
--- a/dmscripts/export_dos_opportunities.py
+++ b/dmscripts/export_dos_opportunities.py
@@ -42,7 +42,7 @@ def _build_row(brief, brief_responses):
         PUBLIC_BRIEF_URL.format(brief['id']),
         brief['frameworkSlug'],
         brief['lotSlug'],
-        brief.get('specialist', ""),
+        brief.get('specialistRole', ""),
         brief['organisation'],
         remove_username_from_email_address(brief['users'][0]['emailAddress']),
         brief['location'],

--- a/tests/test_export_dos_opportunities.py
+++ b/tests/test_export_dos_opportunities.py
@@ -17,7 +17,7 @@ example_brief = {
     "title": "My Brilliant Brief",
     "frameworkSlug": "digital-outcomes-and-specialists-3",
     "lotSlug": "digital-specialists",
-    "specialist": "technicalArchitect",
+    "specialistRole": "technicalArchitect",
     "organisation": "HM Dept of Doing Stuff",
     "location": "London",
     "publishedAt": "2019-01-01T00:00:00.123456Z",


### PR DESCRIPTION
https://trello.com/c/JDz7V5SO/1704-dos-opportunity-export-csv-missing-specialist-role
Previously this was looking for a field which was not returned by the API. 