### PR TITLE
Don't use DMNotifyClient's sent_references_cache when re-running failed script

### DIFF
--- a/dmscripts/notify_suppliers_of_framework_application_event.py
+++ b/dmscripts/notify_suppliers_of_framework_application_event.py
@@ -92,7 +92,7 @@ def notify_suppliers_of_framework_application_event(
                     },
                 )
                 if dry_run:
-                    if notify_client.has_been_sent(notify_ref):
+                    if notify_client.has_been_sent(notify_ref, use_recent_cache=run_is_new):
                         logger.debug(
                             "[DRY RUN] Would NOT send notification to {email_hash} (already sent)",
                             extra={"email_hash": hash_string(user["emailAddress"])},
@@ -110,6 +110,7 @@ def notify_suppliers_of_framework_application_event(
                             framework_context,
                             allow_resend=False,
                             reference=notify_ref,
+                            use_recent_cache=run_is_new,
                         )
                     except EmailError as e:
                         failure_count += 1

--- a/dmscripts/notify_suppliers_of_framework_application_event.py
+++ b/dmscripts/notify_suppliers_of_framework_application_event.py
@@ -92,6 +92,7 @@ def notify_suppliers_of_framework_application_event(
                     },
                 )
                 if dry_run:
+                    # Use the sent references cache unless we're re-running the script following a failure
                     if notify_client.has_been_sent(notify_ref, use_recent_cache=run_is_new):
                         logger.debug(
                             "[DRY RUN] Would NOT send notification to {email_hash} (already sent)",
@@ -104,6 +105,7 @@ def notify_suppliers_of_framework_application_event(
                         )
                 else:
                     try:
+                        # Use the sent references cache unless we're re-running the script following a failure
                         notify_client.send_email(
                             user["emailAddress"],
                             notify_template_id,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,7 @@ entrypoints==0.3          # via flake8
 flake8==3.7.9             # via -r requirements-dev.in
 freezegun==0.3.15         # via -r requirements-dev.in
 idna==2.9                 # via -c requirements.txt, requests
+importlib-metadata==1.5.0  # via -c requirements.txt, pluggy, pytest
 ipython-genutils==0.2.0   # via -r requirements-dev.in, traitlets
 ipython==7.12.0           # via -r requirements-dev.in
 jedi==0.16.0              # via ipython
@@ -45,6 +46,7 @@ six==1.14.0               # via -c requirements.txt, freezegun, mock, packaging,
 traitlets==4.3.3          # via ipython
 urllib3==1.25.8           # via -c requirements.txt, requests
 wcwidth==0.1.8            # via prompt-toolkit, pytest
+zipp==3.0.0               # via -c requirements.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ Flask==1.0.4
 itsdangerous==1.1.0
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.6.0#egg=digitalmarketplace-utils==51.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.7.0#egg=digitalmarketplace-utils==52.7.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.6.0#egg=digitalmarketplace-apiclient==21.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.6.0#egg=digitalmarketplace-apiclient==21.6.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.6.0#egg=digitalmarketplace-utils==51.6.0  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.7.0#egg=digitalmarketplace-utils==52.7.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via -r requirements.in, notifications-python-client
 docutils==0.15.2          # via awscli, botocore
 flask-gzip==0.2           # via digitalmarketplace-utils

--- a/tests/test_notify_suppliers_of_framework_application_event.py
+++ b/tests/test_notify_suppliers_of_framework_application_event.py
@@ -88,7 +88,7 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
         self.mock_notify_client.get_reference.side_effect = lambda *a: ",".join(str(x) for x in a)
         self.mock_notify_client.has_been_sent.side_effect = (
             # this one ref is considered to be already sent
-            lambda reference: reference == (
+            lambda reference, use_recent_cache: reference == (
                 "two@shirts.co.ua,8877eeff,{'framework_slug': 'g-cloud-99', 'run_id': "
                 "'00010203-0405-0607-0809-0a0b0c0d0e0f'}"
             )
@@ -165,16 +165,20 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
         if dry_run:
             assert self.mock_notify_client.has_been_sent.call_args_list == [
                 mock.call(
-                    f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
+                    f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=True
                 ),
                 mock.call(
                     f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=True
                 ),
                 mock.call(
                     f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=True
                 ),
                 mock.call(
                     f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=True
                 )
             ]
         else:
@@ -186,6 +190,7 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
                     allow_resend=False,
                     reference=f"one@peasoup.net,8877eeff,"
                               f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=True
                 ),
                 mock.call(
                     'two@peasoup.net',
@@ -194,6 +199,7 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
                     allow_resend=False,
                     reference=f"two@peasoup.net,8877eeff,"
                               f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=True
                 ),
                 mock.call(
                     'two@shirts.co.ua',
@@ -202,6 +208,7 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
                     allow_resend=False,
                     reference=f"two@shirts.co.ua,8877eeff,"
                               f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=True
                 ),
                 mock.call(
                     'three@shirts.co.ua',
@@ -210,6 +217,7 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
                     allow_resend=False,
                     reference=f"three@shirts.co.ua,8877eeff,"
                               f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=True
                 )
             ]
 
@@ -254,16 +262,20 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
         if dry_run:
             assert self.mock_notify_client.has_been_sent.call_args_list == [
                 mock.call(
-                    f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
+                    f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=False
                 ),
                 mock.call(
                     f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=False
                 ),
                 mock.call(
                     f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=False
                 ),
                 mock.call(
                     f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=False
                 )
             ]
         else:
@@ -275,6 +287,7 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
                     allow_resend=False,
                     reference=f"one@peasoup.net,8877eeff,"
                               f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=False
                 ),
                 mock.call(
                     'two@peasoup.net',
@@ -283,6 +296,7 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
                     allow_resend=False,
                     reference=f"two@peasoup.net,8877eeff,"
                               f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=False
                 ),
                 mock.call(
                     'two@shirts.co.ua',
@@ -291,6 +305,7 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
                     allow_resend=False,
                     reference=f"two@shirts.co.ua,8877eeff,"
                               f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=False
                 ),
                 mock.call(
                     'three@shirts.co.ua',
@@ -299,6 +314,7 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
                     allow_resend=False,
                     reference=f"three@shirts.co.ua,8877eeff,"
                               f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                    use_recent_cache=False
                 )
             ]
 

