### PR TITLE
[Experimental] Alternative method for updating draft services and documents

### DIFF
--- a/scripts/oneoff/update_draft_service_via_csv.py
+++ b/scripts/oneoff/update_draft_service_via_csv.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python
+"""
+Experimental script to provide an alternative method of manually updating draft services, for example if a user
+has accessibility issues that prevent them using the site, they could submit their answers to us via CSV.
+
+- Look up draft service ID by service name
+- Map question numbers to content loader service questions for the lot
+- Construct JSON blob of answers to attempt to update API
+- Output validation errors
+- If service has no further validation errors, output success message 'can be marked as complete'
+
+Usage: update_draft_service_via_csv <framework> <stage> [options]
+
+Options:
+    --folder=<folder>                                     Folder to bulk-upload files
+    --dry-run                                             List actions that would have been taken
+    -h, --help                                            Show this screen
+
+"""
+import sys
+import os
+import csv
+from dmapiclient.data import DataAPIClient
+from dmapiclient import HTTPError
+
+sys.path.insert(0, '.')
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.generate_questions_csv import get_questions
+from dmscripts.helpers.file_helpers import get_all_files_of_type
+from dmcontent.content_loader import ContentLoader
+from dmutils.env_helpers import get_api_endpoint_from_stage
+from docopt import docopt
+
+
+LOT_ANSWER_COUNTS = {
+    'cloud-support': 10,
+    'cloud-hosting': 22,
+    'cloud-software': 42
+}
+
+PRICE_UNITS = [
+    "per unit",
+    "per person",
+    "per licence",
+    "per user",
+    "per device",
+    "per instance",
+    "per server",
+    "per virtual machine",
+    "per transaction",
+    "per megabyte",
+    "per gigabyte",
+    "per terabyte"
+]
+
+PRICE_INTERVAL_UNITS = [
+    "per second",
+    "per minute",
+    "per hour",
+    "per day",
+    "per week",
+    "per quarter",
+    "per 6 months",
+    "per year"
+]
+
+
+def _normalise_service_name(name):
+    return name.lower().replace('-', '').replace(' ', '').replace('/', ':').replace('.csv', '')
+
+
+def get_question_objects(content):
+    question_objs = {
+        # 'Question text': question_obj
+    }
+
+    for section in content.sections:
+        for question in get_questions(section.questions):
+            question_objs[question.get_source('question')] = question
+
+    return question_objs
+
+
+def find_draft_id_by_service_name(client, supplier_id, service_name, framework_slug):
+    normalised_name = _normalise_service_name(service_name)
+
+    drafts = client.find_draft_services_by_framework_iter(framework_slug, supplier_id=supplier_id)
+    matches = []
+    for draft in drafts:
+        if draft.get('serviceName'):
+            if _normalise_service_name(draft['serviceName']) == normalised_name:
+                matches.append(draft['id'])
+    if len(matches) == 0:
+        print(f"Unable to find Draft ID from service name {service_name}")
+        return None
+
+    if len(matches) > 1:
+        print(f"Unable to find Draft ID from service name {service_name} - multiple matches")
+        return 'multi'
+
+    print("Found draft service ID", matches[0])
+    return matches[0]
+
+
+def get_price_data(answers):
+    formatted_answers = []
+    for a in answers:
+        # Get rid of any rogue £ signs
+        formatted_answers.append(a.replace("£", ""))
+    price_dict = {
+        'priceMin': formatted_answers[0]
+    }
+
+    # Parse the mandatory/optional arguments and convert to schema-friendly values
+    for answer in formatted_answers[1:]:
+        if answer in PRICE_UNITS:
+            price_dict['priceUnit'] = answer.replace('per ', '').title()
+        elif answer in PRICE_INTERVAL_UNITS:
+            price_dict['priceInterval'] = answer.replace('per ', '').title()
+        else:
+            price_dict['priceMax'] = answer
+
+    return price_dict
+
+
+def lookup_question_id_and_text(row, questions):
+    question_text = row['Question']
+
+    # Handle curly apostrophes removed from CSV
+    if "'" in question_text:
+        question_text = question_text.replace("'", "’")
+
+    # Lookup long-winded question text in global question_objects to get camelCase ID
+    try:
+        question_id = questions[question_text].id
+    except KeyError:
+        print(f'Could not find question {row["Question"]}')
+        return None, None
+
+    return question_id, question_text
+
+
+def parse_answer_from_csv_row(row, questions, question_text, lot_slug):
+    answers = [row[f"Answer {i + 1}"] for i in range(0, LOT_ANSWER_COUNTS[lot_slug]) if row.get(f"Answer {i + 1}")]
+
+    if not answers:
+        # Question has been left blank
+        return None
+
+    if question_text == 'Which categories does your service fit under?':
+        return answers
+
+    if question_text == 'How much does the service cost (excluding VAT)?':
+        # Price answer can be up to 4 fields - add to JSON in create_draft_json_from_csv()
+        price_dict = get_price_data(answers)
+        return price_dict
+
+    if hasattr(questions[question_text], 'options') and questions[question_text].options:
+        # Check if the answer(s) need to be mapped to another value
+        mapped_answers = []
+        for answer in answers:
+            for option_dict in questions[question_text].options:
+                # handle curly apostrophes in option labels
+                formatted_answer = answer.replace("'", "’")
+                if option_dict['label'] in [formatted_answer, answer]:
+                    # Service categories don't have an option value - use original answers
+                    mapped_answers.append(option_dict.get('value', answer))
+
+        if questions[question_text].type in ['radios']:
+            # Log warning if multiple options chosen
+            if mapped_answers and len(mapped_answers) > 1:
+                print("Multiple answers given for radio button - using first answer", question_text)
+
+            # Only 1 option allowed - use the first
+            mapped_answers = mapped_answers[0] if mapped_answers else None
+
+        return mapped_answers
+
+    if questions[question_text].type in ['list', 'checkboxes']:
+        # Multipart answer that doesn't need mapping
+        return answers
+
+    # Otherwise treat as a single answer
+    answer = answers[0]
+
+    # Check if answer needs to be mapped to another value
+    if hasattr(questions[question_text], 'options') and questions[question_text].options:
+        for option_dict in questions[question_text].options:
+            # handle curly apostrophes in option labels
+            formatted_answer = answer.replace("'", "’")
+            if option_dict['label'] in [formatted_answer, answer]:
+                answer = option_dict.get('value', answer)
+
+    # Convert booleans to JSON true/false
+    if questions[question_text].type == 'boolean':
+        answer = True if answer == 'Yes' else False
+        # Log warning if multiple options chosen
+        if len(answers) > 1:
+            print("Multiple answers given for boolean question")
+
+    return answer
+
+
+def create_draft_json_from_csv(filepath, lot_slug, question_objects, encoding=None):
+    # Parse rows from CSV and build a JSON dict
+    draft_json = {}
+
+    with open(filepath, encoding=encoding) as f:
+        reader = csv.DictReader(f)
+
+        for row in reader:
+            question_id, question_text = lookup_question_id_and_text(row, question_objects)
+            if not question_id:
+                continue
+
+            answer = parse_answer_from_csv_row(row, question_objects, question_text, lot_slug)
+            if answer is not None:
+                if question_id == 'price':
+                    # Add all price fields
+                    draft_json.update(answer)
+                elif 'serviceCategories' in question_id:
+                    if question_id in draft_json:
+                        draft_json[question_id].extend(answer)
+                    else:
+                        draft_json[question_id] = answer
+                    # Remove duplicates
+                    categories = draft_json[question_id]
+                    draft_json[question_id] = list(sorted(set(categories)))
+                else:
+                    draft_json[question_id] = answer
+
+    return draft_json
+
+
+def output_service_categories_features_and_benefits_summary(draft_json):
+    # Useful for determining if these fields are over the max word limit per item
+    print("Service categories count:", len(draft_json.get('serviceCategories', [])))
+
+    print("Service features:", draft_json.get('serviceFeatures'))
+    for item in draft_json.get('serviceFeatures', []):
+        print("{} ({} words)".format(item, len(item.split(' '))))
+
+    print("Service benefits:", draft_json.get('serviceBenefits'))
+    for item in draft_json.get('serviceBenefits', []):
+        print("{} ({} words)".format(item, len(item.split(' '))))
+
+
+def split_lot_and_service(lot_and_service_name):
+    lot_slug, service_name = None, None
+    for lot in LOT_ANSWER_COUNTS.keys():
+        if lot in lot_and_service_name:
+            lot_slug = lot
+            service_name = lot_and_service_name.split(lot_slug)[1]
+            break
+
+    if not lot_slug:
+        print(f"Unable to identify lot for {lot_and_service_name}")
+        return None, None
+
+    service_name = service_name.replace('.csv', '')
+
+    return lot_slug, service_name
+
+
+def output_results(unidentifiable_files, malformed_csvs, successful_draft_ids, failed_draft_ids):
+    # Output successful / failed draft IDs
+    print(len(successful_draft_ids), "successful draft services")
+    if successful_draft_ids:
+        with open('successful-csv-draft-ids.txt', 'w') as f:
+            for s, f_, d in successful_draft_ids:
+                f.write(f"{s}, {f_}, {d}" + '\n')
+
+    if failed_draft_ids:
+        print(len(failed_draft_ids), "failed draft services")
+        with open('failed-csv-draft-ids.txt', 'w') as f:
+            for s, f_, d, exc in failed_draft_ids:
+                f.write(f"{s}, {f_}, {d}, {exc}" + '\n')
+
+    # Output CSVs that we couldn't parse
+    if malformed_csvs:
+        print(len(malformed_csvs), "malformed CSVs")
+        with open('malformed-csv-draft-ids.txt', 'w') as f:
+            for s, d in malformed_csvs:
+                f.write(f"{s}, {d}" + '\n')
+
+    # Output CSVs we couldn't match to a draft service
+    if unidentifiable_files:
+        print(len(unidentifiable_files), "unidentifiable files")
+        with open('unidentifiable-draft-service-files.txt', 'w') as f:
+            for d in unidentifiable_files:
+                f.write(str(d) + '\n')
+
+
+def update_draft_services_from_folder(folder_name, api_client, framework_slug, content_loader, dry_run):
+    failed_draft_ids = []
+    successful_draft_ids = []
+    unidentifiable_files = []
+    malformed_csvs = []
+
+    content_loader.load_manifest(framework_slug, 'services', 'edit_submission')
+    content = content_loader.get_manifest(framework_slug, 'edit_submission')
+
+    for filepath in get_all_files_of_type(folder_name, 'csv'):
+        file_name = os.path.basename(filepath)
+        # Get supplier ID from filename
+        supplier_id, lot_and_service_name = file_name.split('-', maxsplit=1)
+        print(f"Supplier ID {supplier_id}")
+
+        lot_slug, service_name = split_lot_and_service(lot_and_service_name)
+        if not (lot_slug and service_name):
+            unidentifiable_files.append(file_name)
+            continue
+
+        # Get the id
+        id_ = find_draft_id_by_service_name(api_client, supplier_id, service_name, framework_slug)
+        if id_ is None or id_ == 'multi':
+            unidentifiable_files.append(file_name)
+            continue
+
+        # Get a dict of service questions for the lot, where the key matches the question text in the CSVs
+        content = content.filter(context={"lot": lot_slug})
+        question_objects_ = get_question_objects(content)
+
+        # Only then bother trying to parse CSV into JSON
+        try:
+            draft_json = create_draft_json_from_csv(filepath, lot_slug, question_objects_)
+        except UnicodeDecodeError:
+            print("WARNING:", "unable to decode CSV using utf-8, trying cp1252")
+            try:
+                draft_json = create_draft_json_from_csv(filepath, lot_slug, question_objects_, encoding="cp1252")
+            except UnicodeDecodeError as e:
+                print("WARNING:", e)
+                malformed_csvs.append((supplier_id, file_name))
+                continue
+
+        # Try updating service data
+        if dry_run:
+            # Log something
+            print(f"Would update draft ID {id_} with some JSON:")
+            print(draft_json)
+            successful_draft_ids.append((supplier_id, file_name, id_))
+        else:
+            for section in content.sections:
+                questions = section.get_field_names()
+                section_json = {
+                    q: draft_json[q] for q in questions if q in draft_json
+                }
+                try:
+                    if section_json:
+                        api_client.update_draft_service(
+                            id_,
+                            section_json,
+                            f'{framework_slug} service update script',
+                            page_questions=questions
+                        )
+                except HTTPError as exc:
+                    # Unable to update section
+                    print(f"Section '{section.name}' for Draft ID {id_} failed.")
+                    print(section_json)
+                    print(str(exc))
+
+            # Once all sections updated, check for remaining validation errors
+            draft = api_client.get_draft_service(id_)
+            if draft['validationErrors']:
+                print(f"Draft ID {id_} Validation errors:")
+                errors = {k: v for k, v in draft['validationErrors'].items() if k != '_form'}
+                failed_draft_ids.append((supplier_id, file_name, id_, errors))
+                # Debugging serviceCategories, serviceBenefits, serviceFeatures
+                output_service_categories_features_and_benefits_summary(draft_json)
+            else:
+                print(f"Draft ID {id_} ready to be marked as complete.")
+                successful_draft_ids.append((supplier_id, file_name, id_))
+
+    output_results(unidentifiable_files, malformed_csvs, successful_draft_ids, failed_draft_ids)
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    # Get script arguments
+    framework_slug = arguments['<framework>']
+    stage = arguments['<stage>'] or 'local'
+    dry_run = arguments['--dry-run'] or None
+
+    data_api_client = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(stage),
+        auth_token=get_auth_token('api', stage)
+    )
+    content_loader = ContentLoader("../digitalmarketplace-frameworks")
+
+    local_directory = arguments['--folder']
+
+    # Check folder exists
+    if local_directory and not os.path.exists(local_directory):
+        print(f"Local directory {local_directory} not found. Aborting upload.")
+        exit(1)
+
+    # Check framework status
+    framework = data_api_client.get_framework(framework_slug)
+    framework_status = framework['frameworks']['status']
+    if framework_status not in ['open']:
+        print(f"Cannot update services for framework {framework_slug} in status '{framework_status}'")
+        exit(1)
+
+    update_draft_services_from_folder(local_directory, data_api_client, framework_slug, content_loader, dry_run)

