### PR TITLE
Add tests for Notify suppliers whether application made script

### DIFF
--- a/dmscripts/notify_suppliers_whether_application_made_for_framework.py
+++ b/dmscripts/notify_suppliers_whether_application_made_for_framework.py
@@ -1,0 +1,40 @@
+from dmutils.email.exceptions import EmailError
+from dmutils.email.helpers import hash_string
+from dmscripts.helpers.supplier_data_helpers import AppliedToFrameworkSupplierContextForNotify
+
+
+NOTIFY_TEMPLATES = {
+    'application_made': 'de02a7e3-80f6-4391-818c-48326e1f4688',
+    'application_not_made': '87a126b4-7909-4b63-b981-d3c3d6a558ff'
+}
+
+
+def notify_suppliers_whether_application_made(
+    api_client, mail_client, framework_slug, logger, dry_run=False, supplier_ids=None
+):
+
+    context_helper = AppliedToFrameworkSupplierContextForNotify(api_client, framework_slug, supplier_ids=supplier_ids)
+    context_helper.populate_data()
+    prefix = "[Dry Run] " if dry_run else ""
+    error_count = 0
+    for supplier_id, users in context_helper.get_suppliers_with_users_personalisations():
+        logger.info(f"{prefix}Supplier '{supplier_id}'")
+
+        for user, personalisation in users:
+            user_email = user["email address"]
+            template_key = 'application_made' if personalisation['applied'] else 'application_not_made'
+            template = NOTIFY_TEMPLATES[template_key]
+
+            logger.info(
+                f"{prefix}Sending '{template_key}' email to supplier '{supplier_id}' user '{hash_string(user_email)}'")
+
+            if dry_run:
+                continue
+
+            try:
+                mail_client.send_email(user_email, template, personalisation, allow_resend=False)
+            except EmailError as e:
+                logger.error(f"Error sending email to supplier '{supplier_id}' user '{hash_string(user_email)}': {e}")
+                error_count += 1
+
+    return error_count

--- a/scripts/notify-suppliers-whether-application-made-for-framework.py
+++ b/scripts/notify-suppliers-whether-application-made-for-framework.py
@@ -30,61 +30,34 @@ sys.path.insert(0, '.')
 from docopt import docopt
 
 from dmapiclient import DataAPIClient
-from dmutils.email.exceptions import EmailError
-from dmutils.email.helpers import hash_string
 from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
-from dmscripts.helpers.supplier_data_helpers import (
-    AppliedToFrameworkSupplierContextForNotify,
-    get_supplier_ids_from_args,
-)
+from dmscripts.helpers.supplier_data_helpers import get_supplier_ids_from_args
+
 from dmutils.env_helpers import get_api_endpoint_from_stage
+from dmscripts.notify_suppliers_whether_application_made_for_framework import notify_suppliers_whether_application_made
 
 logger = logging_helpers.configure_logger({"dmapiclient": logging.INFO})
-
-NOTIFY_TEMPLATES = {
-    'application_made': 'de02a7e3-80f6-4391-818c-48326e1f4688',
-    'application_not_made': '87a126b4-7909-4b63-b981-d3c3d6a558ff'
-}
 
 
 if __name__ == '__main__':
     arguments = docopt(__doc__)
     supplier_ids = get_supplier_ids_from_args(arguments)
 
-    STAGE = arguments['<stage>']
-    FRAMEWORK_SLUG = arguments['<framework>']
-    GOVUK_NOTIFY_API_KEY = arguments['<notify_api_key>']
-    DRY_RUN = arguments['--dry-run']
+    stage = arguments['<stage>']
 
-    mail_client = scripts_notify_client(GOVUK_NOTIFY_API_KEY, logger=logger)
-    api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(STAGE),
-                               auth_token=get_auth_token('api', STAGE))
+    mail_client = scripts_notify_client(arguments['<notify_api_key>'], logger=logger)
+    api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(stage),
+                               auth_token=get_auth_token('api', stage))
 