--- a/tests/test_notify_suppliers_of_framework_application_event.py
+++ b/tests/test_notify_suppliers_of_framework_application_event.py
@@ -66,329 +66,271 @@ _supplier_users_by_supplier = {
 }
 
 
-@pytest.mark.parametrize("dry_run", (False, True))
-@mock.patch("dmscripts.notify_suppliers_of_framework_application_event.uuid4")
-def test_happy_path_without_resume_run_id(mock_uuid4, dry_run):
-    mock_uuid4.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
+class TestNotifySuppliersOfFrameworkApplicationEvent:
 
-    mock_data_api_client = mock.create_autospec(DataAPIClient, instance=True)
-    framework_response = FrameworkStub(
-        slug="g-cloud-99",
-        status="open",
-    ).single_result_response()
-    framework_response["frameworks"]["intentionToAwardAtUTC"] = "2000-06-29T16:00:00.0000Z"
-    framework_response["frameworks"]["frameworkLiveAtUTC"] = "2000-06-29T16:30:00.0000Z"
-    mock_data_api_client.get_framework.return_value = framework_response
-    mock_data_api_client.find_framework_suppliers_iter.side_effect = lambda *a, **k: iter(_supplier_frameworks)
-    mock_data_api_client.find_users_iter.side_effect = lambda *a, **k: iter(
-        _supplier_users_by_supplier[k["supplier_id"]]
-    )
-
-    mock_notify_client = mock.create_autospec(DMNotifyClient, instance=True)
-    mock_notify_client.get_reference.side_effect = lambda *a: ",".join(str(x) for x in a)
-    mock_notify_client.has_been_sent.side_effect = (
-        # this one ref is considered to be already sent
-        lambda reference: reference == (
-            "two@shirts.co.ua,8877eeff,{'framework_slug': 'g-cloud-99', 'run_id': "
-            "'00010203-0405-0607-0809-0a0b0c0d0e0f'}"
+    def setup(self):
+        # Set up DMAPIClient
+        self.mock_data_api_client = mock.create_autospec(DataAPIClient, instance=True)
+        framework_response = FrameworkStub(
+            slug="g-cloud-99",
+            status="open",
+        ).single_result_response()
+        framework_response["frameworks"]["intentionToAwardAtUTC"] = "2000-06-29T16:00:00.0000Z"
+        framework_response["frameworks"]["frameworkLiveAtUTC"] = "2000-06-29T16:30:00.0000Z"
+        self.mock_data_api_client.get_framework.return_value = framework_response
+        self.mock_data_api_client.find_framework_suppliers_iter.side_effect = lambda *a, **k: iter(_supplier_frameworks)
+        self.mock_data_api_client.find_users_iter.side_effect = lambda *a, **k: iter(
+            _supplier_users_by_supplier[k["supplier_id"]]
         )
-    )
 
-    mock_logger = mock.create_autospec(logging.Logger, instance=True)
+        # Setup DMNotifyClient
+        self.mock_notify_client = mock.create_autospec(DMNotifyClient, instance=True)
+        self.mock_notify_client.get_reference.side_effect = lambda *a: ",".join(str(x) for x in a)
+        self.mock_notify_client.has_been_sent.side_effect = (
+            # this one ref is considered to be already sent
+            lambda reference: reference == (
+                "two@shirts.co.ua,8877eeff,{'framework_slug': 'g-cloud-99', 'run_id': "
+                "'00010203-0405-0607-0809-0a0b0c0d0e0f'}"
+            )
+        )
 
-    with freeze_time('2000-06-29 02:55:55'):
+        # Setup logger
+        self.mock_logger = mock.create_autospec(logging.Logger, instance=True)
+
+        # Setup expected calls
+        self.expected_context = {
+            'framework_name': 'G-Cloud 99',
+            'updates_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/updates',
+            'framework_dashboard_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/',
+            'clarification_questions_closed': 'no',
+            'clarificationsCloseAt_displaytimeformat': '12:00am GMT',
+            'clarificationsCloseAt_dateformat': 'Saturday 1 January 2000',
+            'clarificationsCloseAt_datetimeformat': 'Saturday 1 January 2000 at 12:00am GMT',
+            'clarificationsPublishAt_displaytimeformat': '12:00am GMT',
+            'clarificationsPublishAt_dateformat': 'Sunday 2 January 2000',
+            'clarificationsPublishAt_datetimeformat': 'Sunday 2 January 2000 at 12:00am GMT',
+            'applicationsCloseAt_displaytimeformat': '12:00am GMT',
+            'applicationsCloseAt_dateformat': 'Monday 3 January 2000',
+            'applicationsCloseAt_datetimeformat': 'Monday 3 January 2000 at 12:00am GMT',
+            'intentionToAwardAt_displaytimeformat': '5:00pm BST',
+            'intentionToAwardAt_timetoday': 'Today at 5pm BST',
+            'intentionToAwardAt_dateformat': 'Thursday 29 June 2000',
+            'intentionToAwardAt_datetimeformat': 'Thursday 29 June 2000 at 5:00pm BST',
+            'frameworkLiveAt_displaytimeformat': '5:30pm BST',
+            'frameworkLiveAt_dateformat': 'Thursday 29 June 2000',
+            'frameworkLiveAt_datetimeformat': 'Thursday 29 June 2000 at 5:30pm BST',
+            # no frameworkLiveAt_timetoday because it's non-hour-exact
+            'frameworkExpiresAt_displaytimeformat': '12:00am GMT',
+            'frameworkExpiresAt_dateformat': 'Thursday 6 January 2000',
+            'frameworkExpiresAt_datetimeformat': 'Thursday 6 January 2000 at 12:00am GMT',
+        }
+
+    @pytest.mark.parametrize("dry_run", (False, True))
+    @mock.patch("dmscripts.notify_suppliers_of_framework_application_event.uuid4")
+    def test_happy_path_without_resume_run_id(self, mock_uuid4, dry_run):
+        mock_uuid4.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+        with freeze_time('2000-06-29 02:55:55'):
+            assert notify_suppliers_of_framework_application_event(
+                data_api_client=self.mock_data_api_client,
+                notify_client=self.mock_notify_client,
+                notify_template_id="8877eeff",
+                framework_slug="g-cloud-99",
+                dry_run=dry_run,
+                stage="production",
+                logger=self.mock_logger,
+                run_id=None,
+            ) == 0
+
+        expected_run_id = "12345678-1234-5678-1234-567812345678"
+
+        assert mock_uuid4.mock_calls == [mock.call()]
+        assert self.mock_data_api_client.mock_calls == [
+            mock.call.get_framework("g-cloud-99"),
+            mock.call.find_framework_suppliers_iter("g-cloud-99"),
+            mock.call.find_users_iter(supplier_id=303132),
+            mock.call.find_users_iter(supplier_id=303233),
+            mock.call.find_users_iter(supplier_id=303133),
+            mock.call.find_users_iter(supplier_id=313233),
+        ]
+        assert self.mock_notify_client.mock_calls == [
+            mock.call.get_reference("one@peasoup.net", "8877eeff", {
+                'framework_slug': 'g-cloud-99',
+                'run_id': expected_run_id,
+            }),
+            (mock.call.has_been_sent(
+                f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
+            ) if dry_run else mock.call.send_email(
+                'one@peasoup.net',
+                '8877eeff',
+                self.expected_context,
+                allow_resend=False,
+                reference=f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            )),
+            mock.call.get_reference("two@peasoup.net", "8877eeff", {
+                'framework_slug': 'g-cloud-99',
+                'run_id': expected_run_id,
+            }),
+            (mock.call.has_been_sent(
+                f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            ) if dry_run else mock.call.send_email(
+                'two@peasoup.net',
+                '8877eeff',
+                self.expected_context,
+                allow_resend=False,
+                reference=f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            )),
+            mock.call.get_reference("two@shirts.co.ua", "8877eeff", {
+                'framework_slug': 'g-cloud-99',
+                'run_id': expected_run_id,
+            }),
+            (mock.call.has_been_sent(
+                f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            ) if dry_run else mock.call.send_email(
+                'two@shirts.co.ua',
+                '8877eeff',
+                self.expected_context,
+                allow_resend=False,
+                reference=f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            )),
+            mock.call.get_reference("three@shirts.co.ua", "8877eeff", {
+                'framework_slug': 'g-cloud-99',
+                'run_id': expected_run_id,
+            }),
+            (mock.call.has_been_sent(
+                f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            ) if dry_run else mock.call.send_email(
+                'three@shirts.co.ua',
+                '8877eeff',
+                self.expected_context,
+                allow_resend=False,
+                reference=f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            )),
+        ]
+
+    @pytest.mark.parametrize("dry_run", (False, True))
+    @mock.patch("dmscripts.notify_suppliers_of_framework_application_event.uuid4")
+    def test_happy_paths_with_resume_run_id(self, mock_uuid4, dry_run):
+        run_id = uuid.UUID("00010203-0405-0607-0809-0a0b0c0d0e0f")
+        mock_uuid4.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+        with freeze_time('2000-06-29 02:55:55'):
+            assert notify_suppliers_of_framework_application_event(
+                data_api_client=self.mock_data_api_client,
+                notify_client=self.mock_notify_client,
+                notify_template_id="8877eeff",
+                framework_slug="g-cloud-99",
+                dry_run=dry_run,
+                stage="production",
+                logger=self.mock_logger,
+                run_id=run_id,
+            ) == 0
+
+        expected_run_id = str(run_id)
+
+        assert mock_uuid4.mock_calls == []
+        assert self.mock_data_api_client.mock_calls == [
+            mock.call.get_framework("g-cloud-99"),
+            mock.call.find_framework_suppliers_iter("g-cloud-99"),
+            mock.call.find_users_iter(supplier_id=303132),
+            mock.call.find_users_iter(supplier_id=303233),
+            mock.call.find_users_iter(supplier_id=303133),
+            mock.call.find_users_iter(supplier_id=313233),
+        ]
+        assert self.mock_notify_client.mock_calls == [
+            mock.call.get_reference("one@peasoup.net", "8877eeff", {
+                'framework_slug': 'g-cloud-99',
+                'run_id': expected_run_id,
+            }),
+            (mock.call.has_been_sent(
+                f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
+            ) if dry_run else mock.call.send_email(
+                'one@peasoup.net',
+                '8877eeff',
+                self.expected_context,
+                allow_resend=False,
+                reference=f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            )),
+            mock.call.get_reference("two@peasoup.net", "8877eeff", {
+                'framework_slug': 'g-cloud-99',
+                'run_id': expected_run_id,
+            }),
+            (mock.call.has_been_sent(
+                f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            ) if dry_run else mock.call.send_email(
+                'two@peasoup.net',
+                '8877eeff',
+                self.expected_context,
+                allow_resend=False,
+                reference=f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            )),
+            mock.call.get_reference("two@shirts.co.ua", "8877eeff", {
+                'framework_slug': 'g-cloud-99',
+                'run_id': expected_run_id,
+            }),
+            (mock.call.has_been_sent(
+                f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            ) if dry_run else mock.call.send_email(
+                'two@shirts.co.ua',
+                '8877eeff',
+                self.expected_context,
+                allow_resend=False,
+                reference=f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            )),
+            mock.call.get_reference("three@shirts.co.ua", "8877eeff", {
+                'framework_slug': 'g-cloud-99',
+                'run_id': expected_run_id,
+            }),
+            (mock.call.has_been_sent(
+                f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            ) if dry_run else mock.call.send_email(
+                'three@shirts.co.ua',
+                '8877eeff',
+                self.expected_context,
+                allow_resend=False,
+                reference=f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+            )),
+        ]
+
+        assert dry_run == (
+            mock.call.debug(
+                "[DRY RUN] Would NOT send notification to {email_hash} (already sent)",
+                extra=mock.ANY,
+            ) in self.mock_logger.mock_calls
+        )
+
+    def test_sending_failure_continues(self):
+
+        def _send_email_side_effect(email_address, *args, **kwargs):
+            if email_address == "two@peasoup.net":
+                raise EmailError("foo")
+            return {}
+
+        self.mock_notify_client.send_email.side_effect = _send_email_side_effect
+
         assert notify_suppliers_of_framework_application_event(
-            data_api_client=mock_data_api_client,
-            notify_client=mock_notify_client,
+            data_api_client=self.mock_data_api_client,
+            notify_client=self.mock_notify_client,
             notify_template_id="8877eeff",
             framework_slug="g-cloud-99",
-            dry_run=dry_run,
+            dry_run=False,
             stage="production",
-            logger=mock_logger,
-            run_id=None,
-        ) == 0
+            logger=self.mock_logger,
+            run_id=uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        ) == 1
 
