### PR TITLE
Fix path to admin declaration view

### DIFF
--- a/dmscripts/export_framework_results_reasons.py
+++ b/dmscripts/export_framework_results_reasons.py
@@ -123,7 +123,7 @@ def contact_details(record):
 
 def admin_link(record):
     base = get_web_url_from_stage('production')
-    admin_path = f"{base}/suppliers/{record['supplier']['id']}/edit/declarations/{record['frameworkSlug']}"
+    admin_path = f"{base}/admin/suppliers/{record['supplier']['id']}/edit/declarations/{record['frameworkSlug']}"
     return [('admin_link', admin_path)]
 
 

--- a/tests/test_export_framework_results_reasons.py
+++ b/tests/test_export_framework_results_reasons.py
@@ -117,7 +117,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Q1 - shouldBeFalseStrict",
                     u"Supplier 2345 Empl\u00f6yee 123",
                     "supplier.2345.h-cloud-99@example.com",
-                    'https://www.digitalmarketplace.service.gov.uk/suppliers/2345/edit/declarations/h-cloud-99',
+                    'https://www.digitalmarketplace.service.gov.uk/admin/suppliers/2345/edit/declarations/h-cloud-99',
                 ],
                 [
                     "Supplier 3456 generic name",
@@ -125,7 +125,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "No passed lot",
                     u"Supplier 3456 Empl\u00f6yee 123",
                     "supplier.3456.h-cloud-99@example.com",
-                    'https://www.digitalmarketplace.service.gov.uk/suppliers/3456/edit/declarations/h-cloud-99',
+                    'https://www.digitalmarketplace.service.gov.uk/admin/suppliers/3456/edit/declarations/h-cloud-99',
                 ],
             ),
             (
@@ -138,7 +138,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Supplier 1234's dog ate their homework",
                     u"Supplier 1234 Empl\u00f6yee 123",
                     "supplier.1234.h-cloud-99@example.com",
-                    'https://www.digitalmarketplace.service.gov.uk/suppliers/1234/edit/declarations/h-cloud-99',
+                    'https://www.digitalmarketplace.service.gov.uk/admin/suppliers/1234/edit/declarations/h-cloud-99',
                 ],
                 [
                     "Supplier 7654 generic name",
@@ -149,7 +149,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Supplier 7654's dog ate their homework",
                     u"Supplier 7654 Empl\u00f6yee 123",
                     "supplier.7654.h-cloud-99@example.com",
-                    'https://www.digitalmarketplace.service.gov.uk/suppliers/7654/edit/declarations/h-cloud-99',
+                    'https://www.digitalmarketplace.service.gov.uk/admin/suppliers/7654/edit/declarations/h-cloud-99',
                 ],
             ),
             (
@@ -183,7 +183,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Q1 - shouldBeFalseStrict",
                     u"Supplier 2345 Empl\u00f6yee 123",
                     "supplier.2345.h-cloud-99@example.com",
-                    'https://www.digitalmarketplace.service.gov.uk/suppliers/2345/edit/declarations/h-cloud-99',
+                    'https://www.digitalmarketplace.service.gov.uk/admin/suppliers/2345/edit/declarations/h-cloud-99',
                 ],
                 [
                     "Supplier 3456 generic name",
@@ -191,7 +191,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "No passed lot",
                     u"Supplier 3456 Empl\u00f6yee 123",
                     "supplier.3456.h-cloud-99@example.com",
-                    'https://www.digitalmarketplace.service.gov.uk/suppliers/3456/edit/declarations/h-cloud-99',
+                    'https://www.digitalmarketplace.service.gov.uk/admin/suppliers/3456/edit/declarations/h-cloud-99',
                 ],
             ),
             (
@@ -204,7 +204,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Supplier 1234's dog ate their homework",
                     u"Supplier 1234 Empl\u00f6yee 123",
                     "supplier.1234.h-cloud-99@example.com",
-                    'https://www.digitalmarketplace.service.gov.uk/suppliers/1234/edit/declarations/h-cloud-99',
+                    'https://www.digitalmarketplace.service.gov.uk/admin/suppliers/1234/edit/declarations/h-cloud-99',
                 ],
                 [
                     "Supplier 7654 generic name",
@@ -215,7 +215,7 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "Supplier 7654's dog ate their homework",
                     u"Supplier 7654 Empl\u00f6yee 123",
                     "supplier.7654.h-cloud-99@example.com",
-                    'https://www.digitalmarketplace.service.gov.uk/suppliers/7654/edit/declarations/h-cloud-99',
+                    'https://www.digitalmarketplace.service.gov.uk/admin/suppliers/7654/edit/declarations/h-cloud-99',
                 ],
             ),
             (
@@ -266,7 +266,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "No passed lot",
                     u"Supplier 3456 Empl\u00f6yee 123",
                     "supplier.3456.h-cloud-99@example.com",
-                    "https://www.digitalmarketplace.service.gov.uk/suppliers/3456/edit/declarations/h-cloud-99"
+                    "https://www.digitalmarketplace.service.gov.uk/admin/suppliers/3456/edit/declarations/h-cloud-99"
                 ],
             ),
             (
@@ -279,7 +279,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 1234's dog ate their homework",
                     u"Supplier 1234 Empl\u00f6yee 123",
                     "supplier.1234.h-cloud-99@example.com",
-                    "https://www.digitalmarketplace.service.gov.uk/suppliers/1234/edit/declarations/h-cloud-99",
+                    "https://www.digitalmarketplace.service.gov.uk/admin/suppliers/1234/edit/declarations/h-cloud-99",
                 ],
                 [
                     "Supplier 2345 generic name",
@@ -290,7 +290,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 2345's dog ate their homework",
                     u"Supplier 2345 Empl\u00f6yee 123",
                     "supplier.2345.h-cloud-99@example.com",
-                    "https://www.digitalmarketplace.service.gov.uk/suppliers/2345/edit/declarations/h-cloud-99",
+                    "https://www.digitalmarketplace.service.gov.uk/admin/suppliers/2345/edit/declarations/h-cloud-99",
                 ],
                 [
                     "Supplier 7654 generic name",
@@ -301,7 +301,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 7654's dog ate their homework",
                     u"Supplier 7654 Empl\u00f6yee 123",
                     "supplier.7654.h-cloud-99@example.com",
-                    "https://www.digitalmarketplace.service.gov.uk/suppliers/7654/edit/declarations/h-cloud-99",
+                    "https://www.digitalmarketplace.service.gov.uk/admin/suppliers/7654/edit/declarations/h-cloud-99",
                 ],
             ),
             (
@@ -334,7 +334,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "No passed lot",
                     u"Supplier 3456 Empl\u00f6yee 123",
                     "supplier.3456.h-cloud-99@example.com",
-                    "https://www.digitalmarketplace.service.gov.uk/suppliers/3456/edit/declarations/h-cloud-99",
+                    "https://www.digitalmarketplace.service.gov.uk/admin/suppliers/3456/edit/declarations/h-cloud-99",
                 ],
             ),
             (
@@ -347,7 +347,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 1234's dog ate their homework",
                     u"Supplier 1234 Empl\u00f6yee 123",
                     "supplier.1234.h-cloud-99@example.com",
-                    "https://www.digitalmarketplace.service.gov.uk/suppliers/1234/edit/declarations/h-cloud-99",
+                    "https://www.digitalmarketplace.service.gov.uk/admin/suppliers/1234/edit/declarations/h-cloud-99",
 
                 ],
                 [
@@ -359,7 +359,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 2345's dog ate their homework",
                     u"Supplier 2345 Empl\u00f6yee 123",
                     "supplier.2345.h-cloud-99@example.com",
-                    "https://www.digitalmarketplace.service.gov.uk/suppliers/2345/edit/declarations/h-cloud-99",
+                    "https://www.digitalmarketplace.service.gov.uk/admin/suppliers/2345/edit/declarations/h-cloud-99",
 
                 ],
                 [
@@ -371,7 +371,7 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "Supplier 7654's dog ate their homework",
                     u"Supplier 7654 Empl\u00f6yee 123",
                     "supplier.7654.h-cloud-99@example.com",
-                    "https://www.digitalmarketplace.service.gov.uk/suppliers/7654/edit/declarations/h-cloud-99",
+                    "https://www.digitalmarketplace.service.gov.uk/admin/suppliers/7654/edit/declarations/h-cloud-99",
 
                 ],
             ),


### PR DESCRIPTION
The post-application CSV reports we generate for CCS had a typo: we were missing the `/admin` from the URLs where Sourcing admins can view declaration data.