### PR TITLE
Remove service validation from mark-definite-framework-results script

### DIFF
--- a/dmscripts/mark_definite_framework_results.py
+++ b/dmscripts/mark_definite_framework_results.py
@@ -76,10 +76,8 @@ def mark_definite_framework_results(
     framework_slug,
     declaration_definite_pass_schema,
     declaration_discretionary_pass_schema=None,
-    service_schema=None,
     reassess_passed_suppliers=False,
     reassess_failed_suppliers=False,
-    reassess_failed_draft_services=False,
     dry_run=True,
     supplier_ids=None,
     logger=logging.getLogger("script"),
@@ -122,9 +120,7 @@ def mark_definite_framework_results(
             updated_by,
             framework_slug,
             supplier_id,
-            service_schema=service_schema,
             dry_run=dry_run,
-            reassess_failed_draft_services=reassess_failed_draft_services,
             logger=logger
         )
         if not service_counter["passed"]:

--- a/dmscripts/mark_definite_framework_results.py
+++ b/dmscripts/mark_definite_framework_results.py
@@ -25,7 +25,7 @@ def _assess_draft_services(
 ):
     # A supplier must have at least 1 submitted service
     counter = Counter()
-    for draft_service in client.find_draft_services_iter(supplier_id, framework=framework_slug):
+    for draft_service in client.find_draft_services_by_framework_iter(framework_slug, supplier_id=supplier_id):
         counter[draft_service["status"]] += 1
 
     logger.info(

--- a/dmscripts/mark_definite_framework_results.py
+++ b/dmscripts/mark_definite_framework_results.py
@@ -19,53 +19,19 @@ def _passes_validation(candidate, schema, logger, schema_name="schema", tablevel
 
 def _assess_draft_services(
     client,
-    updated_by,
     framework_slug,
     supplier_id,
-    service_schema=None,
-    dry_run=True,
-    reassess_failed_draft_services=False,
     logger=logging.getLogger("script"),
 ):
+    # A supplier must have at least 1 submitted service
     counter = Counter()
     for draft_service in client.find_draft_services_iter(supplier_id, framework=framework_slug):
-        if draft_service["status"] in ("submitted", "failed",):
-            logger.debug("\tAssessing draft service %s", draft_service["id"])
-            if draft_service["status"] == "failed" and not reassess_failed_draft_services:
-                logger.debug("\t\tSkipping - already marked failed")
-                counter["skipped"] += 1
-            elif (
-                service_schema is None
-                or _passes_validation(
-                    draft_service,
-                    service_schema,
-                    logger,
-                    schema_name="service_schema",
-                    tablevel=2,
-                    loglevel=logging.DEBUG
-                )
-            ):
-                if not dry_run:
-                    # mark this as submitted
-                    if draft_service["status"] != "submitted":
-                        client.update_draft_service_status(draft_service["id"], "submitted", updated_by)
-                    else:
-                        logger.debug("\tUnchanged result - not re-setting")
-                counter["passed"] += 1
-            else:
-                if not dry_run:
-                    # mark this as failed
-                    if draft_service["status"] != "failed":
-                        client.update_draft_service_status(draft_service["id"], "failed", updated_by)
-                    else:
-                        logger.debug("\tUnchanged result - not re-setting")
-                counter["failed"] += 1
+        counter[draft_service["status"]] += 1
 
     logger.info(
-        "\tDraft services:  %s passed, %s failed, %s skipped",
-        counter["passed"],
-        counter["failed"],
-        counter["skipped"],
+        "\tDraft services:  %s submitted, %s not-submitted",
+        counter["submitted"],
+        counter["not-submitted"],
     )
     return counter
 
@@ -117,13 +83,11 @@ def mark_definite_framework_results(
         # A supplier should have at least one valid service to pass their application
         service_counter = _assess_draft_services(
             client,
-            updated_by,
             framework_slug,
             supplier_id,
-            dry_run=dry_run,
             logger=logger
         )
-        if not service_counter["passed"]:
+        if not service_counter["submitted"]:
             fail_supplier(supplier_id, framework_slug, updated_by, supplier_framework, client, logger, dry_run=dry_run)
             continue
 

--- a/scripts/framework-applications/mark-definite-framework-results.py
+++ b/scripts/framework-applications/mark-definite-framework-results.py
@@ -3,27 +3,22 @@
 This script is for marking suppliers as having passed/failed a framework, but it will only do so in cases where the
 result can be determined "automatically" not requiring human involvement.
 
-This is determined using a number of json schemas (specified in arguments). This information is used to decide if a
+This is determined using a json schema (specified in arguments). This information is used to decide if a
 particular supplier should be marked as onFramework. The script will attempt to recover a less strict subset of the
 schema from inside the (mandatory) declaration_definite_pass_schema at its' json path definitions/baseline.
 This is used to differentiate between suppliers that definitely fail and those that will require a human decision
 ("discretionary"). If this subschema is not found, all suppliers failing declaration_definite_pass_schema will have
 onFramework left unmodified (probably remaining null).
 
-If draft_service_schema is supplied, this script will also determine the result of individual draft services associated
-with the supplier_framework and mark those that fail the draft_service_schema as "failed".
+The default behaviour is to skip supplier_frameworks which already have a non-null onFramework set, though this can be
+controlled with the --reassess-passed-sf and --reassess-failed-sf flags.
 
-supplier_frameworks with no remaining non-failed draft services are considered a definite fail in all cases.
+You may only want to reassess certain suppliers. This can be done with the `supplier-id-file` option.
+It should be set to the path to a file containing the supplier ids to check, one per line.
 
-The default behaviour is to skip supplier_frameworks which already have a non-null onFramework set and draft services
-whose status is already "failed", though this can be controlled with the --reassess-passed-sf, --reassess-failed-sf
-and --reassess-failed-draft-services, the latter of which will mark "failed" services back as "submitted" if it proves
-not to fail this time around (or if no draft_service_schema is supplied). You may only want to reassess certain
-suppliers. This can be done with the `supplier-id-file` option. It should be set to the path to a file containing the
-supplier ids to check, one per line.
-
-Usage: scripts/framework-applications/mark-definite-framework-results.py [options] <stage> <framework_slug>
-            <declaration_definite_pass_schema_path> [<draft_service_schema_path>]
+Usage:
+    scripts/framework-applications/mark-definite-framework-results.py <stage> <framework_slug>
+        <declaration_definite_pass_schema_path> [<draft_service_schema_path>] [options]
 
 --updated-by=<user_string>        Specify updated_by string to use in API requests
 --dry-run                         Don't actually perform any updates on API

--- a/scripts/framework-applications/mark-definite-framework-results.py
+++ b/scripts/framework-applications/mark-definite-framework-results.py
@@ -18,13 +18,12 @@ It should be set to the path to a file containing the supplier ids to check, one
 
 Usage:
     scripts/framework-applications/mark-definite-framework-results.py <stage> <framework_slug>
-        <declaration_definite_pass_schema_path> [<draft_service_schema_path>] [options]
+        <declaration_definite_pass_schema_path> [options]
 
 --updated-by=<user_string>        Specify updated_by string to use in API requests
 --dry-run                         Don't actually perform any updates on API
 --reassess-passed-sf              Don't skip supplier_frameworks with onFramework already True
 --reassess-failed-sf              Don't skip supplier_frameworks with onFramework already False
---reassess-failed-draft-services  Don't skip draft_services with "failed" status
 -v, --verbose                     Produce more detailed console output
 --supplier-id-file=<path>         Path to file containing supplier ids to check. One ID per line.
 --excluded-supplier-ids=<esis>    Supplier IDs to be excluded.
@@ -32,10 +31,8 @@ Usage:
 import sys
 sys.path.insert(0, '.')
 
-
 import getpass
 import json
-
 
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmapiclient import DataAPIClient
@@ -58,10 +55,6 @@ if __name__ == "__main__":
     declaration_discretionary_pass_schema = \
         (declaration_definite_pass_schema.get("definitions") or {}).get("baseline")
 
-    service_schema = json.load(
-        open(args["<draft_service_schema_path>"], "r")
-    ) if args["<draft_service_schema_path>"] else None
-
     supplier_id_file = args["--supplier-id-file"]
     supplier_ids = get_supplier_ids_from_file(supplier_id_file)
 
@@ -73,10 +66,8 @@ if __name__ == "__main__":
         args["<framework_slug>"],
         declaration_definite_pass_schema,
         declaration_discretionary_pass_schema=declaration_discretionary_pass_schema,
-        service_schema=service_schema,
         reassess_passed_suppliers=args["--reassess-passed-sf"],
         reassess_failed_suppliers=args["--reassess-failed-sf"],
-        reassess_failed_draft_services=args["--reassess-failed-draft-services"],
         dry_run=args["--dry-run"],
         supplier_ids=supplier_ids,
         excluded_supplier_ids=args["--excluded-supplier-ids"],

--- a/tests/assessment_helpers.py
+++ b/tests/assessment_helpers.py
@@ -43,34 +43,6 @@ class BaseAssessmentTest(object):
             },
         }
 
-    # putting these in methods so we are sure to always get a clean copy
-    def _draft_service_schema(self):
-        return {
-            "$schema": "http://json-schema.org/draft-04/schema#",
-            "type": "object",
-            "anyOf": [
-                {
-                    "properties": {
-                        "lotSlug": {"enum": ["stuffed-roast-heart"]},
-                        "kosher": {"type": "boolean"},
-                    },
-                    "required": ["kosher"],
-                },
-                {
-                    "properties": {
-                        "lotSlug": {"enum": ["pork-kidney", "ham-and-eggs"]},
-                        "kosher": {"enum": [False]},
-                        "butcher": {"enum": ["Dlugacz"]},
-                    },
-                },
-                {
-                    "properties": {
-                        "lotSlug": {"enum": ["grilled-mutton-kidney"]},
-                    },
-                },
-            ],
-        }
-
     def _get_ordered_question_ids(self):
         return (
             "shouldBeFalseLax",

--- a/tests/assessment_helpers.py
+++ b/tests/assessment_helpers.py
@@ -177,14 +177,6 @@ class BaseAssessmentTest(object):
                         "omnipresent": "ether",
                     },
                 },
-                6543: {
-                    "onFramework": True,
-                    "declaration": {
-                        "status": "complete",
-                        "shouldBeTrueStrict": True,
-                        "omnipresent": "ether",
-                    },
-                },
                 7654: {
                     "onFramework": None,
                     "declaration": {
@@ -274,14 +266,6 @@ class BaseAssessmentTest(object):
                     },
                 ),
                 5432: (),
-                6543: (
-                    {
-                        "id": 999010,
-                        "status": "failed",
-                        "lotSlug": "stuffed-roast-heart",
-                        "kosher": True,
-                    },
-                ),
                 7654: (
                     {
                         "id": 999011,
@@ -290,7 +274,7 @@ class BaseAssessmentTest(object):
                     },
                     {
                         "id": 999012,
-                        "status": "failed",
+                        "status": "not-submitted",
                         "lotSlug": "stuffed-roast-heart",
                         "kosher": None,
                     },
@@ -304,7 +288,7 @@ class BaseAssessmentTest(object):
                     },
                     {
                         "id": 999014,
-                        "status": "failed",
+                        "status": "not-submitted",
                         "lotSlug": "grilled-mutton-kidney",
                         "kosher": None,
                     },
@@ -384,7 +368,6 @@ class BaseAssessmentMismatchedOnFrameworksTestMixin(_BaseAssessmentOverriddenOnF
             4321: False,
             4567: False,
             5432: None,
-            6543: None,
             7654: None,
             8765: None,
         }
@@ -400,7 +383,6 @@ class BaseAssessmentOnFrameworksAsThoughNoBaselineTestMixin(_BaseAssessmentOverr
             4321: True,
             4567: None,
             5432: None,
-            6543: True,
             7654: None,
             8765: True,
         }

--- a/tests/assessment_helpers.py
+++ b/tests/assessment_helpers.py
@@ -293,6 +293,10 @@ class BaseAssessmentTest(object):
             "interestedSuppliers": self.mock_supplier_frameworks.keys(),
         }
 