-    expected_run_id = "12345678-1234-5678-1234-567812345678"
-    expected_context = {
-        'framework_name': 'G-Cloud 99',
-        'updates_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/updates',
-        'framework_dashboard_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/',
-        'clarification_questions_closed': 'no',
-        'clarificationsCloseAt_displaytimeformat': '12:00am GMT',
-        'clarificationsCloseAt_dateformat': 'Saturday 1 January 2000',
-        'clarificationsCloseAt_datetimeformat': 'Saturday 1 January 2000 at 12:00am GMT',
-        'clarificationsPublishAt_displaytimeformat': '12:00am GMT',
-        'clarificationsPublishAt_dateformat': 'Sunday 2 January 2000',
-        'clarificationsPublishAt_datetimeformat': 'Sunday 2 January 2000 at 12:00am GMT',
-        'applicationsCloseAt_displaytimeformat': '12:00am GMT',
-        'applicationsCloseAt_dateformat': 'Monday 3 January 2000',
-        'applicationsCloseAt_datetimeformat': 'Monday 3 January 2000 at 12:00am GMT',
-        'intentionToAwardAt_displaytimeformat': '5:00pm BST',
-        'intentionToAwardAt_timetoday': 'Today at 5pm BST',
-        'intentionToAwardAt_dateformat': 'Thursday 29 June 2000',
-        'intentionToAwardAt_datetimeformat': 'Thursday 29 June 2000 at 5:00pm BST',
-        'frameworkLiveAt_displaytimeformat': '5:30pm BST',
-        'frameworkLiveAt_dateformat': 'Thursday 29 June 2000',
-        'frameworkLiveAt_datetimeformat': 'Thursday 29 June 2000 at 5:30pm BST',
-        # no frameworkLiveAt_timetoday because it's non-hour-exact
-        'frameworkExpiresAt_displaytimeformat': '12:00am GMT',
-        'frameworkExpiresAt_dateformat': 'Thursday 6 January 2000',
-        'frameworkExpiresAt_datetimeformat': 'Thursday 6 January 2000 at 12:00am GMT',
-    }
+        assert mock.call.error(
+            "Failed sending to {email_hash}: {e}",
+            extra={
+                "email_hash": mock.ANY,
+                "e": AnyStringMatching("foo"),
+            },
+        ) in self.mock_logger.mock_calls
 
