### PR TITLE
Allow re-run of incomplete applications reminder via supplier ID list

### DIFF
--- a/dmscripts/notify_suppliers_with_incomplete_applications.py
+++ b/dmscripts/notify_suppliers_with_incomplete_applications.py
@@ -1,7 +1,6 @@
 from dmapiclient import DataAPIClient
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.email_helpers import scripts_notify_client
-from dmscripts.helpers.logging_helpers import configure_logger, logging
 from dmutils.email.exceptions import EmailError
 from dmutils.email.helpers import hash_string
 from dmutils.env_helpers import get_api_endpoint_from_stage
@@ -67,8 +66,9 @@ def build_message(sf, framework_slug, data_api_client):
     return message
 
 
-def notify_suppliers_with_incomplete_applications(framework_slug, stage, notify_api_key, dry_run, supplier_ids=None):
-    logger = configure_logger({"dmapiclient": logging.INFO})
+def notify_suppliers_with_incomplete_applications(
+    framework_slug, stage, notify_api_key, dry_run, logger, supplier_ids=None
+):
     data_api_client = DataAPIClient(
         base_url=get_api_endpoint_from_stage(stage), auth_token=get_auth_token('api', stage)
     )

--- a/dmscripts/notify_suppliers_with_incomplete_applications.py
+++ b/dmscripts/notify_suppliers_with_incomplete_applications.py
@@ -67,7 +67,7 @@ def build_message(sf, framework_slug, data_api_client):
     return message
 
 