+    def _mock_find_draft_services_by_framework_iter_impl(self, framework, supplier_id=None):
+        assert framework == self.framework_slug
+        return iter(self.mock_draft_services[supplier_id])
+
     def _mock_find_draft_services_iter_impl(self, supplier_id, framework=None):
         assert framework == self.framework_slug
         return iter(self.mock_draft_services[supplier_id])
@@ -310,7 +314,10 @@ class BaseAssessmentTest(object):
         self.mock_data_client = Mock()
         self.mock_data_client.get_supplier_framework_info.side_effect = self._mock_get_supplier_framework_info_impl
         self.mock_data_client.get_interested_suppliers.side_effect = self._mock_get_interested_suppliers_impl
-        self.mock_data_client.find_draft_services_iter.side_effect = self._mock_find_draft_services_iter_impl
+        self.mock_data_client.find_draft_services_by_framework_iter.side_effect = \
+            self._mock_find_draft_services_by_framework_iter_impl
+        self.mock_data_client.find_draft_services_iter.side_effect = \
+            self._mock_find_draft_services_iter_impl
         self.mock_data_client.get_supplier.side_effect = self._mock_get_supplier_impl
 
 

--- a/tests/test_export_framework_results_reasons.py
+++ b/tests/test_export_framework_results_reasons.py
@@ -160,12 +160,6 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "supplier.4321.h-cloud-99@example.com",
                 ],
                 [
-                    "Supplier 6543 generic name",
-                    "6543",
-                    u"Supplier 6543 Empl\u00f6yee 123",
-                    "supplier.6543.h-cloud-99@example.com",
-                ],
-                [
                     "Supplier 8765 generic name",
                     "8765",
                     u"Supplier 8765 Empl\u00f6yee 123",
@@ -224,12 +218,6 @@ class TestExportOnFrameworkBaseline(_BaseExportTest):
                     "4321",
                     u"Supplier 4321 Empl\u00f6yee 123",
                     "supplier.4321.h-cloud-99@example.com",
-                ],
-                [
-                    "Supplier 6543 generic name",
-                    "6543",
-                    u"Supplier 6543 Empl\u00f6yee 123",
-                    "supplier.6543.h-cloud-99@example.com",
                 ],
                 [
                     "Supplier 8765 generic name",
@@ -312,12 +300,6 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "supplier.4321.h-cloud-99@example.com",
                 ],
                 [
-                    "Supplier 6543 generic name",
-                    "6543",
-                    u"Supplier 6543 Empl\u00f6yee 123",
-                    "supplier.6543.h-cloud-99@example.com",
-                ],
-                [
                     "Supplier 8765 generic name",
                     "8765",
                     u"Supplier 8765 Empl\u00f6yee 123",
@@ -381,12 +363,6 @@ class TestExportOnFrameworkNoBaseline(BaseAssessmentOnFrameworksAsThoughNoBaseli
                     "4321",
                     u"Supplier 4321 Empl\u00f6yee 123",
                     "supplier.4321.h-cloud-99@example.com",
-                ],
-                [
-                    "Supplier 6543 generic name",
-                    "6543",
-                    u"Supplier 6543 Empl\u00f6yee 123",
-                    "supplier.6543.h-cloud-99@example.com",
                 ],
                 [
                     "Supplier 8765 generic name",

--- a/tests/test_mark_definite_framework_results.py
+++ b/tests/test_mark_definite_framework_results.py
@@ -7,17 +7,6 @@ from dmscripts.mark_definite_framework_results import mark_definite_framework_re
 from .assessment_helpers import BaseAssessmentTest, BaseAssessmentMismatchedOnFrameworksTestMixin
 
 
-def _assert_draft_service_result_actions(client, expected_draft_services_actions, dry_run=False):
-    update_draft_service_status_calls = [call[0] for call in client.update_draft_service_status.call_args_list]
-
-    expected_calls = [] if dry_run else [
-        (supplier_id, "submitted" if submitted else "failed", "Blazes Boylan")
-        for supplier_id, submitted
-        in expected_draft_services_actions
-    ]
-    assert update_draft_service_status_calls == expected_calls
-
-
 def _assert_set_framework_result_actions(client, expected_set_framework_actions, dry_run=False):
     set_framework_result_calls = [call[0] for call in client.set_framework_result.call_args_list]
 
@@ -33,57 +22,6 @@ class TestNoPrevResults(BaseAssessmentTest):
         return {
             k: dict(v, onFramework=None) for k, v in super(TestNoPrevResults, self)._get_supplier_frameworks().items()
         }
-
-    def _get_draft_services(self):
-        # no draft services should have been failed yet
-        return {
-            k: tuple(
-                dict(s, status=("submitted" if s["status"] == "failed" else s["status"])) for s in v
-            ) for k, v in super(TestNoPrevResults, self)._get_draft_services().items()
-        }
-
-    @pytest.mark.parametrize(
-        # we can very easily parametrize this into the 16 possible combinations of these flags - the results for the
-        # first three flags should be identical and it's very easy to flip some of the assertions for the dry_run mode
-        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_draft_services,dry_run",
-        tuple(product(*repeat((False, True,), 4))),
-    )
-    def test_with_draft_services_schema(
-            self,
-            reassess_passed_suppliers,
-            reassess_failed_suppliers,
-            reassess_failed_suppliers_draft_services,
-            dry_run,
-    ):
-        mark_definite_framework_results(
-            self.mock_data_client,
-            "Blazes Boylan",
-            "h-cloud-99",
-            self._declaration_definite_pass_schema(),
-            declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
-            service_schema=self._draft_service_schema(),
-            dry_run=dry_run,
-            reassess_passed_suppliers=reassess_passed_suppliers,
-            reassess_failed_suppliers=reassess_failed_suppliers,
-            reassess_failed_draft_services=reassess_failed_suppliers_draft_services,
-        )
-
-        expected_set_framework_actions = (
-            (2345, False),
-            (3456, False),
-            (4321, True),
-            (4567, False),
-            (5432, False),
-            (6543, True),
-            (8765, True),
-        )
-        expected_draft_services_actions = (
-            (999003, False),
-            (999005, False),
-            (999012, False),
-        )
-        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
-        _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
@@ -103,11 +41,9 @@ class TestNoPrevResults(BaseAssessmentTest):
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
             declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
-            service_schema=None,
             dry_run=dry_run,
             reassess_passed_suppliers=reassess_passed_suppliers,
             reassess_failed_suppliers=reassess_failed_suppliers,
-            reassess_failed_draft_services=reassess_failed_suppliers_draft_services,
         )
 
         expected_set_framework_actions = (
@@ -116,7 +52,6 @@ class TestNoPrevResults(BaseAssessmentTest):
             (4321, True),
             (4567, False),
             (5432, False),
-            (6543, True),
             (8765, True),
         )
 
@@ -140,27 +75,18 @@ class TestNoPrevResults(BaseAssessmentTest):
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
             declaration_discretionary_pass_schema=None,
-            service_schema=self._draft_service_schema(),
             dry_run=dry_run,
             reassess_passed_suppliers=reassess_passed_suppliers,
             reassess_failed_suppliers=reassess_failed_suppliers,
-            reassess_failed_draft_services=reassess_failed_suppliers_draft_services,
         )
 
         expected_set_framework_actions = (
-            (3456, False),
+            (3456, True),
             (4321, True),
             (4567, False),
             (5432, False),
-            (6543, True),
             (8765, True),
         )