-    assert mock_uuid4.mock_calls == [mock.call()]
-    assert mock_data_api_client.mock_calls == [
-        mock.call.get_framework("g-cloud-99"),
-        mock.call.find_framework_suppliers_iter("g-cloud-99"),
-        mock.call.find_users_iter(supplier_id=303132),
-        mock.call.find_users_iter(supplier_id=303233),
-        mock.call.find_users_iter(supplier_id=303133),
-        mock.call.find_users_iter(supplier_id=313233),
-    ]
-    assert mock_notify_client.mock_calls == [
-        mock.call.get_reference("one@peasoup.net", "8877eeff", {
-            'framework_slug': 'g-cloud-99',
-            'run_id': expected_run_id,
-        }),
-        (mock.call.has_been_sent(
-            f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
-        ) if dry_run else mock.call.send_email(
-            'one@peasoup.net',
-            '8877eeff',
-            expected_context,
-            allow_resend=False,
-            reference=f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        )),
-        mock.call.get_reference("two@peasoup.net", "8877eeff", {
-            'framework_slug': 'g-cloud-99',
-            'run_id': expected_run_id,
-        }),
-        (mock.call.has_been_sent(
-            f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        ) if dry_run else mock.call.send_email(
-            'two@peasoup.net',
-            '8877eeff',
-            expected_context,
-            allow_resend=False,
-            reference=f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        )),
-        mock.call.get_reference("two@shirts.co.ua", "8877eeff", {
-            'framework_slug': 'g-cloud-99',
-            'run_id': expected_run_id,
-        }),
-        (mock.call.has_been_sent(
-            f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        ) if dry_run else mock.call.send_email(
-            'two@shirts.co.ua',
-            '8877eeff',
-            expected_context,
-            allow_resend=False,
-            reference=f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        )),
-        mock.call.get_reference("three@shirts.co.ua", "8877eeff", {
-            'framework_slug': 'g-cloud-99',
-            'run_id': expected_run_id,
-        }),
-        (mock.call.has_been_sent(
-            f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        ) if dry_run else mock.call.send_email(
-            'three@shirts.co.ua',
-            '8877eeff',
-            expected_context,
-            allow_resend=False,
-            reference=f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        )),
-    ]
-
-
-@pytest.mark.parametrize("dry_run", (False, True))
-@mock.patch("dmscripts.notify_suppliers_of_framework_application_event.uuid4")
-def test_happy_paths_with_resume_run_id(mock_uuid4, dry_run):
-    run_id = uuid.UUID("00010203-0405-0607-0809-0a0b0c0d0e0f")
-    mock_uuid4.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
-
-    mock_data_api_client = mock.create_autospec(DataAPIClient, instance=True)
-    framework_response = FrameworkStub(
-        slug="g-cloud-99",
-        status="open",
-    ).single_result_response()
-    framework_response["frameworks"]["intentionToAwardAtUTC"] = "2000-06-29T16:00:00.0000Z"
-    framework_response["frameworks"]["frameworkLiveAtUTC"] = "2000-06-29T16:30:00.0000Z"
-    mock_data_api_client.get_framework.return_value = framework_response
-    mock_data_api_client.find_framework_suppliers_iter.side_effect = lambda *a, **k: iter(_supplier_frameworks)
-    mock_data_api_client.find_users_iter.side_effect = lambda *a, **k: iter(
-        _supplier_users_by_supplier[k["supplier_id"]]
-    )
-
-    mock_notify_client = mock.create_autospec(DMNotifyClient, instance=True)
-    mock_notify_client.get_reference.side_effect = lambda *a: ",".join(str(x) for x in a)
-    mock_notify_client.has_been_sent.side_effect = (
-        # this one ref is considered to be already sent
-        lambda reference: reference == (
-            "two@shirts.co.ua,8877eeff,{'framework_slug': 'g-cloud-99', 'run_id': "
-            "'00010203-0405-0607-0809-0a0b0c0d0e0f'}"
+        # check that we do actually end up trying to send all emails instead of giving up after error
+        assert tuple(call[0][0] for call in self.mock_notify_client.send_email.call_args_list) == (
+            "one@peasoup.net",
+            "two@peasoup.net",
+            "two@shirts.co.ua",
+            "three@shirts.co.ua",
         )
-    )
-
-    mock_logger = mock.create_autospec(logging.Logger, instance=True)
-
-    with freeze_time('2000-06-29 02:55:55'):
-        assert notify_suppliers_of_framework_application_event(
-            data_api_client=mock_data_api_client,
-            notify_client=mock_notify_client,
-            notify_template_id="8877eeff",
-            framework_slug="g-cloud-99",
-            dry_run=dry_run,
-            stage="production",
-            logger=mock_logger,
-            run_id=run_id,
-        ) == 0
-
-    expected_run_id = str(run_id)
-    expected_context = {
-        'framework_name': 'G-Cloud 99',
-        'updates_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/updates',
-        'framework_dashboard_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/',
-        'clarification_questions_closed': 'no',
-        'clarificationsCloseAt_displaytimeformat': '12:00am GMT',
-        'clarificationsCloseAt_dateformat': 'Saturday 1 January 2000',
-        'clarificationsCloseAt_datetimeformat': 'Saturday 1 January 2000 at 12:00am GMT',
-        'clarificationsPublishAt_displaytimeformat': '12:00am GMT',
-        'clarificationsPublishAt_dateformat': 'Sunday 2 January 2000',
-        'clarificationsPublishAt_datetimeformat': 'Sunday 2 January 2000 at 12:00am GMT',
-        'applicationsCloseAt_displaytimeformat': '12:00am GMT',
-        'applicationsCloseAt_dateformat': 'Monday 3 January 2000',
-        'applicationsCloseAt_datetimeformat': 'Monday 3 January 2000 at 12:00am GMT',
-        'intentionToAwardAt_displaytimeformat': '5:00pm BST',
-        'intentionToAwardAt_timetoday': 'Today at 5pm BST',
-        'intentionToAwardAt_dateformat': 'Thursday 29 June 2000',
-        'intentionToAwardAt_datetimeformat': 'Thursday 29 June 2000 at 5:00pm BST',
-        'frameworkLiveAt_displaytimeformat': '5:30pm BST',
-        'frameworkLiveAt_dateformat': 'Thursday 29 June 2000',
-        'frameworkLiveAt_datetimeformat': 'Thursday 29 June 2000 at 5:30pm BST',
-        # no frameworkLiveAt_timetoday because it's non-hour-exact
-        'frameworkExpiresAt_displaytimeformat': '12:00am GMT',
-        'frameworkExpiresAt_dateformat': 'Thursday 6 January 2000',
-        'frameworkExpiresAt_datetimeformat': 'Thursday 6 January 2000 at 12:00am GMT',
-    }
-
-    assert mock_uuid4.mock_calls == []
-    assert mock_data_api_client.mock_calls == [
-        mock.call.get_framework("g-cloud-99"),
-        mock.call.find_framework_suppliers_iter("g-cloud-99"),
-        mock.call.find_users_iter(supplier_id=303132),
-        mock.call.find_users_iter(supplier_id=303233),
-        mock.call.find_users_iter(supplier_id=303133),
-        mock.call.find_users_iter(supplier_id=313233),
-    ]
-    assert mock_notify_client.mock_calls == [
-        mock.call.get_reference("one@peasoup.net", "8877eeff", {
-            'framework_slug': 'g-cloud-99',
-            'run_id': expected_run_id,
-        }),
-        (mock.call.has_been_sent(
-            f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
-        ) if dry_run else mock.call.send_email(
-            'one@peasoup.net',
-            '8877eeff',
-            expected_context,
-            allow_resend=False,
-            reference=f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        )),
-        mock.call.get_reference("two@peasoup.net", "8877eeff", {
-            'framework_slug': 'g-cloud-99',
-            'run_id': expected_run_id,
-        }),
-        (mock.call.has_been_sent(
-            f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        ) if dry_run else mock.call.send_email(
-            'two@peasoup.net',
-            '8877eeff',
-            expected_context,
-            allow_resend=False,
-            reference=f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        )),
-        mock.call.get_reference("two@shirts.co.ua", "8877eeff", {
-            'framework_slug': 'g-cloud-99',
-            'run_id': expected_run_id,
-        }),
-        (mock.call.has_been_sent(
-            f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        ) if dry_run else mock.call.send_email(
-            'two@shirts.co.ua',
-            '8877eeff',
-            expected_context,
-            allow_resend=False,
-            reference=f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        )),
-        mock.call.get_reference("three@shirts.co.ua", "8877eeff", {
-            'framework_slug': 'g-cloud-99',
-            'run_id': expected_run_id,
-        }),
-        (mock.call.has_been_sent(
-            f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        ) if dry_run else mock.call.send_email(
-            'three@shirts.co.ua',
-            '8877eeff',
-            expected_context,
-            allow_resend=False,
-            reference=f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-        )),
-    ]
-
-    assert dry_run == (
-        mock.call.debug(
-            "[DRY RUN] Would NOT send notification to {email_hash} (already sent)",
-            extra=mock.ANY,
-        ) in mock_logger.mock_calls
-    )
-
-
-def test_sending_failure_continues():
-    mock_data_api_client = mock.create_autospec(DataAPIClient, instance=True)
-    mock_data_api_client.get_framework.return_value = FrameworkStub(
-        slug="g-cloud-99",
-        status="open",
-    ).single_result_response()
-    mock_data_api_client.find_framework_suppliers_iter.side_effect = lambda *a, **k: iter(_supplier_frameworks)
-    mock_data_api_client.find_users_iter.side_effect = lambda *a, **k: iter(
-        _supplier_users_by_supplier[k["supplier_id"]]
-    )
-
-    def _send_email_side_effect(email_address, *args, **kwargs):
-        if email_address == "two@peasoup.net":
-            raise EmailError("foo")
-        return {}
-
-    mock_notify_client = mock.create_autospec(DMNotifyClient, instance=True)
-    mock_notify_client.get_reference.side_effect = lambda *a: ",".join(str(x) for x in a)
-    mock_notify_client.send_email.side_effect = _send_email_side_effect
-
-    mock_logger = mock.create_autospec(logging.Logger, instance=True)
-
-    assert notify_suppliers_of_framework_application_event(
-        data_api_client=mock_data_api_client,
-        notify_client=mock_notify_client,
-        notify_template_id="8877eeff",
-        framework_slug="g-cloud-99",
-        dry_run=False,
-        stage="production",
-        logger=mock_logger,
-        run_id=uuid.UUID("12345678-1234-5678-1234-567812345678"),
-    ) == 1
-
-    assert mock.call.error(
-        "Failed sending to {email_hash}: {e}",
-        extra={
-            "email_hash": mock.ANY,
-            "e": AnyStringMatching("foo"),
-        },
-    ) in mock_logger.mock_calls
-
-    # check that we do actually end up trying to send all emails instead of giving up after error
-    assert tuple(call[0][0] for call in mock_notify_client.send_email.call_args_list) == (
-        "one@peasoup.net",
-        "two@peasoup.net",
-        "two@shirts.co.ua",
-        "three@shirts.co.ua",
-    )

--- a/tests/test_notify_suppliers_of_framework_application_event.py
+++ b/tests/test_notify_suppliers_of_framework_application_event.py
@@ -142,8 +142,6 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
                 run_id=None,
             ) == 0
 