--- a/scripts/oneoff/upload_draft_service_pdfs.py
+++ b/scripts/oneoff/upload_draft_service_pdfs.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+"""
+Experimental script to provide an alternative method of manually uploading documents for draft services,
+for example if a user has accessibility issues that prevent them using the site, they could submit documents
+to CCS via email.
+
+IMPORTANT: ensure you have the correct AWS_PROFILE env variable set for the environment, otherwise the S3 uploads will
+fail.
+
+- For each file in the given folder
+- Look up draft service ID by supplier ID and service name
+- Determine whether doc is pricing/SFIA/T&C/service definition
+- Upload documents to S3, following the standardised naming scheme <draft_id>-<doctype>-<datestamp>.pdf
+- Update draft service with S3 URLs
+
+Any failures will skip and continue to the next document in the folder.
+
+Not included: Modern Slavery Statement documents
+
+Usage: upload_draft_service_pdfs <framework> <stage> [options]
+
+Options:
+    --folder=<folder>                                     Folder to bulk-upload files
+    --dry-run                                             List actions that would have been taken
+    -h, --help                                            Show this screen
+
+"""
+import sys
+import os
+import urllib.parse as urlparse
+from dmapiclient.data import DataAPIClient
+
+sys.path.insert(0, '.')
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.file_helpers import get_all_files_of_type
+from dmscripts.helpers.s3_helpers import get_bucket_name
+from scripts.oneoff.update_draft_service_via_csv import find_draft_id_by_service_name
+
+from dmutils.env_helpers import get_api_endpoint_from_stage, get_assets_endpoint_from_stage
+from dmutils.documents import default_file_suffix, generate_download_filename
+from dmutils.s3 import S3
+
+from docopt import docopt
+
+
+DOC_TYPES = {
+    'servicedefinitiondocument': 'serviceDefinitionDocumentURL',
+    'termsandconditions': 'termsAndConditionsDocumentURL',
+    'sfiaratecard': 'sfiaRateDocumentURL',
+    'pricingdocument': 'pricingDocumentURL'
+}
+
+
+def _normalise_service_name(name):
+    return name.lower().\
+        replace('-', '').\
+        replace('_', ''). \
+        replace(':', ''). \
+        replace(' ', '').\
+        replace('.pdf', '')
+
+
+def get_info_from_filename(filepath, client, framework_slug):
+    supplier_id, doc_type, draft_id = None, None, None
+
+    # Split out Supplier ID first - should be the prefix
+    supplier_id, service_name_and_doctype = filepath.split('-', maxsplit=1)
+    service_name = _normalise_service_name(service_name_and_doctype)
+
+    for dt in DOC_TYPES.keys():
+        if dt in service_name:
+            doc_type = dt
+
+    if doc_type is None:
+        # Can't continue
+        return int(supplier_id), None, None
+
+    service_name = service_name.replace(doc_type, '')
+    draft_id = find_draft_id_by_service_name(client, supplier_id, service_name, framework_slug)
+    if draft_id == 'multi':
+        print("Multiple drafts found for service name", service_name)
+        return int(supplier_id), doc_type, None
+    elif draft_id is None:
+        print("No draft found for service name", service_name)
+        return int(supplier_id), doc_type, None
+
+    return int(supplier_id), doc_type, draft_id
+
+
+def construct_upload_filename(draft_id, doc_type):
+    datestamp = default_file_suffix()
+    return f"{draft_id}-{doc_type}-{datestamp}.pdf"
+
+
+def upload_to_submissions_bucket(
+    document_name, bucket, bucket_category, framework_slug, supplier_id, file_path, dry_run, supplier_name_dict
+):
+    # Construct the upload path
+    upload_path = '{0}/{1}/{2}/{3}'.format(framework_slug, bucket_category, supplier_id, document_name)
+
+    # Download filename, if available
+    if supplier_name_dict is None:
+        download_filename = None
+    else:
+        supplier_name = supplier_name_dict[supplier_id]
+        download_filename = generate_download_filename(supplier_id, document_name, supplier_name)
+        print(download_filename)
+
+    # Do the actual upload
+    if not dry_run:
+        with open(file_path, 'rb') as source_file:
+            # TODO check if we need download_filename for submissions
+            bucket.save(upload_path, source_file, acl='bucket-owner-full-control', download_filename=download_filename)
+            print(f"Successfully uploaded {upload_path} to S3")
+
+    else:
+        print("[Dry-run] UPLOAD: '{}' to '{}'".format(file_path, upload_path))
+
+
+def update_draft_service_with_document_paths(full_document_url, doc_type, draft_id, api_client, dry_run):
+    draft_json = {
+        DOC_TYPES[doc_type]: full_document_url
+    }
+    if dry_run:
+        # Log something
+        print(f"[Dry-run] API: Would update draft ID {draft_id} with some JSON:")
+        print(draft_json)
+        return True
+
+    try:
+        api_client.update_draft_service(
+            draft_id,
+            draft_json,
+            'one off PDF upload script'
+        )
+        print(f"Draft ID {draft_id} updated.")
+        draft = api_client.get_draft_service(draft_id)
+        if draft['validationErrors']:
+            print(f"Validation errors:")
+            print(draft['validationErrors'])
+            return False
+        else:
+            print("Ready to be marked as complete.")
+            return True
+    except Exception as exc:
+        print(str(exc))
+    return False
+
+
+def output_results(unidentifiable_files, successful_draft_ids, failed_draft_ids):
+    # Output successful / failed draft IDs
+    if successful_draft_ids:
+        with open('successful-uploads-draft-ids.txt', 'w') as f:
+            for d in successful_draft_ids:
+                f.write(str(d) + '\n')
+
+    if failed_draft_ids:
+        with open('failed-uploads-draft-ids.txt', 'w') as f:
+            for d in failed_draft_ids:
+                f.write(str(d) + '\n')
+
+    if unidentifiable_files:
+        with open('unidentifiable-draft-service-files.txt', 'w') as f:
+            for d in unidentifiable_files:
+                f.write(str(d) + '\n')
+
+
+def upload_draft_service_pdfs_from_folder(
+    bucket, bucket_category, assets_path, local_directory, api_client, framework_slug, dry_run
+):
+    failed_draft_ids = []
+    successful_draft_ids = []
+    unidentifiable_files = []
+
+    # Parse files in folder (TODO: support ODF files)
+    for path in get_all_files_of_type(local_directory, 'pdf'):
+        # Check file is open document format or PDF
+        file_name = os.path.basename(path)
+        print(f"File name: {file_name}")
+        _, file_extension = os.path.splitext(file_name)
+        if file_extension not in [".pdf", ".odt", ".ods", ".odp"]:
+            print(f'Invalid file type {file_extension}, skipping')
+            unidentifiable_files.append(file_name)
+            continue
+
+        # Get IDs etc
+        supplier_id, doc_type, draft_id = get_info_from_filename(file_name, api_client, framework_slug)
+        if supplier_id is None:
+            print("Unable to determine Supplier ID")
+            unidentifiable_files.append(file_name)
+            continue
+        if doc_type is None:
+            print("Unable to determine doctype")
+            unidentifiable_files.append(file_name)
+            continue
+        if draft_id is None:
+            print("Unable to determine Draft ID")
+            unidentifiable_files.append(file_name)
+            continue
+        print(f"Found Supplier ID {supplier_id}, file type {doc_type} and Draft ID {draft_id}")
+
+        # Get supplier name, to add to S3 metadata (ie visible to buyers on download)
+        supplier = api_client.get_supplier(supplier_id)
+        supplier_name_dict = {supplier_id: supplier['suppliers']['name']}
+        new_filename = construct_upload_filename(draft_id, doc_type)
+
+        # Upload to S3
+        upload_to_submissions_bucket(
+            new_filename, bucket, bucket_category, framework_slug, supplier_id, path, dry_run, supplier_name_dict
+        )
+
+        # Try updating service data
+        full_url = urlparse.urljoin(
+            assets_path,
+            f"suppliers/assets/{framework_slug}/submissions/{supplier_id}/{new_filename}"
+        )
+        if update_draft_service_with_document_paths(full_url, doc_type, draft_id, api_client, dry_run):
+            successful_draft_ids.append(draft_id)
+        else:
+            failed_draft_ids.append(draft_id)
+
+    output_results(unidentifiable_files, successful_draft_ids, failed_draft_ids)
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    # Get script arguments
+    framework_slug = arguments['<framework>']
+    stage = arguments['<stage>'] or 'local'
+    dry_run = arguments['--dry-run'] or None
+
+    data_api_client = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(stage),
+        auth_token=get_auth_token('api', stage)
+    )
+    local_directory = arguments['--folder']
+
+    # Check framework status
+    framework = data_api_client.get_framework(framework_slug)
+    framework_status = framework['frameworks']['status']
+    if framework_status not in ['open']:
+        print(f"Cannot update services for framework {framework_slug} in status '{framework_status}'")
+        exit(1)
+
+    # Check folder exists
+    if local_directory and not os.path.exists(local_directory):
+        print(f"Local directory {local_directory} not found. Aborting upload.")
+        exit(1)
+
+    # Setup S3 stuff
+    bucket_category = "submissions"
+    bucket = None if dry_run else S3(get_bucket_name(stage, bucket_category))
+    try:
+        assets_path = get_assets_endpoint_from_stage(stage)
+    except NotImplementedError:
+        assets_path = "http://localhost"
+
+    upload_draft_service_pdfs_from_folder(
+        bucket,
+        bucket_category,
+        assets_path,
+        local_directory,
+        data_api_client,
+        framework_slug,
+        dry_run
+    )

