### PR TITLE
[Experimental] Create draft services via CSV

### DIFF
--- a/tests/test_update_draft_service_via_csv.py
+++ b/tests/test_update_draft_service_via_csv.py
@@ -234,11 +234,39 @@ class TestUpdateDraftServicesFromFolder:
         find_draft_id_by_service_name.return_value = 12345
         create_draft_json_from_csv.return_value = {}
 
-        update_draft_services_from_folder("~/local/folder", api_client, 'g-cloud-12', self.content_loader, dry_run)
+        update_draft_services_from_folder(
+            "~/local/folder", api_client, 'g-cloud-12', self.content_loader, dry_run, False
+        )
 
         assert output_results.call_args_list == [
             # unidentifiable, malformed, successful, failed
             mock.call([], [], [('555777', '555777-cloud-software-myservice.csv', 12345)], [])
+        ]
+        assert self.content_loader.load_manifest.call_args_list == [
+            mock.call('g-cloud-12', 'services', 'edit_submission')
+        ]
+
+    @pytest.mark.parametrize('dry_run', (True, False))
+    def test_update_draft_services_from_folder_create_new_service(
+        self, get_all_files_of_type, output_results, find_draft_id_by_service_name, get_question_objects,
+        create_draft_json_from_csv, dry_run
+    ):
+        api_client = mock.Mock(autospec=DataAPIClient)
+        api_client.create_new_draft_service.return_value = {"services": {"id": 999}}
+        api_client.get_draft_service.return_value = {"validationErrors": {}}
+
+        get_all_files_of_type.return_value = [
+            '/path/to/555777-cloud-software-myservice.csv',
+        ]
+        create_draft_json_from_csv.return_value = {}
+
+        update_draft_services_from_folder(
+            "~/local/folder", api_client, 'g-cloud-12', self.content_loader, dry_run, True
+        )
+
+        assert output_results.call_args_list == [
+            # unidentifiable, malformed, successful, failed
+            mock.call([], [], [('555777', '555777-cloud-software-myservice.csv', 999)], [])
         ]
         assert self.content_loader.load_manifest.call_args_list == [
             mock.call('g-cloud-12', 'services', 'edit_submission')
@@ -256,7 +284,9 @@ class TestUpdateDraftServicesFromFolder:
         find_draft_id_by_service_name.return_value = 12345
         create_draft_json_from_csv.return_value = {}
 
-        update_draft_services_from_folder("~/local/folder", api_client, 'g-cloud-12', self.content_loader, False)
+        update_draft_services_from_folder(
+            "~/local/folder", api_client, 'g-cloud-12', self.content_loader, False, False
+        )
 
         assert output_results.call_args_list == [
             # unidentifiable, malformed, successful, failed
@@ -278,7 +308,9 @@ class TestUpdateDraftServicesFromFolder:
         ]
         find_draft_id_by_service_name.return_value = get_draft_response
 
-        update_draft_services_from_folder("~/local/folder", api_client, 'g-cloud-12', content_loader, False)
+        update_draft_services_from_folder(
+            "~/local/folder", api_client, 'g-cloud-12', content_loader, False, False
+        )
 
         assert output_results.call_args_list == [
             # unidentifiable, malformed, successful, failed
@@ -298,7 +330,9 @@ class TestUpdateDraftServicesFromFolder:
         find_draft_id_by_service_name.return_value = 12345
         create_draft_json_from_csv.side_effect = UnicodeDecodeError("utf-8", b'bytesobject', 1, 2, "Yikes")
 
-        update_draft_services_from_folder("~/local/folder", api_client, 'g-cloud-12', content_loader, False)
+        update_draft_services_from_folder(
+            "~/local/folder", api_client, 'g-cloud-12', content_loader, False, False
+        )
 
         assert output_results.call_args_list == [
             # unidentifiable, malformed, successful, failed


### PR DESCRIPTION
Following on from https://github.com/alphagov/digitalmarketplace-scripts/pull/527, adjust the `update_draft_service_via_csv.py` script to allow new services to be created, given an optional flag `--create-draft`.

If this flag is present, the script will not attempt to look up an existing service to update, but create a new draft with the service name given in the filename. The script then parses the JSON and updates the service as before. 

I also did a small bit of tidying for the `output_service_categories_features_and_benefits_summary` function. This now only outputs the items that caused a problem.

This PR also adds support for ODF formats in `upload_draft_service_pdfs.py` (I decided not to change the script name for now, to avoid confusion!) The default mode is still `pdf`, but other formats can now be supplied with the `--file-format` argument.