-    context_helper = AppliedToFrameworkSupplierContextForNotify(api_client, FRAMEWORK_SLUG, supplier_ids=supplier_ids)
-    context_helper.populate_data()
-    prefix = "[Dry Run] " if DRY_RUN else ""
-    error_count = 0
-    for supplier_id, users in context_helper.get_suppliers_with_users_personalisations():
-        logger.info(f"{prefix}Supplier '{supplier_id}'")
-
-        for user, personalisation in users:
-            user_email = user["email address"]
-            template_key = 'application_made' if personalisation['applied'] else 'application_not_made'
-            template = NOTIFY_TEMPLATES[template_key]
-
-            logger.info(
-                f"{prefix}Sending '{template_key}' email to supplier '{supplier_id}' user '{hash_string(user_email)}'")
-
-            if DRY_RUN:
-                continue
-
-            try:
-                mail_client.send_email(user_email, template, personalisation, allow_resend=False)
-            except EmailError as e:
-                logger.error(f"Error sending email to supplier '{supplier_id}' user '{hash_string(user_email)}': {e}")
-                error_count += 1
-
+    error_count = notify_suppliers_whether_application_made(
+        api_client,
+        mail_client,
+        arguments['<framework>'],
+        logger=logger,
+        dry_run=arguments['--dry-run'],
+        supplier_ids=supplier_ids,
+    )
     sys.exit(error_count)