--- a/tests/test_update_draft_service_via_csv.py
+++ b/tests/test_update_draft_service_via_csv.py
@@ -1,0 +1,306 @@
+import mock
+import pytest
+from dmapiclient import DataAPIClient
+from dmcontent.content_loader import ContentLoader
+from scripts.oneoff.update_draft_service_via_csv import (
+    find_draft_id_by_service_name,
+    get_price_data,
+    lookup_question_id_and_text,
+    parse_answer_from_csv_row,
+    update_draft_services_from_folder
+)
+
+
+class TestFindDraftIDByServiceName:
+
+    def test_find_draft_id_by_service_name_finds_draft_id(self):
+        client = mock.Mock(autospec=DataAPIClient)
+        client.find_draft_services_by_framework_iter.return_value = [
+            {'id': 998, 'serviceName': 'My Other Service Name'},
+            {'id': 999, 'serviceName': 'My Service Name'},
+        ]
+
+        assert find_draft_id_by_service_name(client, "12345", "myservicename", "g-cloud-12") == 999
+
+    def test_find_draft_id_by_service_name_raises_if_no_matching_service_name(self):
+        client = mock.Mock(autospec=DataAPIClient)
+        client.find_draft_services_by_framework_iter.return_value = [
+            {'id': 998, 'serviceName': 'My Other Service Name'},
+            {'id': 999, 'serviceName': 'My Rubbish Service Name'},
+        ]
+        assert find_draft_id_by_service_name(client, "12345", "myservicename", "g-cloud-12") is None
+
+    def test_find_draft_id_by_service_name_raises_if_multiple_matching_service_names(self):
+        client = mock.Mock(autospec=DataAPIClient)
+        client.find_draft_services_by_framework_iter.return_value = [
+            {'id': 998, 'serviceName': 'My Service Name'},
+            {'id': 999, 'serviceName': 'My Service Name'},
+        ]
+        assert find_draft_id_by_service_name(client, "12345", "myservicename", "g-cloud-12") == 'multi'
+
+
+class TestGetPriceData:
+
+    @pytest.mark.parametrize(
+        'answers, expected',
+        [
+            (
+                ["1", "3", 'per user', 'per day'],
+                {'priceMin': "1", 'priceMax': "3", 'priceUnit': 'User', 'priceInterval': 'Day'}
+            ),
+            (
+                ["1", 'per user'],
+                {'priceMin': "1", 'priceUnit': 'User'}
+            ),
+            (
+                ["1", 'per user', 'per day'],
+                {'priceMin': "1", 'priceUnit': 'User', 'priceInterval': 'Day'}
+            ),
+            (
+                ["1", "3", 'per user'],
+                {'priceMin': "1", 'priceMax': "3", 'priceUnit': 'User'}
+            ),
+            (
+                ["£1", "£3", 'per user'],
+                {'priceMin': "1", 'priceMax': "3", 'priceUnit': 'User'}
+            ),
+        ]
+    )
+    def test_get_price_data(self, answers, expected):
+        assert get_price_data(answers) == expected
+
+
+class TestLookupQuestionTextAndID:
+
+    def test_lookup_question_id_and_text(self):
+        row = {
+            'Question': 'Very Important Question'
+        }
+        questions = {
+            'Very Important Question': mock.Mock(id='veryImportantQuestion')
+        }
+        assert lookup_question_id_and_text(row, questions) == ('veryImportantQuestion', 'Very Important Question')
+
+    def test_lookup_question_id_and_text_handles_curly_apostrophes(self):
+        row = {
+            'Question': "It's A Very Important Question"
+        }
+        questions = {
+            "It’s A Very Important Question": mock.Mock(id='veryImportantQuestion')
+        }
+        assert lookup_question_id_and_text(row, questions) == (
+            'veryImportantQuestion', "It’s A Very Important Question"
+        )
+
+    def test_lookup_question_id_and_text_returns_null_if_not_found(self):
+        row = {
+            'Question': "Very Important Question"
+        }
+        questions = {
+            "A Different Question": mock.Mock(id='veryImportantQuestion')
+        }
+        assert lookup_question_id_and_text(row, questions) == (None, None)
+
+
+class TestParseAnswerFromCSVRow:
+
+    cloud_support_row = {
+        'Question': 'Very Important Question',
+        'Answer 1': '',
+        'Answer 2': '',
+        'Answer 3': '',
+        'Answer 4': '',
+        'Answer 5': '',
+        'Answer 6': '',
+        'Answer 7': '',
+        'Answer 8': '',
+        'Answer 9': '',
+        'Answer 10': '',
+    }
+
+    questions = {
+        'Which categories does your service fit under?': mock.Mock(),
+        'Pick a card any card': mock.Mock(
+            options=(
+                {'label': 'Option 1', 'value': 'option_1'},
+                {'label': 'Option 2', 'value': 'option_2'},
+            )
+        ),
+        'Tick at least two things': mock.Mock(type='checkboxes', options=None),
+        'List at least two things': mock.Mock(type='list', options=None),
+        'Enter your name': mock.Mock(options=None),
+        'How much does the service cost (excluding VAT)?': mock.Mock(options=None),
+    }
+
+    def _mock_question(self, type=None, options=None):
+        mock_question = mock.Mock()
+        mock_question.type = type if type else 'text'
+        mock_question.options = options if options else []
+
+    def test_parse_answer_from_csv_row_returns_none_for_blank_answer(self):
+        assert parse_answer_from_csv_row(
+            self.cloud_support_row, self.questions, 'Very Important Question', 'cloud-support'
+        ) is None
+
+    def test_parse_answer_from_csv_row_service_categories(self):
+        row = self.cloud_support_row.copy()
+        question_text = 'Which categories does your service fit under?'
+        row['Question'] = question_text
+        row['Answer 1'] = 'Bathtime'
+        row['Answer 2'] = 'Benidorm'
+        # Answer 3 column left blank
+        row['Answer 4'] = 'Bananas'
+
+        assert parse_answer_from_csv_row(row, self.questions, question_text, 'cloud-support') == [
+            'Bathtime', 'Benidorm', 'Bananas'
+        ]
+
+    def test_parse_answer_from_csv_option_labels(self):
+        row = self.cloud_support_row.copy()
+        question_text = 'Pick a card any card'
+        row['Question'] = question_text
+        row['Answer 1'] = 'Option 1'
+        row['Answer 2'] = 'Option 2'
+
+        assert parse_answer_from_csv_row(row, self.questions, question_text, 'cloud-support') == [
+            'option_1', 'option_2'
+        ]
+
+    def test_parse_answer_from_csv_list_question(self):
+        row = self.cloud_support_row.copy()
+        question_text = 'List at least two things'
+        row['Question'] = question_text
+        row['Answer 1'] = 'Thing 1'
+        row['Answer 2'] = 'Thing 2'
+
+        assert parse_answer_from_csv_row(row, self.questions, question_text, 'cloud-support') == [
+            'Thing 1', 'Thing 2'
+        ]
+
+    def test_parse_answer_from_csv_checkbox_question(self):
+        row = self.cloud_support_row.copy()
+        question_text = 'Tick at least two things'
+        row['Question'] = question_text
+        row['Answer 1'] = 'Thing 1'
+        row['Answer 2'] = 'Thing 2'
+
+        assert parse_answer_from_csv_row(row, self.questions, question_text, 'cloud-support') == [
+            'Thing 1', 'Thing 2'
+        ]
+
+    def test_parse_answer_from_csv_price_question(self):
+        row = self.cloud_support_row.copy()
+        question_text = 'How much does the service cost (excluding VAT)?'
+        row['Question'] = question_text
+        row['Answer 1'] = '£1'
+        row['Answer 2'] = 'per hour'
+
+        assert parse_answer_from_csv_row(row, self.questions, question_text, 'cloud-support') == {
+            'priceInterval': 'Hour', 'priceMin': '1'
+        }
+
+    def test_parse_answer_from_csv_single_answer(self):
+        row = self.cloud_support_row.copy()
+        question_text = 'Enter your name'
+        row['Answer 1'] = "Basil Brush"
+
+        assert parse_answer_from_csv_row(row, self.questions, question_text, 'cloud-support') == 'Basil Brush'
+
+
+@mock.patch('scripts.oneoff.update_draft_service_via_csv.create_draft_json_from_csv')
+@mock.patch('scripts.oneoff.update_draft_service_via_csv.get_question_objects')
+@mock.patch('scripts.oneoff.update_draft_service_via_csv.find_draft_id_by_service_name')
+@mock.patch('scripts.oneoff.update_draft_service_via_csv.output_results')
+@mock.patch('scripts.oneoff.update_draft_service_via_csv.get_all_files_of_type')
+class TestUpdateDraftServicesFromFolder:
+
+    def setup(self):
+        self.content_loader = mock.Mock(autospec=ContentLoader)
+        section = mock.Mock()
+        section.get_field_names.return_value = ['bananas']
+        self.content_loader.get_manifest.return_value.filter.return_value.sections = [section]
+
+    @pytest.mark.parametrize('dry_run', (True, False))
+    def test_update_draft_services_from_folder_successful(
+        self, get_all_files_of_type, output_results, find_draft_id_by_service_name, get_question_objects,
+        create_draft_json_from_csv, dry_run
+    ):
+        api_client = mock.Mock(autospec=DataAPIClient)
+        api_client.get_draft_service.return_value = {"validationErrors": {}}
+
+        get_all_files_of_type.return_value = [
+            '/path/to/555777-cloud-software-myservice.csv',
+        ]
+        find_draft_id_by_service_name.return_value = 12345
+        create_draft_json_from_csv.return_value = {}
+
+        update_draft_services_from_folder("~/local/folder", api_client, 'g-cloud-12', self.content_loader, dry_run)
+
+        assert output_results.call_args_list == [
+            # unidentifiable, malformed, successful, failed
+            mock.call([], [], [('555777', '555777-cloud-software-myservice.csv', 12345)], [])
+        ]
+        assert self.content_loader.load_manifest.call_args_list == [
+            mock.call('g-cloud-12', 'services', 'edit_submission')
+        ]
+
+    def test_update_draft_services_from_folder_failed(
+        self, get_all_files_of_type, output_results, find_draft_id_by_service_name, get_question_objects,
+        create_draft_json_from_csv
+    ):
+        api_client = mock.Mock(autospec=DataAPIClient)
+        api_client.get_draft_service.return_value = {"validationErrors": {"not": "good"}}
+        get_all_files_of_type.return_value = [
+            '/path/to/555777-cloud-software-myservice.csv',
+        ]
+        find_draft_id_by_service_name.return_value = 12345
+        create_draft_json_from_csv.return_value = {}
+
+        update_draft_services_from_folder("~/local/folder", api_client, 'g-cloud-12', self.content_loader, False)
+
+        assert output_results.call_args_list == [
+            # unidentifiable, malformed, successful, failed
+            mock.call([], [], [], [('555777', '555777-cloud-software-myservice.csv', 12345, {'not': 'good'})])
+        ]
+        assert self.content_loader.load_manifest.call_args_list == [
+            mock.call('g-cloud-12', 'services', 'edit_submission')
+        ]
+
+    @pytest.mark.parametrize('get_draft_response', (None, 'multi'))
+    def test_update_draft_services_from_folder_unidentifiable(
+        self, get_all_files_of_type, output_results, find_draft_id_by_service_name, get_question_objects,
+        create_draft_json_from_csv, get_draft_response
+    ):
+        api_client = mock.Mock(autospec=DataAPIClient)
+        content_loader = mock.Mock()
+        get_all_files_of_type.return_value = [
+            '/path/to/555777-cloud-software-myservice.csv',
+        ]
+        find_draft_id_by_service_name.return_value = get_draft_response
+
+        update_draft_services_from_folder("~/local/folder", api_client, 'g-cloud-12', content_loader, False)
+
+        assert output_results.call_args_list == [
+            # unidentifiable, malformed, successful, failed
+            mock.call(['555777-cloud-software-myservice.csv'], [], [], [])
+        ]
+
+    def test_update_draft_services_from_folder_malformed_csv(
+        self, get_all_files_of_type, output_results, find_draft_id_by_service_name, get_question_objects,
+        create_draft_json_from_csv
+    ):
+        api_client = mock.Mock(autospec=DataAPIClient)
+        api_client.get_draft_service.return_value = {"validationErrors": {}}
+        content_loader = mock.Mock()
+        get_all_files_of_type.return_value = [
+            '/path/to/555777-cloud-software-myservice.csv',
+        ]
+        find_draft_id_by_service_name.return_value = 12345
+        create_draft_json_from_csv.side_effect = UnicodeDecodeError("utf-8", b'bytesobject', 1, 2, "Yikes")
+
+        update_draft_services_from_folder("~/local/folder", api_client, 'g-cloud-12', content_loader, False)
+
+        assert output_results.call_args_list == [
+            # unidentifiable, malformed, successful, failed
+            mock.call([], [('555777', '555777-cloud-software-myservice.csv')], [], [])
+        ]