-        expected_draft_services_actions = (
-            (999003, False),
-            (999005, False),
-            (999012, False),
-        )
-        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
         _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     @pytest.mark.parametrize(
@@ -181,11 +107,9 @@ class TestNoPrevResults(BaseAssessmentTest):
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
             declaration_discretionary_pass_schema=None,
-            service_schema=None,
             dry_run=dry_run,
             reassess_passed_suppliers=reassess_passed_suppliers,
             reassess_failed_suppliers=reassess_failed_suppliers,
-            reassess_failed_draft_services=reassess_failed_suppliers_draft_services,
         )
 
         expected_set_framework_actions = (
@@ -193,7 +117,6 @@ class TestNoPrevResults(BaseAssessmentTest):
             (4321, True),
             (4567, False),
             (5432, False),
-            (6543, True),
             (8765, True),
         )
 
@@ -210,23 +133,16 @@ class TestPrevResults(BaseAssessmentMismatchedOnFrameworksTestMixin, BaseAssessm
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
             declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
-            service_schema=self._draft_service_schema(),
             dry_run=dry_run,
             reassess_passed_suppliers=False,
             reassess_failed_suppliers=False,
-            reassess_failed_draft_services=False,
         )
 
         expected_set_framework_actions = (
             (2345, False),
             (5432, False),
-            (6543, False),
             (8765, True),
         )