-        expected_run_id = "12345678-1234-5678-1234-567812345678"
-
         assert mock_uuid4.mock_calls == [mock.call()]
         assert self.mock_data_api_client.mock_calls == [
             mock.call.get_framework("g-cloud-99"),
@@ -153,60 +151,67 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
             mock.call.find_users_iter(supplier_id=303133),
             mock.call.find_users_iter(supplier_id=313233),
         ]
-        assert self.mock_notify_client.mock_calls == [
-            mock.call.get_reference("one@peasoup.net", "8877eeff", {
-                'framework_slug': 'g-cloud-99',
-                'run_id': expected_run_id,
-            }),
-            (mock.call.has_been_sent(
-                f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
-            ) if dry_run else mock.call.send_email(
-                'one@peasoup.net',
-                '8877eeff',
-                self.expected_context,
-                allow_resend=False,
-                reference=f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            )),
-            mock.call.get_reference("two@peasoup.net", "8877eeff", {
-                'framework_slug': 'g-cloud-99',
-                'run_id': expected_run_id,
-            }),
-            (mock.call.has_been_sent(
-                f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            ) if dry_run else mock.call.send_email(
-                'two@peasoup.net',
-                '8877eeff',
-                self.expected_context,
-                allow_resend=False,
-                reference=f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            )),
-            mock.call.get_reference("two@shirts.co.ua", "8877eeff", {
-                'framework_slug': 'g-cloud-99',
-                'run_id': expected_run_id,
-            }),
-            (mock.call.has_been_sent(
-                f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            ) if dry_run else mock.call.send_email(
-                'two@shirts.co.ua',
-                '8877eeff',
-                self.expected_context,
-                allow_resend=False,
-                reference=f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            )),
+
+        expected_run_id = "12345678-1234-5678-1234-567812345678"
+        assert self.mock_notify_client.get_reference.call_args_list == [
+            mock.call("one@peasoup.net", "8877eeff", {'framework_slug': 'g-cloud-99', 'run_id': expected_run_id}),
+            mock.call("two@peasoup.net", "8877eeff", {'framework_slug': 'g-cloud-99', 'run_id': expected_run_id}),
+            mock.call("two@shirts.co.ua", "8877eeff", {'framework_slug': 'g-cloud-99', 'run_id': expected_run_id}),
             mock.call.get_reference("three@shirts.co.ua", "8877eeff", {
                 'framework_slug': 'g-cloud-99',
                 'run_id': expected_run_id,
             }),
-            (mock.call.has_been_sent(
-                f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            ) if dry_run else mock.call.send_email(
-                'three@shirts.co.ua',
-                '8877eeff',
-                self.expected_context,
-                allow_resend=False,
-                reference=f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            )),
         ]
+        if dry_run:
+            assert self.mock_notify_client.has_been_sent.call_args_list == [
+                mock.call(
+                    f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
+                ),
+                mock.call(
+                    f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                ),
+                mock.call(
+                    f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                ),
+                mock.call(
+                    f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                )
+            ]
+        else:
+            assert self.mock_notify_client.send_email.call_args_list == [
+                mock.call(
+                    'one@peasoup.net',
+                    '8877eeff',
+                    self.expected_context,
+                    allow_resend=False,
+                    reference=f"one@peasoup.net,8877eeff,"
+                              f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                ),
+                mock.call(
+                    'two@peasoup.net',
+                    '8877eeff',
+                    self.expected_context,
+                    allow_resend=False,
+                    reference=f"two@peasoup.net,8877eeff,"
+                              f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                ),
+                mock.call(
+                    'two@shirts.co.ua',
+                    '8877eeff',
+                    self.expected_context,
+                    allow_resend=False,
+                    reference=f"two@shirts.co.ua,8877eeff,"
+                              f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                ),
+                mock.call(
+                    'three@shirts.co.ua',
+                    '8877eeff',
+                    self.expected_context,
+                    allow_resend=False,
+                    reference=f"three@shirts.co.ua,8877eeff,"
+                              f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                )
+            ]
 
     @pytest.mark.parametrize("dry_run", (False, True))
     @mock.patch("dmscripts.notify_suppliers_of_framework_application_event.uuid4")
@@ -226,8 +231,6 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
                 run_id=run_id,
             ) == 0
 