--- a/tests/test_notify_suppliers_whether_application_made_for_framework.py
+++ b/tests/test_notify_suppliers_whether_application_made_for_framework.py
@@ -30,8 +30,8 @@ class TestNotifySuppliersWhetherApplicationMade:
             {"supplierId": 712346},
         ]
         self.data_api_client.export_users.return_value = {
-            # This endpoint returns some unusually formmatted keys :(
-            # See https://github.com/alphagov/digitalmarketplace-api/blob/master/app/main/views/users.py#L417
+            # This endpoint returns some unusually formatted keys :(
+            # See https://github.com/alphagov/digitalmarketplace-api/blob/6ad35e526fcf4d76320159a1a4ac97133a1ce13d/app/main/views/users.py#L417  # noqa
             'users': [
                 {'supplier_id': 712345, 'email address': 'user1@example.com', 'application_status': 'no_application'},
                 {'supplier_id': 712346, 'email address': 'user2@example.com', 'application_status': 'application'},

--- a/tests/test_notify_suppliers_whether_application_made_for_framework.py
+++ b/tests/test_notify_suppliers_whether_application_made_for_framework.py
@@ -49,12 +49,13 @@ class TestNotifySuppliersWhetherApplicationMade:
         self.logger = mock.create_autospec(Logger, instance=True)
 
     def test_notify_suppliers_whether_application_made_happy_path(self):
+        expected_error_count = 0
         assert notify_suppliers_whether_application_made(
             self.data_api_client,
             self.notify_client,
             'g-cloud-12',
             self.logger,
-        ) == 0
+        ) == expected_error_count
 
         assert self.notify_client.send_email.call_args_list == [
             mock.call(
@@ -109,13 +110,14 @@ class TestNotifySuppliersWhetherApplicationMade:
         ]
 
     def test_notify_suppliers_whether_application_made_dry_run(self):
+        expected_error_count = 0
         assert notify_suppliers_whether_application_made(
             self.data_api_client,
             self.notify_client,
             'g-cloud-12',
             self.logger,
             dry_run=True
-        ) == 0
+        ) == expected_error_count
 
         assert self.notify_client.send_email.call_args_list == []
         assert self.logger.info.call_args_list == [
@@ -136,13 +138,14 @@ class TestNotifySuppliersWhetherApplicationMade:
         ]
 
     def test_notify_suppliers_whether_application_made_supplier_ids_list(self):
+        expected_error_count = 0
         assert notify_suppliers_whether_application_made(
             self.data_api_client,
             self.notify_client,
             'g-cloud-12',
             self.logger,
             supplier_ids=[712345]
-        ) == 0
+        ) == expected_error_count
 
         assert self.notify_client.send_email.call_args_list == [
             mock.call(
@@ -166,6 +169,7 @@ class TestNotifySuppliersWhetherApplicationMade:
         ]
 
     def test_notify_suppliers_whether_application_made_email_error_logs_supplier_id(self):
+        expected_error_count = 1
         self.notify_client.send_email.side_effect = [
             EmailError("Arghhh!"),  # The first user email fails
             None,
@@ -177,7 +181,7 @@ class TestNotifySuppliersWhetherApplicationMade:
             self.notify_client,
             'g-cloud-12',
             self.logger
-        ) == 1
+        ) == expected_error_count
 
         assert self.logger.info.call_args_list == [
             mock.call("Supplier '712345'"),

--- a/tests/test_notify_suppliers_whether_application_made_for_framework.py
+++ b/tests/test_notify_suppliers_whether_application_made_for_framework.py
@@ -1,0 +1,202 @@
+from logging import Logger
+import mock
+from dmutils.email import DMNotifyClient
+from dmutils.email.exceptions import EmailError
+from dmapiclient import DataAPIClient
+from dmscripts.notify_suppliers_whether_application_made_for_framework import (
+    notify_suppliers_whether_application_made,
+    NOTIFY_TEMPLATES,
+)
+
+
+class TestNotifySuppliersWhetherApplicationMade:
+
+    def setup(self):
+        self.data_api_client = mock.create_autospec(DataAPIClient, instance=True)
+        self.data_api_client.get_framework.return_value = {
+            "frameworks": {
+                "slug": "g-cloud-12",
+                "name": "G-Cloud 12",
+                "frameworkExpiresAtUTC": "2017-12-31T23:59:59.999999Z",
+                "clarificationsCloseAtUTC": "2017-12-31T23:59:59.999999Z",
+                "clarificationsPublishAtUTC": "2017-12-31T23:59:59.999999Z",
+                'applicationsCloseAtUTC': "2017-12-31T23:59:59.999999Z",
+                'intentionToAwardAtUTC': "2017-12-31T23:59:59.999999Z",
+                'frameworkLiveAtUTC': "2017-12-31T23:59:59.999999Z"
+            }
+        }
+        self.data_api_client.find_framework_suppliers_iter.return_value = [
+            {"supplierId": 712345},
+            {"supplierId": 712346},
+        ]
+        self.data_api_client.export_users.return_value = {
+            # This endpoint returns some unusually formmatted keys :(
+            # See https://github.com/alphagov/digitalmarketplace-api/blob/master/app/main/views/users.py#L417
+            'users': [
+                {'supplier_id': 712345, 'email address': 'user1@example.com', 'application_status': 'no_application'},
+                {'supplier_id': 712346, 'email address': 'user2@example.com', 'application_status': 'application'},
+                {'supplier_id': 712346, 'email address': 'user3@example.com', 'application_status': 'application'},
+            ]
+        }
+        self.data_api_client.find_draft_services_iter.return_value = {
+            # Assume all suppliers have submitted a service
+            'services': [
+                {'status': 'submitted'}
+            ]
+        }
+
+        self.notify_client = mock.create_autospec(DMNotifyClient, instance=True)
+        self.logger = mock.create_autospec(Logger, instance=True)
+
+    def test_notify_suppliers_whether_application_made_happy_path(self):
+        assert notify_suppliers_whether_application_made(
+            self.data_api_client,
+            self.notify_client,
+            'g-cloud-12',
+            self.logger,
+        ) == 0
+
+        assert self.notify_client.send_email.call_args_list == [
+            mock.call(
+                "user1@example.com",
+                NOTIFY_TEMPLATES['application_not_made'],
+                {
+                    'intention_to_award_at': 'Sunday 31 December 2017',
+                    'framework_name': 'G-Cloud 12',
+                    'framework_slug': 'g-cloud-12',
+                    'applied': False
+                },
+                allow_resend=False
+            ),
+            mock.call(
+                "user2@example.com",
+                NOTIFY_TEMPLATES['application_made'],
+                {
+                    'intention_to_award_at': 'Sunday 31 December 2017',
+                    'framework_name': 'G-Cloud 12',
+                    'framework_slug': 'g-cloud-12',
+                    'applied': True
+                },
+                allow_resend=False
+            ),
+            mock.call(
+                "user3@example.com",
+                NOTIFY_TEMPLATES['application_made'],
+                {
+                    'intention_to_award_at': 'Sunday 31 December 2017',
+                    'framework_name': 'G-Cloud 12',
+                    'framework_slug': 'g-cloud-12',
+                    'applied': True
+                },
+                allow_resend=False
+            ),
+        ]
+        assert self.logger.info.call_args_list == [
+            mock.call("Supplier '712345'"),
+            mock.call(
+                "Sending 'application_not_made' email to supplier '712345' "
+                "user 's2qDcB8cMZHhlyLW-QJ0vBtVAf5p6_MzE-RA_ksP4hA='"
+            ),
+            mock.call("Supplier '712346'"),
+            mock.call(
+                "Sending 'application_made' email to supplier '712346' "
+                "user 'KzsrnOhCq4tqbGFMsflgS7ig1QLRr0nFJrcrEIlOlbU='"
+            ),
+            mock.call(
+                "Sending 'application_made' email to supplier '712346' "
+                "user 'iYYo4oiQ-Te98Ak5He9Ch5xAGkvPG1_STnONn12oy7s='"
+            )
+        ]
+
+    def test_notify_suppliers_whether_application_made_dry_run(self):
+        assert notify_suppliers_whether_application_made(
+            self.data_api_client,
+            self.notify_client,
+            'g-cloud-12',
+            self.logger,
+            dry_run=True
+        ) == 0
+
+        assert self.notify_client.send_email.call_args_list == []
+        assert self.logger.info.call_args_list == [
+            mock.call("[Dry Run] Supplier '712345'"),
+            mock.call(
+                "[Dry Run] Sending 'application_not_made' email to supplier '712345' "
+                "user 's2qDcB8cMZHhlyLW-QJ0vBtVAf5p6_MzE-RA_ksP4hA='"
+            ),
+            mock.call("[Dry Run] Supplier '712346'"),
+            mock.call(
+                "[Dry Run] Sending 'application_made' email to supplier '712346' "
+                "user 'KzsrnOhCq4tqbGFMsflgS7ig1QLRr0nFJrcrEIlOlbU='"
+            ),
+            mock.call(
+                "[Dry Run] Sending 'application_made' email to supplier '712346' "
+                "user 'iYYo4oiQ-Te98Ak5He9Ch5xAGkvPG1_STnONn12oy7s='"
+            )
+        ]
+
+    def test_notify_suppliers_whether_application_made_supplier_ids_list(self):
+        assert notify_suppliers_whether_application_made(
+            self.data_api_client,
+            self.notify_client,
+            'g-cloud-12',
+            self.logger,
+            supplier_ids=[712345]
+        ) == 0
+
+        assert self.notify_client.send_email.call_args_list == [
+            mock.call(
+                "user1@example.com",
+                NOTIFY_TEMPLATES['application_not_made'],
+                {
+                    'intention_to_award_at': 'Sunday 31 December 2017',
+                    'framework_name': 'G-Cloud 12',
+                    'framework_slug': 'g-cloud-12',
+                    'applied': False
+                },
+                allow_resend=False
+            )
+        ]
+        assert self.logger.info.call_args_list == [
+            mock.call("Supplier '712345'"),
+            mock.call(
+                "Sending 'application_not_made' email to supplier '712345' "
+                "user 's2qDcB8cMZHhlyLW-QJ0vBtVAf5p6_MzE-RA_ksP4hA='"
+            )
+        ]
+
+    def test_notify_suppliers_whether_application_made_email_error_logs_supplier_id(self):
+        self.notify_client.send_email.side_effect = [
+            EmailError("Arghhh!"),  # The first user email fails
+            None,
+            None
+        ]
+
+        assert notify_suppliers_whether_application_made(
+            self.data_api_client,
+            self.notify_client,
+            'g-cloud-12',
+            self.logger
+        ) == 1
+
+        assert self.logger.info.call_args_list == [
+            mock.call("Supplier '712345'"),
+            mock.call(
+                "Sending 'application_not_made' email to supplier '712345' "
+                "user 's2qDcB8cMZHhlyLW-QJ0vBtVAf5p6_MzE-RA_ksP4hA='"
+            ),
+            mock.call("Supplier '712346'"),
+            mock.call(
+                "Sending 'application_made' email to supplier '712346' "
+                "user 'KzsrnOhCq4tqbGFMsflgS7ig1QLRr0nFJrcrEIlOlbU='"
+            ),
+            mock.call(
+                "Sending 'application_made' email to supplier '712346' "
+                "user 'iYYo4oiQ-Te98Ak5He9Ch5xAGkvPG1_STnONn12oy7s='"
+            )
+        ]
+        assert self.logger.error.call_args_list == [
+            mock.call(
+                "Error sending email to supplier '712345' user 's2qDcB8cMZHhlyLW-QJ0vBtVAf5p6_MzE-RA_ksP4hA=': Arghhh!"
+            )
+        ]


### PR DESCRIPTION
https://trello.com/c/EnPFfpum/

This script already provides a facility for re-running with a list of supplier IDs from a previous failed run. However there were no tests for it 🙀 

I've added some! This meant moving some of the code to a separate module (consistent structure with our other scripts).