-        expected_draft_services_actions = (
-            (999003, False),
-        )
-        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
         _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
@@ -238,24 +154,17 @@ class TestPrevResults(BaseAssessmentMismatchedOnFrameworksTestMixin, BaseAssessm
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
             declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
-            service_schema=self._draft_service_schema(),
             dry_run=dry_run,
             reassess_passed_suppliers=False,
             reassess_failed_suppliers=True,
-            reassess_failed_draft_services=False,
         )
 
         expected_set_framework_actions = (
             (2345, False),
             (4321, True),
             (5432, False),
-            (6543, False),
             (8765, True),
         )
-        expected_draft_services_actions = (
-            (999003, False),
-        )
-        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
         _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
@@ -267,25 +176,16 @@ class TestPrevResults(BaseAssessmentMismatchedOnFrameworksTestMixin, BaseAssessm
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
             declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
-            service_schema=self._draft_service_schema(),
             dry_run=dry_run,
             reassess_passed_suppliers=True,
             reassess_failed_suppliers=False,
-            reassess_failed_draft_services=False,
         )
 
         expected_set_framework_actions = (
             (2345, False),
-            (3456, False),
             (5432, False),
-            (6543, False),
             (8765, True),
         )
-        expected_draft_services_actions = (
-            (999003, False),
-            (999005, False),
-        )
-        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
         _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