-        expected_run_id = str(run_id)
-
         assert mock_uuid4.mock_calls == []
         assert self.mock_data_api_client.mock_calls == [
             mock.call.get_framework("g-cloud-99"),
@@ -237,60 +240,67 @@ class TestNotifySuppliersOfFrameworkApplicationEvent:
             mock.call.find_users_iter(supplier_id=303133),
             mock.call.find_users_iter(supplier_id=313233),
         ]
-        assert self.mock_notify_client.mock_calls == [
-            mock.call.get_reference("one@peasoup.net", "8877eeff", {
-                'framework_slug': 'g-cloud-99',
-                'run_id': expected_run_id,
-            }),
-            (mock.call.has_been_sent(
-                f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
-            ) if dry_run else mock.call.send_email(
-                'one@peasoup.net',
-                '8877eeff',
-                self.expected_context,
-                allow_resend=False,
-                reference=f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            )),
-            mock.call.get_reference("two@peasoup.net", "8877eeff", {
-                'framework_slug': 'g-cloud-99',
-                'run_id': expected_run_id,
-            }),
-            (mock.call.has_been_sent(
-                f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            ) if dry_run else mock.call.send_email(
-                'two@peasoup.net',
-                '8877eeff',
-                self.expected_context,
-                allow_resend=False,
-                reference=f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            )),
-            mock.call.get_reference("two@shirts.co.ua", "8877eeff", {
-                'framework_slug': 'g-cloud-99',
-                'run_id': expected_run_id,
-            }),
-            (mock.call.has_been_sent(
-                f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            ) if dry_run else mock.call.send_email(
-                'two@shirts.co.ua',
-                '8877eeff',
-                self.expected_context,
-                allow_resend=False,
-                reference=f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            )),
+
+        expected_run_id = str(run_id)
+        assert self.mock_notify_client.get_reference.call_args_list == [
+            mock.call("one@peasoup.net", "8877eeff", {'framework_slug': 'g-cloud-99', 'run_id': expected_run_id}),
+            mock.call("two@peasoup.net", "8877eeff", {'framework_slug': 'g-cloud-99', 'run_id': expected_run_id}),
+            mock.call("two@shirts.co.ua", "8877eeff", {'framework_slug': 'g-cloud-99', 'run_id': expected_run_id}),
             mock.call.get_reference("three@shirts.co.ua", "8877eeff", {
                 'framework_slug': 'g-cloud-99',
                 'run_id': expected_run_id,
             }),
-            (mock.call.has_been_sent(
-                f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            ) if dry_run else mock.call.send_email(
-                'three@shirts.co.ua',
-                '8877eeff',
-                self.expected_context,
-                allow_resend=False,
-                reference=f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
-            )),
         ]
+        if dry_run:
+            assert self.mock_notify_client.has_been_sent.call_args_list == [
+                mock.call(
+                    f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
+                ),
+                mock.call(
+                    f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                ),
+                mock.call(
+                    f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                ),
+                mock.call(
+                    f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                )
+            ]
+        else:
+            assert self.mock_notify_client.send_email.call_args_list == [
+                mock.call(
+                    'one@peasoup.net',
+                    '8877eeff',
+                    self.expected_context,
+                    allow_resend=False,
+                    reference=f"one@peasoup.net,8877eeff,"
+                              f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                ),
+                mock.call(
+                    'two@peasoup.net',
+                    '8877eeff',
+                    self.expected_context,
+                    allow_resend=False,
+                    reference=f"two@peasoup.net,8877eeff,"
+                              f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                ),
+                mock.call(
+                    'two@shirts.co.ua',
+                    '8877eeff',
+                    self.expected_context,
+                    allow_resend=False,
+                    reference=f"two@shirts.co.ua,8877eeff,"
+                              f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                ),
+                mock.call(
+                    'three@shirts.co.ua',
+                    '8877eeff',
+                    self.expected_context,
+                    allow_resend=False,
+                    reference=f"three@shirts.co.ua,8877eeff,"
+                              f"{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+                )
+            ]
 
         assert dry_run == (
             mock.call.debug(

--- a/tests/test_notify_suppliers_of_framework_application_event.py
+++ b/tests/test_notify_suppliers_of_framework_application_event.py
@@ -67,9 +67,8 @@ _supplier_users_by_supplier = {
 
 
 @pytest.mark.parametrize("dry_run", (False, True))
-@pytest.mark.parametrize("run_id", (None, uuid.UUID("00010203-0405-0607-0809-0a0b0c0d0e0f")))
 @mock.patch("dmscripts.notify_suppliers_of_framework_application_event.uuid4")
-def test_happy_paths(mock_uuid4, run_id, dry_run):
+def test_happy_path_without_resume_run_id(mock_uuid4, dry_run):
     mock_uuid4.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
 
     mock_data_api_client = mock.create_autospec(DataAPIClient, instance=True)
@@ -106,10 +105,10 @@ def test_happy_paths(mock_uuid4, run_id, dry_run):
             dry_run=dry_run,
             stage="production",
             logger=mock_logger,
-            run_id=run_id,
+            run_id=None,
         ) == 0
 
-    expected_run_id = str(run_id or "12345678-1234-5678-1234-567812345678")
+    expected_run_id = "12345678-1234-5678-1234-567812345678"
     expected_context = {
         'framework_name': 'G-Cloud 99',
         'updates_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/updates',
@@ -137,7 +136,7 @@ def test_happy_paths(mock_uuid4, run_id, dry_run):
         'frameworkExpiresAt_datetimeformat': 'Thursday 6 January 2000 at 12:00am GMT',
     }
 
-    assert mock_uuid4.mock_calls == ([mock.call()] if run_id is None else [])
+    assert mock_uuid4.mock_calls == [mock.call()]
     assert mock_data_api_client.mock_calls == [
         mock.call.get_framework("g-cloud-99"),
         mock.call.find_framework_suppliers_iter("g-cloud-99"),
@@ -201,7 +200,143 @@ def test_happy_paths(mock_uuid4, run_id, dry_run):
         )),
     ]
 
-    assert (dry_run and run_id == uuid.UUID("00010203-0405-0607-0809-0a0b0c0d0e0f")) == (
+
+@pytest.mark.parametrize("dry_run", (False, True))
+@mock.patch("dmscripts.notify_suppliers_of_framework_application_event.uuid4")
+def test_happy_paths_with_resume_run_id(mock_uuid4, dry_run):
+    run_id = uuid.UUID("00010203-0405-0607-0809-0a0b0c0d0e0f")
+    mock_uuid4.return_value = uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+    mock_data_api_client = mock.create_autospec(DataAPIClient, instance=True)
+    framework_response = FrameworkStub(
+        slug="g-cloud-99",
+        status="open",
+    ).single_result_response()
+    framework_response["frameworks"]["intentionToAwardAtUTC"] = "2000-06-29T16:00:00.0000Z"
+    framework_response["frameworks"]["frameworkLiveAtUTC"] = "2000-06-29T16:30:00.0000Z"
+    mock_data_api_client.get_framework.return_value = framework_response
+    mock_data_api_client.find_framework_suppliers_iter.side_effect = lambda *a, **k: iter(_supplier_frameworks)
+    mock_data_api_client.find_users_iter.side_effect = lambda *a, **k: iter(
+        _supplier_users_by_supplier[k["supplier_id"]]
+    )
+
+    mock_notify_client = mock.create_autospec(DMNotifyClient, instance=True)
+    mock_notify_client.get_reference.side_effect = lambda *a: ",".join(str(x) for x in a)
+    mock_notify_client.has_been_sent.side_effect = (
+        # this one ref is considered to be already sent
+        lambda reference: reference == (
+            "two@shirts.co.ua,8877eeff,{'framework_slug': 'g-cloud-99', 'run_id': "
+            "'00010203-0405-0607-0809-0a0b0c0d0e0f'}"
+        )
+    )
+
+    mock_logger = mock.create_autospec(logging.Logger, instance=True)
+
+    with freeze_time('2000-06-29 02:55:55'):
+        assert notify_suppliers_of_framework_application_event(
+            data_api_client=mock_data_api_client,
+            notify_client=mock_notify_client,
+            notify_template_id="8877eeff",
+            framework_slug="g-cloud-99",
+            dry_run=dry_run,
+            stage="production",
+            logger=mock_logger,
+            run_id=run_id,
+        ) == 0
+
+    expected_run_id = str(run_id)
+    expected_context = {
+        'framework_name': 'G-Cloud 99',
+        'updates_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/updates',
+        'framework_dashboard_url': 'https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-99/',
+        'clarification_questions_closed': 'no',
+        'clarificationsCloseAt_displaytimeformat': '12:00am GMT',
+        'clarificationsCloseAt_dateformat': 'Saturday 1 January 2000',
+        'clarificationsCloseAt_datetimeformat': 'Saturday 1 January 2000 at 12:00am GMT',
+        'clarificationsPublishAt_displaytimeformat': '12:00am GMT',
+        'clarificationsPublishAt_dateformat': 'Sunday 2 January 2000',
+        'clarificationsPublishAt_datetimeformat': 'Sunday 2 January 2000 at 12:00am GMT',
+        'applicationsCloseAt_displaytimeformat': '12:00am GMT',
+        'applicationsCloseAt_dateformat': 'Monday 3 January 2000',
+        'applicationsCloseAt_datetimeformat': 'Monday 3 January 2000 at 12:00am GMT',
+        'intentionToAwardAt_displaytimeformat': '5:00pm BST',
+        'intentionToAwardAt_timetoday': 'Today at 5pm BST',
+        'intentionToAwardAt_dateformat': 'Thursday 29 June 2000',
+        'intentionToAwardAt_datetimeformat': 'Thursday 29 June 2000 at 5:00pm BST',
+        'frameworkLiveAt_displaytimeformat': '5:30pm BST',
+        'frameworkLiveAt_dateformat': 'Thursday 29 June 2000',
+        'frameworkLiveAt_datetimeformat': 'Thursday 29 June 2000 at 5:30pm BST',
+        # no frameworkLiveAt_timetoday because it's non-hour-exact
+        'frameworkExpiresAt_displaytimeformat': '12:00am GMT',
+        'frameworkExpiresAt_dateformat': 'Thursday 6 January 2000',
+        'frameworkExpiresAt_datetimeformat': 'Thursday 6 January 2000 at 12:00am GMT',
+    }
+
+    assert mock_uuid4.mock_calls == []
+    assert mock_data_api_client.mock_calls == [
+        mock.call.get_framework("g-cloud-99"),
+        mock.call.find_framework_suppliers_iter("g-cloud-99"),
+        mock.call.find_users_iter(supplier_id=303132),
+        mock.call.find_users_iter(supplier_id=303233),
+        mock.call.find_users_iter(supplier_id=303133),
+        mock.call.find_users_iter(supplier_id=313233),
+    ]
+    assert mock_notify_client.mock_calls == [
+        mock.call.get_reference("one@peasoup.net", "8877eeff", {
+            'framework_slug': 'g-cloud-99',
+            'run_id': expected_run_id,
+        }),
+        (mock.call.has_been_sent(
+            f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}"
+        ) if dry_run else mock.call.send_email(
+            'one@peasoup.net',
+            '8877eeff',
+            expected_context,
+            allow_resend=False,
+            reference=f"one@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        )),
+        mock.call.get_reference("two@peasoup.net", "8877eeff", {
+            'framework_slug': 'g-cloud-99',
+            'run_id': expected_run_id,
+        }),
+        (mock.call.has_been_sent(
+            f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        ) if dry_run else mock.call.send_email(
+            'two@peasoup.net',
+            '8877eeff',
+            expected_context,
+            allow_resend=False,
+            reference=f"two@peasoup.net,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        )),
+        mock.call.get_reference("two@shirts.co.ua", "8877eeff", {
+            'framework_slug': 'g-cloud-99',
+            'run_id': expected_run_id,
+        }),
+        (mock.call.has_been_sent(
+            f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        ) if dry_run else mock.call.send_email(
+            'two@shirts.co.ua',
+            '8877eeff',
+            expected_context,
+            allow_resend=False,
+            reference=f"two@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        )),
+        mock.call.get_reference("three@shirts.co.ua", "8877eeff", {
+            'framework_slug': 'g-cloud-99',
+            'run_id': expected_run_id,
+        }),
+        (mock.call.has_been_sent(
+            f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        ) if dry_run else mock.call.send_email(
+            'three@shirts.co.ua',
+            '8877eeff',
+            expected_context,
+            allow_resend=False,
+            reference=f"three@shirts.co.ua,8877eeff,{{'framework_slug': 'g-cloud-99', 'run_id': '{expected_run_id}'}}",
+        )),
+    ]
+
+    assert dry_run == (
         mock.call.debug(
             "[DRY RUN] Would NOT send notification to {email_hash} (already sent)",
             extra=mock.ANY,


### PR DESCRIPTION
https://trello.com/c/EnPFfpum/1751-p3-incident-failure-to-send-g-cloud-12-clarification-questions-closing-email

- Pulls in new `dmutils.DMNotifyClient`, that now has the option to do a fresh lookup in the Notify API rather than using the client's sent references cache
- De-parametrizes the tests for `notify_suppliers_of_framework_application_event`, so we can better isolate the behaviour that's about to change
- Moves the tests into a class, so we can minimise the repetition from de-parametrizing 
- Finally, adds the kwarg `use_recent_cache` to the relevant notify client method calls, so we can use the fresh lookup if a `--resume-run-id` is provided.

There are 3 other scripts that require amending (see ticket), however they do not use `--resume-run-id` in the same way, so I'll address those in a separate PR.