### PR TITLE
Turn off Mailchimp user tracking

### DIFF
--- a/dmscripts/send_dos_opportunities_email.py
+++ b/dmscripts/send_dos_opportunities_email.py
@@ -68,8 +68,8 @@ def get_campaign_data(lot_name, list_id, framework_name):
             "fb_comments": False
         },
         "tracking": {
-            "opens": True,
-            "html_clicks": True,
+            "opens": False,
+            "html_clicks": False,
             "text_clicks": False,
             "goal_tracking": False,
             "ecomm360": False


### PR DESCRIPTION
https://trello.com/c/Qk3SHoov/

We no longer need to track opens/clicks for individual users on the Mailchimp DOS Opportunities email campaigns (see ticket for details).

We will still be able to track anonymised clicks per campaign via analytics, using the `utm` suffix on the links.