-def notify_suppliers_with_incomplete_applications(framework_slug, stage, notify_api_key, dry_run):
+def notify_suppliers_with_incomplete_applications(framework_slug, stage, notify_api_key, dry_run, supplier_ids=None):
     logger = configure_logger({"dmapiclient": logging.INFO})
     data_api_client = DataAPIClient(
         base_url=get_api_endpoint_from_stage(stage), auth_token=get_auth_token('api', stage)
@@ -81,6 +81,13 @@ def notify_suppliers_with_incomplete_applications(framework_slug, stage, notify_
     error_count = 0
 
     for sf in data_api_client.find_framework_suppliers_iter(framework_slug):
+        # Restrict suppliers to those specified in the argument, if given.
+        # While this is inefficient for a small number of supplier IDs, looking up
+        # each supplier individually for a large number of supplier IDs would be worse.
+        if supplier_ids:
+            if sf['supplierId'] not in supplier_ids:
+                continue
+
         message = build_message(sf, framework_slug, data_api_client)
 
         if message:

--- a/dmscripts/notify_suppliers_with_incomplete_applications.py
+++ b/dmscripts/notify_suppliers_with_incomplete_applications.py
@@ -1,9 +1,6 @@
-from dmapiclient import DataAPIClient
-from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmutils.email.exceptions import EmailError
 from dmutils.email.helpers import hash_string
-from dmutils.env_helpers import get_api_endpoint_from_stage
 from dmutils.formats import utctoshorttimelongdateformat
 
 
@@ -67,12 +64,8 @@ def build_message(sf, framework_slug, data_api_client):
 
 
 def notify_suppliers_with_incomplete_applications(
-    framework_slug, stage, notify_api_key, dry_run, logger, supplier_ids=None
+    framework_slug, data_api_client, notify_api_key, dry_run, logger, supplier_ids=None
 ):
-    data_api_client = DataAPIClient(
-        base_url=get_api_endpoint_from_stage(stage), auth_token=get_auth_token('api', stage)
-    )
-
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     if framework['status'] != 'open':
         raise ValueError("Suppliers cannot amend applications unless the framework is open.")

--- a/scripts/notify-suppliers-with-incomplete-applications.py
+++ b/scripts/notify-suppliers-with-incomplete-applications.py
@@ -34,6 +34,9 @@ sys.path.insert(0, '.')
 
 import logging
 from dmscripts.helpers import logging_helpers
+from dmapiclient import DataAPIClient
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmutils.env_helpers import get_api_endpoint_from_stage
 from dmscripts.notify_suppliers_with_incomplete_applications import notify_suppliers_with_incomplete_applications
 
 
@@ -46,10 +49,15 @@ if __name__ == '__main__':
     if doc_opt_arguments['--supplier-ids']:
         list_of_supplier_ids = list(map(int, doc_opt_arguments['--supplier-ids'].split(',')))
 
+    stage = doc_opt_arguments['<stage>']
+    data_api_client = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(stage), auth_token=get_auth_token('api', stage)
+    )
+
     sys.exit(
         notify_suppliers_with_incomplete_applications(
             doc_opt_arguments['<framework>'],
-            doc_opt_arguments['<stage>'],
+            data_api_client,
             doc_opt_arguments['<notify_api_key>'],
             doc_opt_arguments['--dry-run'],
             logger,

--- a/scripts/notify-suppliers-with-incomplete-applications.py
+++ b/scripts/notify-suppliers-with-incomplete-applications.py
@@ -31,11 +31,16 @@ Options:
 from docopt import docopt
 import sys
 sys.path.insert(0, '.')
+
+import logging
+from dmscripts.helpers import logging_helpers
 from dmscripts.notify_suppliers_with_incomplete_applications import notify_suppliers_with_incomplete_applications
 
 
 if __name__ == '__main__':
     doc_opt_arguments = docopt(__doc__)
+
+    logger = logging_helpers.configure_logger({"dmapiclient": logging.INFO})
 
     list_of_supplier_ids = []
     if doc_opt_arguments['--supplier-ids']:
@@ -47,6 +52,7 @@ if __name__ == '__main__':
             doc_opt_arguments['<stage>'],
             doc_opt_arguments['<notify_api_key>'],
             doc_opt_arguments['--dry-run'],
-            supplier_ids=list_of_supplier_ids
+            logger,
+            supplier_ids=list_of_supplier_ids,
         )
     )

--- a/scripts/notify-suppliers-with-incomplete-applications.py
+++ b/scripts/notify-suppliers-with-incomplete-applications.py
@@ -23,7 +23,9 @@ Options:
     <notify_api_key>            API key for GOV.UK Notify.
 
     -n, --dry-run               Run script without sending emails.
-
+    --supplier-ids=SUPPLIERS    Comma separated list of suppliers IDs to be emailed. This is in case the
+                                script fails halfway and we need to resume it without sending emails twice
+                                to any supplier
     -h, --help                  Show this screen
 """
 from docopt import docopt
@@ -34,11 +36,17 @@ from dmscripts.notify_suppliers_with_incomplete_applications import notify_suppl
 
 if __name__ == '__main__':
     doc_opt_arguments = docopt(__doc__)
+
+    list_of_supplier_ids = []
+    if doc_opt_arguments['--supplier-ids']:
+        list_of_supplier_ids = list(map(int, doc_opt_arguments['--supplier-ids'].split(',')))
+
     sys.exit(
         notify_suppliers_with_incomplete_applications(
             doc_opt_arguments['<framework>'],
             doc_opt_arguments['<stage>'],
             doc_opt_arguments['<notify_api_key>'],
-            doc_opt_arguments['--dry-run']
+            doc_opt_arguments['--dry-run'],
+            supplier_ids=list_of_supplier_ids
         )
     )

--- a/tests/test_notify_suppliers_with_incomplete_applications.py
+++ b/tests/test_notify_suppliers_with_incomplete_applications.py
@@ -4,6 +4,7 @@ import pytest
 from freezegun import freeze_time
 
 from dmutils.email import DMNotifyClient
+from dmapiclient import DataAPIClient
 from dmscripts.notify_suppliers_with_incomplete_applications import (
     notify_suppliers_with_incomplete_applications,
     MESSAGES,
@@ -120,34 +121,34 @@ for fs in FRAMEWORK_SUPPLIERS_TEST_CASES:
 @pytest.mark.parametrize(
     'draft_services_case,framework_supplier_case,users_case,expected_mails,expected_message', message_test_cases
 )
-@mock.patch('dmscripts.notify_suppliers_with_incomplete_applications.get_api_endpoint_from_stage', autospec=True)
-@mock.patch('dmscripts.notify_suppliers_with_incomplete_applications.get_auth_token', autospec=True)
 @mock.patch('dmscripts.notify_suppliers_with_incomplete_applications.scripts_notify_client', autospec=True)
-@mock.patch('dmscripts.notify_suppliers_with_incomplete_applications.DataAPIClient', autospec=True)
 def test_message_combinations(
-    data_api_client_mock, mail_client_constructor_mock,
-    get_auth_token_constructor_mock, get_api_endpoint_from_stage_constructor_mock,
+    mail_client_constructor_mock,
     draft_services_case, framework_supplier_case, users_case, expected_mails, expected_message
 ):
     """
     Test if the correct number of email are sent and with the correct message.
     """
+    data_api_client_mock = mock.create_autospec(DataAPIClient)
+
     mail_client_mock = mail_client_constructor_mock.return_value = mock.Mock(spec=DMNotifyClient)
     mail_client_mock.logger = mock.Mock(spec=Logger)
 
     logging_mock = mock.create_autospec(Logger, instance=True)
 
-    data_api_client_mock().get_framework.return_value = FrameworkStub(
+    data_api_client_mock.get_framework.return_value = FrameworkStub(
         applications_close_at="2025-07-01T16:00:00.000000Z",
         status="open"
     ).single_result_response()
-    data_api_client_mock().find_draft_services_iter.return_value = draft_services_case
-    data_api_client_mock().find_framework_suppliers_iter.return_value = framework_supplier_case
-    data_api_client_mock().find_users.return_value = users_case
+    data_api_client_mock.find_draft_services_iter.return_value = draft_services_case
+    data_api_client_mock.find_framework_suppliers_iter.return_value = framework_supplier_case
+    data_api_client_mock.find_users.return_value = users_case
 
     with freeze_time('2025-06-24 16:00:00'):
         # Test localisation during BST, 1 week before the deadline
-        notify_suppliers_with_incomplete_applications('g-cloud-10', 'preview', 'notify_api_key', False, logging_mock)
+        notify_suppliers_with_incomplete_applications(
+            'g-cloud-10', data_api_client_mock, 'notify_api_key', False, logging_mock
+        )
 
     assert mail_client_mock.send_email.call_count == len(expected_mails)
     for i, call in enumerate(mail_client_mock.send_email.call_args_list):
@@ -159,15 +160,17 @@ def test_message_combinations(
 
 
 @pytest.mark.parametrize('framework_status', ['coming', 'pending', 'standstill', 'live', 'expired'])
-@mock.patch('dmscripts.notify_suppliers_with_incomplete_applications.DataAPIClient', autospec=True)
-def test_notify_suppliers_with_incomplete_applications_fails_for_non_open_frameworks(data_api_client, framework_status):
-    data_api_client().get_framework.return_value = FrameworkStub(
+def test_notify_suppliers_with_incomplete_applications_fails_for_non_open_frameworks(framework_status):
+    data_api_client = mock.create_autospec(DataAPIClient)
+    data_api_client.get_framework.return_value = FrameworkStub(
         applications_close_at="2025-07-01T16:00:00.000000Z",
         status=framework_status
     ).single_result_response()
     logging_mock = mock.create_autospec(Logger, instance=True)
 
     with pytest.raises(ValueError) as exc:
-        notify_suppliers_with_incomplete_applications('g-cloud-10', 'local', 'notify_api_key', False, logging_mock)
+        notify_suppliers_with_incomplete_applications(
+            'g-cloud-10', data_api_client, 'notify_api_key', False, logging_mock
+        )
 
     assert str(exc.value) == "Suppliers cannot amend applications unless the framework is open."


### PR DESCRIPTION
https://trello.com/c/EnPFfpum

Part of the work to make our critical framework scripts more robust against Notify failures.

This script sends a reminder to suppliers with incomplete applications, 1 week before the deadline. It already logs the supplier ID if email sending fails. This PR adds functionality for a developer to re-run the script, passing a comma-separated list of supplier IDs to re-run against.

I've also refactored it a little:
- moved the initialisation of the `logger` and `DataAPIClient` instances to the top level script (to help this script be more consistent with our other scripts, and simplify the test setup). I tried moving the Notify client there as well but it was Unhappy. I may give this another go if people are keen but I was trying not to spend too much time on refactoring!
- moved the tests into a class, so we can use shared set up of mocks where possible
- made the main `notify_suppliers_with_incomplete_applications` function less complex by pulling out the code into a separate function