### PR TITLE
Tidy Export framework applicant details script

### DIFF
--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -3,9 +3,7 @@ from itertools import chain
 from dmscripts.helpers.csv_helpers import write_csv
 from dmscripts.helpers.framework_helpers import find_suppliers_with_details_and_draft_service_counts
 from dmscripts.helpers.supplier_data_helpers import country_code_to_name
-from dmscripts.helpers.logging_helpers import get_logger
 
-logger = get_logger()
 
 DECLARATION_FIELDS = (
     "primaryContact",
@@ -40,6 +38,7 @@ def get_csv_rows(
     count_statuses=("submitted", "failed",),
     dry_run=False,
     include_central_supplier_details=False,
+    logger=None
 ):
     """
     :param count_statuses:                      tuple of draft service statuses that should be
@@ -49,6 +48,7 @@ def get_csv_rows(
     :param dry_run:                             if True the records will be returned without
                                                 declaration information.
     :param include_central_supplier_details:    include contact info from supplier account (i.e. not the declaration)
+    :param logger:                              Logger object
 
     :returns:                                   row headers and rows as a sequence of dictionaries
                                                 with the headers as keys.
@@ -81,7 +81,8 @@ def get_csv_rows(
         and any(status in count_statuses for (lot, status) in record['counts'])
     ]
 
-    logger.info(f"found {len(records)} supplier records to process")
+    if logger:
+        logger.info(f"found {len(records)} supplier records to process")
 
     rows_iter = (
         _create_row(
@@ -159,7 +160,9 @@ def _create_row(
     return row
 
 
-def export_supplier_details(data_api_client, framework_slug, filename, framework_lot_slugs, map_impl=map):
+def export_supplier_details(
+    data_api_client, framework_slug, filename, framework_lot_slugs, map_impl=map, logger=None
+):
     records = find_suppliers_with_details_and_draft_service_counts(data_api_client, framework_slug, map_impl=map_impl)
-    headers, rows_iter = get_csv_rows(records, framework_slug, framework_lot_slugs)
+    headers, rows_iter = get_csv_rows(records, framework_slug, framework_lot_slugs, logger=logger)
     write_csv(headers, rows_iter, filename)

--- a/scripts/framework-applications/export-framework-applicant-details.py
+++ b/scripts/framework-applications/export-framework-applicant-details.py
@@ -5,6 +5,10 @@
 Usage:
     scripts/framework-applications/export-framework-applicant-details.py <stage> <framework_slug> <output_dir>
 
+Options:
+    --verbose                   Show debug log messages
+    -h, --help                  Show this screen
+
 Example:
     scripts/framework-applications/export-framework-applicant-details.py dev g-cloud-12 SCRIPT_OUTPUTS
 
@@ -33,7 +37,7 @@ if __name__ == '__main__':
     FRAMEWORK = arguments['<framework_slug>']
     OUTPUT_DIR = arguments['<output_dir>']
 
-    configure_logger({"script": loglevel_DEBUG if args["--verbose"] else loglevel_INFO})
+    configure_logger({"script": loglevel_DEBUG if arguments["--verbose"] else loglevel_INFO})
     logger = get_logger()
 
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))

--- a/scripts/framework-applications/export-framework-applicant-details.py
+++ b/scripts/framework-applications/export-framework-applicant-details.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
-"""Export supplier "about you" information for suppliers who applied to a framework
-
-Currently will only work for the following frameworks:
-  * g-cloud-8, g-cloud-9, g-cloud-10, g-cloud-11
-  * digital-outcomes-and-specialists-2, digital-outcomes-and-specialists-3
-
-Support for new frameworks needs to be explicitly added to the DECLARATION_FIELDS in
-dmscripts/export_framework_applicant_details.py, though in the (far) future it would be nice if this information could
-be pulled from the frameworks themselves provided the frameworks repo knew which fields classed as "about you".
+"""Export supplier "about you" information for suppliers who applied to a framework.
+   This report includes registered company information and contact details.
 
 Usage:
     scripts/framework-applications/export-framework-applicant-details.py <stage> <framework_slug> <output_dir>
 
 Example:
-    scripts/framework-applications/export-framework-applicant-details.py dev g-cloud-8 SCRIPT_OUTPUTS
+    scripts/framework-applications/export-framework-applicant-details.py dev g-cloud-12 SCRIPT_OUTPUTS
 
 """
 import datetime

--- a/scripts/framework-applications/export-framework-applicant-details.py
+++ b/scripts/framework-applications/export-framework-applicant-details.py
@@ -19,6 +19,8 @@ sys.path.insert(0, '.')
 
 from docopt import docopt
 from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.logging_helpers import configure_logger, get_logger
+from dmscripts.helpers.logging_helpers import INFO as loglevel_INFO, DEBUG as loglevel_DEBUG
 from dmscripts.export_framework_applicant_details import export_supplier_details
 from dmapiclient import DataAPIClient
 from dmutils.env_helpers import get_api_endpoint_from_stage
@@ -30,6 +32,9 @@ if __name__ == '__main__':
     STAGE = arguments['<stage>']
     FRAMEWORK = arguments['<framework_slug>']
     OUTPUT_DIR = arguments['<output_dir>']
+
+    configure_logger({"script": loglevel_DEBUG if args["--verbose"] else loglevel_INFO})
+    logger = get_logger()
 
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))
     now = datetime.datetime.now()
@@ -49,4 +54,6 @@ if __name__ == '__main__':
 
     pool = ThreadPool(3)
 
-    export_supplier_details(client, FRAMEWORK, filepath, framework_lot_slugs=framework_lot_slugs, map_impl=pool.imap)
+    export_supplier_details(
+        client, FRAMEWORK, filepath, framework_lot_slugs=framework_lot_slugs, map_impl=pool.imap, logger=logger
+    )

--- a/tests/test_export_framework_applicant_details.py
+++ b/tests/test_export_framework_applicant_details.py
@@ -88,5 +88,5 @@ def test_export_supplier_details_calls_helper_functions(find_suppliers, get_csv_
     export_supplier_details(data_api_client, 'g-things-23', "filename.csv", "lot-1,lot-2")
 
     find_suppliers.assert_called_once_with(data_api_client, 'g-things-23', map_impl=mock.ANY)
-    get_csv_rows.assert_called_once_with(find_suppliers.return_value, 'g-things-23', "lot-1,lot-2")
+    get_csv_rows.assert_called_once_with(find_suppliers.return_value, 'g-things-23', "lot-1,lot-2", logger=None)
     write_csv.assert_called_once_with(['header1', 'header2'], 'rows_iter', "filename.csv")


### PR DESCRIPTION
Tidies up an outdated docstring - we made this script framework agnostic for DOS4 last year.

Also moves the `logger` config to the top level script, for consistency with our other scripts.