### PR TITLE
Take updated dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile requirements-dev.in
 #
-appnope==0.1.0            # via ipython
 attrs==19.3.0             # via -c requirements.txt, pytest
 backcall==0.1.0           # via ipython
 certifi==2019.11.28       # via -c requirements.txt, requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile requirements-dev.in
 #
+appnope==0.1.0            # via ipython
 attrs==19.3.0             # via -c requirements.txt, pytest
 backcall==0.1.0           # via ipython
 certifi==2019.11.28       # via -c requirements.txt, requests

--- a/requirements.in
+++ b/requirements.in
@@ -5,9 +5,9 @@ Flask==1.0.4
 itsdangerous==1.1.0
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.7.0#egg=digitalmarketplace-utils==52.7.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.6.0#egg=digitalmarketplace-apiclient==21.6.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.9.0#egg=digitalmarketplace-apiclient==21.9.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.21.0#egg=digitalmarketplace-content-loader==7.21.0
 
 awscli~=1.18.137
 backoff==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,9 @@ colorama==0.4.3           # via awscli
 contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.6.0#egg=digitalmarketplace-apiclient==21.6.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.7.0#egg=digitalmarketplace-utils==52.7.0  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.9.0#egg=digitalmarketplace-apiclient==21.9.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.21.0#egg=digitalmarketplace-content-loader==7.21.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via -r requirements.in, notifications-python-client
 docutils==0.15.2          # via awscli, botocore
 flask-gzip==0.2           # via digitalmarketplace-utils


### PR DESCRIPTION
Will allow us to make use of https://github.com/alphagov/digitalmarketplace-apiclient/pull/234/, and other recent changes.