--- a/tests/test_upload_draft_service_pdfs.py
+++ b/tests/test_upload_draft_service_pdfs.py
@@ -1,0 +1,240 @@
+import mock
+import pytest
+import builtins
+from freezegun import freeze_time
+from dmapiclient import DataAPIClient
+from scripts.oneoff.upload_draft_service_pdfs import (
+    upload_to_submissions_bucket,
+    get_info_from_filename,
+    update_draft_service_with_document_paths,
+    upload_draft_service_pdfs_from_folder
+)
+
+
+class TestUploadToSubmissionsBucket:
+
+    @pytest.mark.parametrize('dry_run', (True, False))
+    def test_upload_to_submissions_bucket_uploads_if_not_dry_run(self, dry_run):
+        bucket = mock.Mock()
+        with mock.patch.object(builtins, 'open', mock.mock_open()) as mock_open:
+            upload_to_submissions_bucket(
+                "pricing.pdf", bucket, "submissions", "g-cloud-12", 12345, "/path/to/file", dry_run, None
+            )
+
+        assert bucket.save.called is False if dry_run else bucket.save.called_once_with(
+            "g-cloud-12/submissions/12345/pricing.pdf",
+            mock_open,
+            acl='bucket-owner-full-control',
+            download_filename=None
+        )
+
+    def test_upload_to_submissions_bucket_uploads_with_supplier_download_name(self):
+        bucket = mock.Mock()
+        with mock.patch.object(builtins, 'open', mock.mock_open()) as mock_open:
+            upload_to_submissions_bucket(
+                "pricing.pdf", bucket, "submissions", "g-cloud-12", 12345, "/path/to/file", False,
+                {12345: "ACME LTD"}
+            )
+
+        assert bucket.save.call_args_list == [
+            mock.call(
+                "g-cloud-12/submissions/12345/pricing.pdf",
+                mock_open.return_value,
+                acl='bucket-owner-full-control',
+                download_filename="ACME_LTD-12345-pricing.pdf"
+            )
+        ]
+
+
+class TestGetInfoFromFilename:
+
+    @pytest.mark.parametrize(
+        'matching_drafts, expected_result',
+        [
+            (555, 555),
+            (None, None),
+            ('multi', None)
+        ]
+    )
+    @mock.patch('scripts.oneoff.upload_draft_service_pdfs.find_draft_id_by_service_name')
+    def test_get_info_from_filename(self, find_draft_id_by_service_name, matching_drafts, expected_result):
+        find_draft_id_by_service_name.return_value = matching_drafts
+        api_client = mock.Mock(autospec=DataAPIClient)
+        assert get_info_from_filename('12345-myservice-pricing-document.pdf', api_client, "g-cloud-12") == (
+            12345, 'pricingdocument', expected_result
+        )
+
+    def test_get_info_from_filename_cant_identify_document_type(self):
+        api_client = mock.Mock()
+        assert get_info_from_filename('12345-myservice.pdf', api_client, "g-cloud-12") == (12345, None, None)
+
+
+class TestUpdateDraftServiceWithDocumentPaths:
+
+    def test_update_draft_service_with_document_paths_dry_run(self):
+        assert update_draft_service_with_document_paths(
+            "path/to/document", "pricingdocument", 12345, mock.Mock(), True
+        )
+
+    def test_update_draft_service_with_document_paths_valid_service(self):
+        client = mock.Mock(autospec=DataAPIClient)
+        client.get_draft_service.return_value = {'validationErrors': {}}
+
+        assert update_draft_service_with_document_paths(
+            "path/to/document", "pricingdocument", 12345, client, False
+        )
+        assert client.update_draft_service.call_args_list == [
+            mock.call(12345, {'pricingDocumentURL': 'path/to/document'}, 'one off PDF upload script')
+        ]
+        assert client.get_draft_service.call_args_list == [
+            mock.call(12345)
+        ]
+
+    def test_update_draft_service_with_document_paths_invalid_service(self):
+        client = mock.Mock(autospec=DataAPIClient)
+        client.get_draft_service.return_value = {'validationErrors': {'something': 'bad'}}
+
+        assert update_draft_service_with_document_paths(
+            "path/to/document", "pricingdocument", 12345, client, False
+        ) is False
+
+    def test_update_draft_service_with_document_paths_catches_exception_and_continues(self):
+        client = mock.Mock(autospec=DataAPIClient)
+        client.get_draft_service.side_effect = Exception('Boom')
+
+        assert update_draft_service_with_document_paths(
+            "path/to/document", "pricingdocument", 12345, client, False
+        ) is False
+
+
+@mock.patch('scripts.oneoff.upload_draft_service_pdfs.find_draft_id_by_service_name')
+@mock.patch('scripts.oneoff.upload_draft_service_pdfs.update_draft_service_with_document_paths')
+@mock.patch('scripts.oneoff.upload_draft_service_pdfs.upload_to_submissions_bucket')
+@mock.patch('scripts.oneoff.upload_draft_service_pdfs.output_results')
+@mock.patch('scripts.oneoff.upload_draft_service_pdfs.get_all_files_of_type')
+class TestUploadDraftPDFsFromFolder:
+
+    def setup(self):
+        self.bucket = mock.Mock()
+        self.client = mock.Mock(autospec=DataAPIClient)
+        self.client.get_supplier.return_value = {"suppliers": {"name": "ACME LTD"}}
+
+    @pytest.mark.parametrize('dry_run', (True, False))
+    def test_upload_draft_service_pdfs_from_folder_happy_path(
+        self, get_all_files_of_type, output_results, upload_to_submissions_bucket,
+        update_draft_service_with_document_paths, find_draft_id_by_service_name, dry_run
+    ):
+        get_all_files_of_type.return_value = [
+            '/path/to/555777-myservice-pricing-document.pdf',
+            '/path/to/555777-myservice-service-definition-document.pdf',
+            '/path/to/555777-myservice-terms-and-conditions.pdf',
+        ]
+        find_draft_id_by_service_name.return_value = 12345
+
+        with freeze_time('2020-01-01'):
+            upload_draft_service_pdfs_from_folder(
+                self.bucket, "submissions", "https://assets.example.com",
+                "~/local/folder", self.client, 'g-cloud-12', dry_run
+            )
+
+        assert get_all_files_of_type.call_args_list == [
+            mock.call("~/local/folder", "pdf")
+        ]
+        assert upload_to_submissions_bucket.call_args_list == [
+            mock.call(
+                '12345-pricingdocument-2020-01-01-0000.pdf',
+                self.bucket,
+                "submissions",
+                "g-cloud-12",
+                555777,
+                '/path/to/555777-myservice-pricing-document.pdf',
+                dry_run,
+                {555777: "ACME LTD"}
+            ),
+            mock.call(
+                '12345-servicedefinitiondocument-2020-01-01-0000.pdf',
+                self.bucket,
+                "submissions",
+                "g-cloud-12",
+                555777,
+                '/path/to/555777-myservice-service-definition-document.pdf',
+                dry_run,
+                {555777: "ACME LTD"}
+            ),
+            mock.call(
+                '12345-termsandconditions-2020-01-01-0000.pdf',
+                self.bucket,
+                "submissions",
+                "g-cloud-12",
+                555777,
+                '/path/to/555777-myservice-terms-and-conditions.pdf',
+                dry_run,
+                {555777: "ACME LTD"}
+            )
+        ]
+        assert update_draft_service_with_document_paths.call_args_list == [
+            mock.call(
+                "https://assets.example.com/suppliers/assets/g-cloud-12/submissions/"
+                "555777/12345-pricingdocument-2020-01-01-0000.pdf",
+                "pricingdocument", 12345, self.client, dry_run
+            ),
+            mock.call(
+                "https://assets.example.com/suppliers/assets/g-cloud-12/submissions/"
+                "555777/12345-servicedefinitiondocument-2020-01-01-0000.pdf",
+                "servicedefinitiondocument", 12345, self.client, dry_run
+            ),
+            mock.call(
+                "https://assets.example.com/suppliers/assets/g-cloud-12/submissions/"
+                "555777/12345-termsandconditions-2020-01-01-0000.pdf",
+                "termsandconditions", 12345, self.client, dry_run
+            )
+        ]
+        assert output_results.call_args_list == [
+            # unidentifiable, successful, failed
+            mock.call([], [12345, 12345, 12345], [])
+        ]
+
+    def test_upload_draft_service_pdfs_from_folder_unidentifiable_service(
+        self, get_all_files_of_type, output_results, upload_to_submissions_bucket,
+        update_draft_service_with_document_paths, find_draft_id_by_service_name
+    ):
+        get_all_files_of_type.return_value = [
+            '/path/to/555777-myservice-pricing-document.pdf',
+        ]
+        find_draft_id_by_service_name.return_value = None
+
+        with freeze_time('2020-01-01'):
+            upload_draft_service_pdfs_from_folder(
+                self.bucket, "submissions", "https://assets.example.com",
+                "~/local/folder", self.client, 'g-cloud-12', False
+            )
+
+        assert get_all_files_of_type.call_args_list == [
+            mock.call("~/local/folder", "pdf")
+        ]
+        assert upload_to_submissions_bucket.call_args_list == []
+        assert update_draft_service_with_document_paths.call_args_list == []
+        assert output_results.call_args_list == [
+            # unidentifiable, successful, failed
+            mock.call(['555777-myservice-pricing-document.pdf'], [], [])
+        ]
+
+    def test_upload_draft_service_pdfs_from_folder_invalid_service(
+        self, get_all_files_of_type, output_results, upload_to_submissions_bucket,
+        update_draft_service_with_document_paths, find_draft_id_by_service_name
+    ):
+        get_all_files_of_type.return_value = [
+            '/path/to/555777-myservice-pricing-document.pdf',
+        ]
+        find_draft_id_by_service_name.return_value = 12345
+        update_draft_service_with_document_paths.return_value = False
+
+        upload_draft_service_pdfs_from_folder(
+            self.bucket, "submissions", "https://assets.example.com",
+            "~/local/folder", self.client, 'g-cloud-12', False
+        )
+
+        assert output_results.call_args_list == [
+            # unidentifiable, successful, failed
+            mock.call([], [], [12345])
+        ]