@@ -297,28 +197,17 @@ class TestPrevResults(BaseAssessmentMismatchedOnFrameworksTestMixin, BaseAssessm
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
             declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
-            service_schema=self._draft_service_schema(),
             dry_run=dry_run,
             reassess_passed_suppliers=True,
             reassess_failed_suppliers=True,
-            reassess_failed_draft_services=True,
         )
 
         expected_set_framework_actions = (
             (2345, False),
-            (3456, False),
             (4321, True),
             (5432, False),
-            (6543, True),
             (8765, True),
         )
-        expected_draft_services_actions = (
-            (999003, False),
-            (999005, False),
-            (999010, True),
-            (999014, True),
-        )
-        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
         _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)
 
     # it's very easy to flip some of the assertions for the dry_run mode so using parametrization here
@@ -330,24 +219,15 @@ class TestPrevResults(BaseAssessmentMismatchedOnFrameworksTestMixin, BaseAssessm
             "h-cloud-99",
             self._declaration_definite_pass_schema(),
             declaration_discretionary_pass_schema=self._declaration_definite_pass_schema()["definitions"]["baseline"],
-            service_schema=None,
             dry_run=dry_run,
             reassess_passed_suppliers=True,
             reassess_failed_suppliers=True,
-            reassess_failed_draft_services=True,
         )
 
         expected_set_framework_actions = (
             (2345, False),
             (4321, True),
             (5432, False),
-            (6543, True),
             (8765, True),
         )
