### PR TITLE
Make the script to notify successful suppliers easier to understand

### DIFF
--- a/dmscripts/helpers/logging_helpers.py
+++ b/dmscripts/helpers/logging_helpers.py
@@ -24,7 +24,8 @@ def configure_logger(log_levels: Optional[Mapping] = None) -> Logger:
     :param log_levels: a dictionary of logger name and corresponding log
                        levels. Can be used to silence or add additional log
                        output from other packages. By default configures
-                       'script' and 'dmutils' loggers with INFO level.
+                       'script', 'dmapiclient' and 'dmutils' loggers with
+                       INFO level.
 
     :return: 'script' logger object
 

--- a/scripts/framework-applications/notify-successful-suppliers-for-framework.py
+++ b/scripts/framework-applications/notify-successful-suppliers-for-framework.py
@@ -41,7 +41,6 @@ from dmutils.email.helpers import hash_string
 from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers import logging_helpers
-from dmscripts.helpers.logging_helpers import logging
 from dmscripts.helpers.supplier_data_helpers import (
     SuccessfulSupplierContextForNotify,
     get_supplier_ids_from_args,
@@ -79,8 +78,9 @@ if __name__ == '__main__':
         "frameworkLiveAt_dateformat": "28 September 2020",
     }
 
-    for user_email, personalisation in context_data.items():
-        logger.info(f"{prefix}Sending email to supplier user '{hash_string(user_email)}'")
+    user_count = len(context_data)
+    for user_number, (user_email, personalisation) in enumerate(context_data.items(), start=1):
+        logger.info(f"{prefix}Sending email to supplier user {user_number} of {user_count} '{hash_string(user_email)}'")
 
         personalisation.update(extra_template_context)
 

--- a/scripts/framework-applications/notify-successful-suppliers-for-framework.py
+++ b/scripts/framework-applications/notify-successful-suppliers-for-framework.py
@@ -44,7 +44,7 @@ from dmscripts.helpers.supplier_data_helpers import (
 )
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
-logger = logging_helpers.configure_logger({"dmapiclient": logging.INFO})
+logger = logging_helpers.configure_logger()
 
 
 if __name__ == '__main__':

--- a/scripts/framework-applications/notify-successful-suppliers-for-framework.py
+++ b/scripts/framework-applications/notify-successful-suppliers-for-framework.py
@@ -6,6 +6,8 @@ their framework agreement.
 
 Uses the Notify API to inform suppliers of success result. This script *should not* resend emails.
 
+If possible, provide the supplier IDs. This is much faster than scanning all suppliers for eligibility.
+
 Usage:
     scripts/framework-applications/notify-successful-suppliers-for-framework.py [options]
          [--supplier-id=<id> ... | --supplier-ids-from=<file>]
@@ -14,11 +16,13 @@ Usage:
 Example:
     scripts/framework-applications/notify-successful-suppliers-for-framework.py preview g-cloud-11 api-key template-id
 
-Options:
+Parameters:
     <stage>                     Environment to run script against.
     <framework>                 Slug of framework to run script against.
     <notify_api_key>            API key for GOV.UK Notify.
+    <notify_template_id>        The ID of the Notify template
 
+Options:
     --supplier-id=<id>          ID(s) of supplier(s) to email.
     --supplier-ids-from=<file>  Path to file containing supplier ID(s), one per line.
 


### PR DESCRIPTION
We ran this earlier today, and noticed some possible improvements.

Fix the doc comment to include all the parameters and recommend providing the list of suppliers.

Also add in logs to the parts that take a while to give the person running the script an indication of progress.

I've manually tested that this gives the expected output when we run the script (with `--dry-run`, of course)