### PR TITLE
Bump rsa from 3.4.2 to 4.5

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@52.7.0#egg=digitalm
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.6.0#egg=digitalmarketplace-apiclient==21.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
 
-awscli==1.18.49
+awscli~=1.18.49
 backoff==1.10.0
 docopt==0.6.2
 jsonschema==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,11 @@
 argcomplete==1.11.1       # via yq
 asn1crypto==1.3.0         # via cryptography
 attrs==19.3.0             # via jsonschema
-awscli==1.18.49           # via -r requirements.in
+awscli==1.18.111          # via -r requirements.in
 backoff==1.10.0           # via -r requirements.in
 blinker==1.4              # via gds-metrics
-boto3==1.12.6             # via digitalmarketplace-utils
-botocore==1.15.49         # via awscli, boto3, s3transfer
+boto3==1.14.34            # via digitalmarketplace-utils
+botocore==1.17.34         # via awscli, boto3, s3transfer
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
@@ -58,7 +58,7 @@ git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logg
 pytz==2019.3              # via digitalmarketplace-utils
 pyyaml==5.3.1             # via awscli, digitalmarketplace-content-loader, yq
 requests==2.23.0          # via digitalmarketplace-apiclient, digitalmarketplace-utils, mailchimp3, notifications-python-client
-rsa==3.4.2                # via awscli
+rsa==4.5                  # via awscli
 s3transfer==0.3.3         # via awscli, boto3
 six==1.14.0               # via cryptography, jsonschema, pyrsistent, python-dateutil
 unicodecsv==0.14.1        # via -r requirements.in, digitalmarketplace-utils


### PR DESCRIPTION
Snyk notified us about a vulnerability in rsa<=4.1, https://app.snyk.io/vuln/SNYK-PYTHON-RSA-570831

This commit updates rsa to the latest version. We also need to loosen
the requirement on awscli to allow this.