-        expected_draft_services_actions = (
-            (999010, True),
-            (999012, True),
-            (999014, True),
-        )
-        _assert_draft_service_result_actions(self.mock_data_client, expected_draft_services_actions, dry_run=dry_run)
         _assert_set_framework_result_actions(self.mock_data_client, expected_set_framework_actions, dry_run=dry_run)

--- a/tests/test_mark_definite_framework_results.py
+++ b/tests/test_mark_definite_framework_results.py
@@ -28,7 +28,7 @@ class TestNoPrevResults(BaseAssessmentTest):
         "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_draft_services,dry_run",
         tuple(product(*repeat((False, True,), 4))),
     )
-    def test_without_draft_services_schema(
+    def test_with_discretionary_pass_schema(
             self,
             reassess_passed_suppliers,
             reassess_failed_suppliers,

--- a/tests/test_mark_definite_framework_results.py
+++ b/tests/test_mark_definite_framework_results.py
@@ -25,14 +25,13 @@ class TestNoPrevResults(BaseAssessmentTest):
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_draft_services,dry_run",
-        tuple(product(*repeat((False, True,), 4))),
+        "reassess_passed_suppliers,reassess_failed_suppliers,dry_run",
+        tuple(product(*repeat((False, True,), 3))),
     )
     def test_with_discretionary_pass_schema(
             self,
             reassess_passed_suppliers,
             reassess_failed_suppliers,
-            reassess_failed_suppliers_draft_services,
             dry_run,
     ):
         mark_definite_framework_results(
@@ -59,14 +58,13 @@ class TestNoPrevResults(BaseAssessmentTest):
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_draft_services,dry_run",
-        tuple(product(*repeat((False, True,), 4))),
+        "reassess_passed_suppliers,reassess_failed_suppliers,dry_run",
+        tuple(product(*repeat((False, True,), 3))),
     )
     def test_no_discretionary_pass_schema(
         self,
         reassess_passed_suppliers,
         reassess_failed_suppliers,
-        reassess_failed_suppliers_draft_services,
         dry_run,
     ):
         mark_definite_framework_results(
@@ -91,14 +89,13 @@ class TestNoPrevResults(BaseAssessmentTest):
 
     @pytest.mark.parametrize(
         # see above explanation of parameterization
-        "reassess_passed_suppliers,reassess_failed_suppliers,reassess_failed_suppliers_draft_services,dry_run",
-        tuple(product(*repeat((False, True,), 4))),
+        "reassess_passed_suppliers,reassess_failed_suppliers,dry_run",
+        tuple(product(*repeat((False, True,), 3))),
     )
     def test_neither_optional_schema(
         self,
         reassess_passed_suppliers,
         reassess_failed_suppliers,
-        reassess_failed_suppliers_draft_services,
         dry_run,
     ):
         mark_definite_framework_results(


### PR DESCRIPTION
Final bit of post-G12 script cleanup. 

The `mark-definite-framework-results` script is used to automatically determine whether a supplier has passed or failed their declaration (given a JSON schema), and set the `onFramework` value in the API.

At one point, the script used to also validate service data (for DOS frameworks only - a service could have status 'failed'), however since DOS4 this validation has been done in the Supplier FE instead. This means a lot of redundant code and confusing instructions can now be removed from this script 🎉 

- Removes mentions of draft service schemas from top-level script docstring
- Remove code that assesses draft services using a schema
- Simplify the 'assess drafts' step (we still need to check that a supplier has at least 1 submitted draft)
- Test cleanup