### PR TITLE
add date_generated key to snapshot framework stats json

### DIFF
--- a/scripts/framework-applications/snapshot-framework-stats.py
+++ b/scripts/framework-applications/snapshot-framework-stats.py
@@ -60,13 +60,13 @@ def log_human_readable_stats(stats):
 
 def snapshot_framework_stats(client, framework_slug):
     stats = client.get_framework_stats(framework_slug)
-    stats['date_generated'] = datetime.datetime.now().replace(microsecond=0).isoformat()
     client.create_audit_event(
         AuditTypes.snapshot_framework_stats,
         data=stats,
         object_type='frameworks',
         object_id=framework_slug
     )
+    stats['date_generated'] = datetime.datetime.now().replace(microsecond=0).isoformat()
     log_human_readable_stats(stats)
 
     logger.info("Framework stats snapshot saved as audit event")

--- a/scripts/framework-applications/snapshot-framework-stats.py
+++ b/scripts/framework-applications/snapshot-framework-stats.py
@@ -15,6 +15,7 @@ from docopt import docopt
 import json
 import logging
 import sys
+import datetime
 
 import dmapiclient
 from dmapiclient.audit import AuditTypes
@@ -59,6 +60,7 @@ def log_human_readable_stats(stats):
 
 def snapshot_framework_stats(client, framework_slug):
     stats = client.get_framework_stats(framework_slug)
+    stats['date_generated'] = datetime.datetime.now().replace(microsecond=0).isoformat()
     client.create_audit_event(
         AuditTypes.snapshot_framework_stats,
         data=stats,


### PR DESCRIPTION
https://trello.com/c/ahJ94DdS/202-1-performance-data-json-files-do-not-include-datetime-information﻿