### PR DESCRIPTION
This PR contains two experimental scripts that could provide an alternative way for users to submit G-Cloud services, for example if accessibility problems prevented them from using the usual submission journey.

1. Update existing draft services from a folder of CSV files

The CSV files require a specific naming structure: `<supplier_id>-<lot-slug>-<service-name>.csv`. Lot is required in order to retrieve the correct questions for the service.

The CSV file content also needs to match the format exported by [scripts/framework-applications/generate-questions-csv.py](https://github.com/alphagov/digitalmarketplace-scripts/blob/master/scripts/framework-applications/generate-questions-csv.py). The script also currently hardcodes the number of question columns per lot.

Some service questions will need manual tweaking in the frameworks repo to give a correct match (converting from a markup object to a string).

Pricing also needs special handling, which is normally done by the Supplier FE form input.

2. Update existing draft services from a folder of PDF documents

The PDF files require a specific naming structure: `<supplier_id>-<service-name>-<document-type>.pdf`. Document type (eg `pricing`) is required in order to update the correct field on the draft service with the path to the document.

Both scripts require a match on service name to find an existing draft service - some punctuation/spacing is removed to assist with this. Ambiguous matches are rejected.

Both scripts output the following reports: `unidentified-files` (could not match supplier or draft service), `successful` (successful update) and `failed` (failed validation). 

TODO:
- ~Refactor `parse_csv_and_update_draft_service` into testable function~
- ~Flesh out remaining tests~

Out of scope:
- creating new services (in follow up branch)
- marking services as complete
- DOS services
- updating declarations
- uploading Modern Slavery statement documents
- handling ODF files (in followup branch)
- PDF file size validation or typechecking with `fleep`
- Look at matching questions by id (eg `serviceBenefits`) rather than question text. Would require change to question export script. 
- using a proper logger instead of `print` everywhere 😹 