### PR TITLE
Adapt countersigning job for e-signatures

### DIFF
--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -130,6 +130,9 @@ def _create_row(
         "pass_fail": _pass_fail_from_record(record),
         "countersigned_at": record["countersignedAt"],
         "countersigned_path": record["countersignedPath"],
+        "signer_name": record["signerName"],
+        "signer_role": record["signerRole"],
+        "signed_agreement_returned_at": record['signedAgreementReturnedAt']
     }
     row.update(
         (lot, sum(record["counts"][(lot, status)] for status in count_statuses))

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -151,7 +151,6 @@ def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
                             2: "4"}
 
             exit_code = subprocess.call(['wkhtmltopdf',
-                                         '--enable-local-file-access',
                                          '--footer-right',
                                          page_numbers.get(index, ""),
                                          '--margin-bottom',

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -133,7 +133,7 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework, templat
         yield html_dir, output_pages
 
 
-def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir, framework_slug):
+def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
     html_dir = Path(html_dir).resolve()
     pdf_dir = Path(pdf_dir).resolve()
 
@@ -143,9 +143,15 @@ def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir, framework_slug)
         os.mkdir(pdf_dir)
 
     if len(html_pages) > 1:
-        for html_path in html_pages:
+        for index, html_path in enumerate(html_pages):
             pdf_path = html_dir / (html_path.stem + ".pdf")
-            exit_code = subprocess.call(['wkhtmltopdf', 'file://{}'.format(html_path), pdf_path])
+            # Insert page number for dynamically generated pages
+            footer_page_number = str(index + 1) if index <= 3 else ""
+            exit_code = subprocess.call(['wkhtmltopdf',
+                                         '--footer-right',
+                                         footer_page_number,
+                                         'file://{}'.format(html_path),
+                                         pdf_path])
             if exit_code > 0:
                 logger.error("ERROR {} on {}".format(exit_code, html_path))
                 ok = False

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -147,8 +147,8 @@ def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
             pdf_path = html_dir / (html_path.stem + ".pdf")
             # Insert page number for dynamically generated pages
             page_numbers = {0: "1",
-                            2: "3",
-                            3: "4"}
+                            1: "3",
+                            2: "4"}
 
             exit_code = subprocess.call(['wkhtmltopdf',
                                          '--footer-right',

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -1,15 +1,17 @@
 import os
 import io
 import shutil
-import re
 import subprocess
+from pathlib import Path
 
 from datetime import datetime
+from PyPDF2 import PdfFileMerger
 
 from dmscripts.helpers.html_helpers import render_html
 from dmscripts.helpers.logging_helpers import get_logger
 from dmscripts.helpers.framework_helpers import (
-    find_suppliers_with_details_and_draft_service_counts
+    find_suppliers_with_details_and_draft_service_counts,
+    framework_supports_e_signature
 )
 from dmscripts.export_framework_applicant_details import get_csv_rows
 
@@ -51,6 +53,7 @@ def save_page(html, supplier_id, output_dir, descriptive_filename_part):
     page_path = os.path.join(output_dir, '{}-{}.html'.format(supplier_id, descriptive_filename_part))
     with io.open(page_path, 'w+', encoding='UTF-8') as htmlfile:
         htmlfile.write(html)
+    return page_path
 
 
 def render_html_for_successful_suppliers(rows, framework, template_dir, output_dir, dry_run=False):
@@ -78,9 +81,19 @@ def render_html_for_successful_suppliers(rows, framework, template_dir, output_d
 
 
 def render_html_for_suppliers_awaiting_countersignature(rows, framework, template_dir, output_dir):
-    template_path = os.path.join(template_dir, 'framework-agreement-signature-page.html')
-    template_css_path = os.path.join(template_dir, 'framework-agreement-signature-page.css')
-    template_countersignature_path = os.path.join(template_dir, 'framework-agreement-countersignature.png')
+    output_dir = Path(output_dir).resolve()
+    html_pages = [Path(template_dir, 'framework-agreement-signature-page.html').resolve()]
+    static_files = [Path(template_dir, 'framework-agreement-signature-page.css').resolve()]
+
+    if not framework_supports_e_signature(framework['slug']):
+        static_files.append(Path(template_dir, 'framework-agreement-countersignature.png'))
+
+    if framework_supports_e_signature(framework['slug']):
+        html_pages.append(Path(template_dir, 'framework-agreement-cover-page.html'))
+        static_files.append(Path(template_dir, 'ccs_logo.png'))
+        static_files.append(Path(template_dir, 'framework-agreement-toc.pdf'))
+        static_files.append(Path(template_dir, 'framework-agreement-boilerplate.pdf'))
+
     for data in rows:
         if data['pass_fail'] == 'fail' or data['countersigned_path'] or not data['countersigned_at']:
             logger.info("SKIPPING {}: pass_fail={} countersigned_at={} countersigned_path={}".format(
@@ -95,28 +108,65 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework, templat
         data['countersigned_at'] = datetime.strptime(
             data['countersigned_at'], '%Y-%m-%dT%H:%M:%S.%fZ'
         ).strftime('%d %B %Y')
+        if data['signed_agreement_returned_at']:
+            data['signed_agreement_returned_at'] = datetime.strptime(
+                data['signed_agreement_returned_at'], '%Y-%m-%dT%H:%M:%S.%fZ'
+            ).strftime('%d %B %Y')
         data['includeCountersignature'] = True
-        html = render_html(template_path, data)
-        save_page(html, data['supplier_id'], output_dir, "agreement-countersignature")
-    shutil.copyfile(template_css_path, os.path.join(output_dir, 'framework-agreement-signature-page.css'))
-    shutil.copyfile(
-        template_countersignature_path,
-        os.path.join(output_dir, 'framework-agreement-countersignature.png')
-    )
+
+        html_dir = output_dir / str(data['supplier_id'])
+        output_pages = []
+        for html_page in html_pages:
+            html = render_html(str(html_page), data)
+            page_path = save_page(html, data['supplier_id'], html_dir, html_page.stem)
+            output_pages.append(Path(page_path).resolve())
+
+        for static_file in static_files:
+            shutil.copyfile(static_file, Path(html_dir, static_file.name))
+
+        yield html_dir, output_pages
 
 
-def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
-    html_dir = os.path.abspath(html_dir)
-    pdf_dir = os.path.abspath(pdf_dir)
+def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir, framework_slug):
+    html_dir = Path(html_dir).resolve()
+    pdf_dir = Path(pdf_dir).resolve()
+
     ok = True
+
     if not os.path.exists(pdf_dir):
         os.mkdir(pdf_dir)
-    for index, html_page in enumerate(html_pages):
-        html_path = os.path.join(html_dir, html_page)
-        pdf_path = '{}'.format(re.sub(r'\.html$', '.pdf', html_path))
-        pdf_path = '{}'.format(re.sub(html_dir, pdf_dir, pdf_path))
+
+    if len(html_pages) > 1:
+        for html_path in html_pages:
+            pdf_path = html_dir / (html_path.stem + ".pdf")
+            exit_code = subprocess.call(['wkhtmltopdf', 'file://{}'.format(html_path), pdf_path])
+            if exit_code > 0:
+                logger.error("ERROR {} on {}".format(exit_code, html_path))
+                ok = False
+        merge_e_signature_docs(html_dir, pdf_dir)
+    else:
+        html_path = html_pages[0]
+        pdf_path = pdf_dir / (html_path.stem + ".pdf")
         exit_code = subprocess.call(['wkhtmltopdf', 'file://{}'.format(html_path), pdf_path])
         if exit_code > 0:
-            logger.error("ERROR {} on {}".format(exit_code, html_page))
+            logger.error("ERROR {} on {}".format(exit_code, html_path))
             ok = False
+
     return ok
+
+
+def merge_e_signature_docs(input_dir, output_dir):
+    supplier_id = input_dir.name
+    pdf_list = [
+        input_dir / f"{supplier_id}-framework-agreement-cover-page.pdf",
+        input_dir / "framework-agreement-toc.pdf",
+        input_dir / f"{supplier_id}-framework-agreement-signature-page.pdf",
+        input_dir / "framework-agreement-boilerplate.pdf",
+    ]
+
+    assert all(pdf.exists() for pdf in pdf_list)
+
+    pdf_file_merger = PdfFileMerger()
+    for index, filename in enumerate(pdf_list):
+        pdf_file_merger.merge(position=index, fileobj=str(filename.resolve()), import_bookmarks=False)
+    pdf_file_merger.write(f"{output_dir}/{supplier_id}-framework-agreement-signature-page.pdf")

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -85,7 +85,7 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework, templat
     html_pages = []
     static_files = []
 
-    if framework_supports_e_signature(framework['slug']):
+    if framework_supports_e_signature(framework):
         html_pages.append(Path(template_dir, 'framework-agreement-cover-page.html'))
         html_pages.append(Path(template_dir, 'framework-agreement-appointment-page-1.html'))
         html_pages.append(Path(template_dir, 'framework-agreement-appointment-page-2.html'))
@@ -151,6 +151,7 @@ def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
                             2: "4"}
 
             exit_code = subprocess.call(['wkhtmltopdf',
+                                         '--enable-local-file-access',
                                          '--footer-right',
                                          page_numbers.get(index, ""),
                                          '--margin-bottom',

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -128,7 +128,7 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework, templat
             output_pages.append(Path(page_path).resolve())
 
         for static_file in static_files:
-            shutil.copyfile(static_file, Path(html_dir, static_file.name))
+            Path(html_dir, static_file.name).symlink_to(static_file.resolve())
 
         yield html_dir, output_pages
 

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -146,10 +146,13 @@ def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
         for index, html_path in enumerate(html_pages):
             pdf_path = html_dir / (html_path.stem + ".pdf")
             # Insert page number for dynamically generated pages
-            footer_page_number = str(index + 1) if index <= 3 else ""
+            page_numbers = {0: "1",
+                            2: "3",
+                            3: "4"}
+
             exit_code = subprocess.call(['wkhtmltopdf',
                                          '--footer-right',
-                                         footer_page_number,
+                                         page_numbers.get(index, ""),
                                          'file://{}'.format(html_path),
                                          pdf_path])
             if exit_code > 0:

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -85,14 +85,14 @@ def render_html_for_suppliers_awaiting_countersignature(rows, framework, templat
     html_pages = [Path(template_dir, 'framework-agreement-signature-page.html').resolve()]
     static_files = [Path(template_dir, 'framework-agreement-signature-page.css').resolve()]
 
-    if not framework_supports_e_signature(framework['slug']):
-        static_files.append(Path(template_dir, 'framework-agreement-countersignature.png'))
-
     if framework_supports_e_signature(framework['slug']):
         html_pages.append(Path(template_dir, 'framework-agreement-cover-page.html'))
         static_files.append(Path(template_dir, 'ccs_logo.png'))
         static_files.append(Path(template_dir, 'framework-agreement-toc.pdf'))
         static_files.append(Path(template_dir, 'framework-agreement-boilerplate.pdf'))
+    else:
+        # Only non e-signature document includes countersignature graphic
+        static_files.append(Path(template_dir, 'framework-agreement-countersignature.png'))
 
     for data in rows:
         if data['pass_fail'] == 'fail' or data['countersigned_path'] or not data['countersigned_at']:

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -82,17 +82,23 @@ def render_html_for_successful_suppliers(rows, framework, template_dir, output_d
 
 def render_html_for_suppliers_awaiting_countersignature(rows, framework, template_dir, output_dir):
     output_dir = Path(output_dir).resolve()
-    html_pages = [Path(template_dir, 'framework-agreement-signature-page.html').resolve()]
-    static_files = [Path(template_dir, 'framework-agreement-signature-page.css').resolve()]
+    html_pages = []
+    static_files = []
 
     if framework_supports_e_signature(framework['slug']):
         html_pages.append(Path(template_dir, 'framework-agreement-cover-page.html'))
+        html_pages.append(Path(template_dir, 'framework-agreement-appointment-page-1.html'))
+        html_pages.append(Path(template_dir, 'framework-agreement-appointment-page-2.html'))
         static_files.append(Path(template_dir, 'ccs_logo.png'))
+        static_files.append(Path(template_dir, 'framework-agreement-appointment-page.css'))
+        static_files.append(Path(template_dir, 'framework-agreement-cover-page.css'))
         static_files.append(Path(template_dir, 'framework-agreement-toc.pdf'))
         static_files.append(Path(template_dir, 'framework-agreement-boilerplate.pdf'))
     else:
         # Only non e-signature document includes countersignature graphic
+        html_pages.append(Path(template_dir, 'framework-agreement-signature-page.html'))
         static_files.append(Path(template_dir, 'framework-agreement-countersignature.png'))
+        static_files.append(Path(template_dir, 'framework-agreement-signature-page.css'))
 
     for data in rows:
         if data['pass_fail'] == 'fail' or data['countersigned_path'] or not data['countersigned_at']:
@@ -160,7 +166,8 @@ def merge_e_signature_docs(input_dir, output_dir):
     pdf_list = [
         input_dir / f"{supplier_id}-framework-agreement-cover-page.pdf",
         input_dir / "framework-agreement-toc.pdf",
-        input_dir / f"{supplier_id}-framework-agreement-signature-page.pdf",
+        input_dir / f"{supplier_id}-framework-agreement-appointment-page-1.pdf",
+        input_dir / f"{supplier_id}-framework-agreement-appointment-page-2.pdf",
         input_dir / "framework-agreement-boilerplate.pdf",
     ]
 

--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -153,6 +153,10 @@ def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
             exit_code = subprocess.call(['wkhtmltopdf',
                                          '--footer-right',
                                          page_numbers.get(index, ""),
+                                         '--margin-bottom',
+                                         '20mm',
+                                         '--margin-right',
+                                         '20mm',
                                          'file://{}'.format(html_path),
                                          pdf_path])
             if exit_code > 0:

--- a/dmscripts/helpers/framework_helpers.py
+++ b/dmscripts/helpers/framework_helpers.py
@@ -5,7 +5,9 @@ from functools import partial
 import logging
 import re
 
+from datetime import datetime
 from dmapiclient import DataAPIClient, HTTPError
+from dmutils.formats import DATETIME_FORMAT
 
 logger = logging.getLogger("framework_helpers")
 
@@ -45,15 +47,15 @@ def find_suppliers_with_details_and_draft_services(
     return records
 
 
-def framework_supports_e_signature(framework_slug):
+def framework_supports_e_signature(framework):
     """
     This is a hacky way to determine if a framework supports e-signature,
     which will be frameworks from G-Cloud-12 onwards
     # TODO: Do more robust check
-    :param framework_slug:
+    :param framework: framework object
     :return: Boolean
     """
-    return framework_slug in ['g-cloud-12']
+    return datetime.strptime(framework['frameworkLiveAtUTC'], DATETIME_FORMAT) > datetime(2020, 9, 28)
 
 
 def find_suppliers_with_details_and_draft_service_counts(

--- a/dmscripts/helpers/framework_helpers.py
+++ b/dmscripts/helpers/framework_helpers.py
@@ -45,6 +45,17 @@ def find_suppliers_with_details_and_draft_services(
     return records
 
 
+def framework_supports_e_signature(framework_slug):
+    """
+    This is a hacky way to determine if a framework supports e-signature,
+    which will be frameworks from G-Cloud-12 onwards
+    # TODO: Do more robust check
+    :param framework_slug:
+    :return: Boolean
+    """
+    return framework_slug in ['g-cloud-12']
+
+
 def find_suppliers_with_details_and_draft_service_counts(
     client,
     framework_slug,
@@ -55,6 +66,7 @@ def find_suppliers_with_details_and_draft_service_counts(
     length = len(records)
     records = map_impl(partial(add_supplier_info, client), records)
     records = map_impl(partial(add_framework_info, client, framework_slug), records)
+    records = map_impl(partial(add_agreement_info, client), records)
     records = map_impl(partial(add_draft_counts, client, framework_slug), records)
     records = map_watch(
         records,
@@ -86,6 +98,17 @@ def add_framework_info(client, framework_slug, record):
                 declaration=supplier_framework['declaration'] or {},
                 countersignedPath=supplier_framework['countersignedPath'] or "",
                 countersignedAt=supplier_framework['countersignedAt'] or "",
+                agreementId=supplier_framework['agreementId'] or ""
+                )
+
+
+def add_agreement_info(client, record):
+    framework_agreement_id = record['agreementId']
+    framework_agreement = client.get_framework_agreement(framework_agreement_id)
+    return dict(record,
+                signerName=framework_agreement['agreement']['signedAgreementDetails']['signerName'] or "",
+                signerRole=framework_agreement['agreement']['signedAgreementDetails']['signerRole'] or "",
+                signedAgreementReturnedAt=framework_agreement['agreement']['signedAgreementReturnedAt'] or ""
                 )
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -14,6 +14,7 @@ backoff==1.10.0
 docopt==0.6.2
 jsonschema==3.2.0
 lorem==0.1.1
+pypdf2==1.26.0
 python-dateutil==2.8.1
 unicodecsv==0.14.1
 xeger==0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ prometheus-client==0.2.0  # via gds-metrics
 pyasn1==0.4.8             # via rsa
 pycparser==2.19           # via cffi
 pyjwt==1.7.1              # via notifications-python-client
+pypdf2==1.26.0            # via -r requirements.in
 pyrsistent==0.15.7        # via jsonschema
 python-dateutil==2.8.1    # via -r requirements.in, botocore
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8  # via -r requirements.in, digitalmarketplace-utils

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -119,8 +119,7 @@ if __name__ == '__main__':
 
     ok = True
     for html_dir, html_pages in html_to_render:
-        ok &= render_pdf_for_each_html_page(html_pages, html_dir, args['<output_folder>'],
-                                            framework_slug=framework['slug']) and ok
+        ok &= render_pdf_for_each_html_page(html_pages, html_dir, args['<output_folder>']) and ok
 
     if ok:
         shutil.rmtree(html_dir)

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -70,6 +70,7 @@ from dmscripts.generate_framework_agreement_signature_pages import (
 from dmapiclient import DataAPIClient
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
+# CCS Sourcing Admin user using developer team email
 AUTOMATED_COUNTERSIGNING_USER_ID = 64041
 
 if __name__ == '__main__':

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -50,7 +50,6 @@ Options:
     -h, --help                  Show this screen
     -v, --verbose               Log verbosely
 """
-
 import os
 import shutil
 import sys
@@ -61,7 +60,8 @@ sys.path.insert(0, '.')
 from docopt import docopt
 from dmscripts.export_framework_applicant_details import get_csv_rows
 from dmscripts.helpers.auth_helpers import get_auth_token
-from dmscripts.helpers.framework_helpers import find_suppliers_with_details_and_draft_service_counts
+from dmscripts.helpers.framework_helpers import find_suppliers_with_details_and_draft_service_counts, \
+    framework_supports_e_signature
 from dmscripts.helpers.logging_helpers import configure_logger
 from dmscripts.helpers.supplier_data_helpers import get_supplier_ids_from_args
 from dmscripts.generate_framework_agreement_signature_pages import (
@@ -69,6 +69,8 @@ from dmscripts.generate_framework_agreement_signature_pages import (
 )
 from dmapiclient import DataAPIClient
 from dmutils.env_helpers import get_api_endpoint_from_stage
+
+AUTOMATED_COUNTERSIGNING_USER_ID = 64041
 
 if __name__ == '__main__':
     args = docopt(__doc__)
@@ -95,17 +97,30 @@ if __name__ == '__main__':
     html_dir = tempfile.mkdtemp()
 
     records = find_suppliers_with_details_and_draft_service_counts(client, framework_slug, supplier_ids)
+    records = list(records)
+    for record in records:
+        if framework_supports_e_signature(record['frameworkSlug']) and \
+                (client.get_framework_agreement(record['agreementId'])
+                 ['agreement']['status'] == 'signed'):
+            # E-signatures are automatically approved.
+            client.approve_agreement_for_countersignature(record['agreementId'],
+                                                          "automated countersignature script",
+                                                          AUTOMATED_COUNTERSIGNING_USER_ID)
+
     headers, rows = get_csv_rows(
         records, framework_slug, framework_lot_slugs, count_statuses=("submitted",),
         include_central_supplier_details=True
     )
-    render_html_for_suppliers_awaiting_countersignature(
+
+    html_to_render = render_html_for_suppliers_awaiting_countersignature(
         rows, framework, os.path.join(args['<path_to_agreements_repo>'], 'documents', framework['slug']), html_dir
     )
-    html_pages = os.listdir(html_dir)
-    html_pages.remove('framework-agreement-signature-page.css')
-    html_pages.remove('framework-agreement-countersignature.png')
-    ok = render_pdf_for_each_html_page(html_pages, html_dir, args['<output_folder>'])
+
+    ok = True
+    for html_dir, html_pages in html_to_render:
+        ok = render_pdf_for_each_html_page(html_pages, html_dir, args['<output_folder>'],
+                                           framework_slug=framework['slug']) and ok
+
     if ok:
         shutil.rmtree(html_dir)
     if not ok:

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -100,9 +100,8 @@ if __name__ == '__main__':
     records = find_suppliers_with_details_and_draft_service_counts(client, framework_slug, supplier_ids)
     records = list(records)
     for record in records:
-        if framework_supports_e_signature(framework) and \
-                (client.get_framework_agreement(record['agreementId'])
-                 ['agreement']['status'] == 'signed'):
+        if (framework_supports_e_signature(framework) and
+                client.get_framework_agreement(record['agreementId'])['agreement']['status'] == 'signed'):
             # E-signatures are automatically approved.
             client.approve_agreement_for_countersignature(record['agreementId'],
                                                           "automated countersignature script",

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
     records = find_suppliers_with_details_and_draft_service_counts(client, framework_slug, supplier_ids)
     records = list(records)
     for record in records:
-        if framework_supports_e_signature(record['frameworkSlug']) and \
+        if framework_supports_e_signature(framework) and \
                 (client.get_framework_agreement(record['agreementId'])
                  ['agreement']['status'] == 'signed'):
             # E-signatures are automatically approved.

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -118,8 +118,8 @@ if __name__ == '__main__':
 
     ok = True
     for html_dir, html_pages in html_to_render:
-        ok = render_pdf_for_each_html_page(html_pages, html_dir, args['<output_folder>'],
-                                           framework_slug=framework['slug']) and ok
+        ok &= render_pdf_for_each_html_page(html_pages, html_dir, args['<output_folder>'],
+                                            framework_slug=framework['slug']) and ok
 
     if ok:
         shutil.rmtree(html_dir)

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -118,7 +118,7 @@ if __name__ == '__main__':
 
     ok = True
     for html_dir, html_pages in html_to_render:
-        ok &= render_pdf_for_each_html_page(html_pages, html_dir, args['<output_folder>']) and ok
+        ok &= render_pdf_for_each_html_page(html_pages, html_dir, args['<output_folder>'])
 
     if ok:
         shutil.rmtree(html_dir)

--- a/tests/assessment_helpers.py
+++ b/tests/assessment_helpers.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from mock import Mock, MagicMock
 
 
 class BaseAssessmentTest(object):
@@ -73,6 +73,7 @@ class BaseAssessmentTest(object):
                 v,
                 supplierId=k,
                 frameworkSlug=self.framework_slug,
+                agreementId="",
                 countersignedPath="",
                 countersignedAt="",
                 declaration=dict(
@@ -312,6 +313,7 @@ class BaseAssessmentTest(object):
         self.mock_suppliers = self._get_suppliers()
 
         self.mock_data_client = Mock()
+        self.mock_data_client.get_framework_agreement.return_value = MagicMock()
         self.mock_data_client.get_supplier_framework_info.side_effect = self._mock_get_supplier_framework_info_impl
         self.mock_data_client.get_interested_suppliers.side_effect = self._mock_get_interested_suppliers_impl
         self.mock_data_client.find_draft_services_by_framework_iter.side_effect = \

--- a/tests/helpers/test_framework_helpers.py
+++ b/tests/helpers/test_framework_helpers.py
@@ -1,7 +1,6 @@
 import pytest
 from collections import Counter
 from mock import Mock, call
-
 from dmapiclient import HTTPError
 import dmscripts.helpers.framework_helpers as framework_helpers
 
@@ -48,6 +47,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
     mock_data_client.get_supplier_framework_info.side_effect = lambda *args: {
         (4, 'framework-slug'): {
             'frameworkInterest': {
+                'agreementId': None,
                 'declaration': {'status': 'complete'},
                 'onFramework': True,
                 'frameworkSlug': 'g-things-1',
@@ -57,6 +57,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
         },
         (3, 'framework-slug'): {
             'frameworkInterest': {
+                'agreementId': None,
                 'declaration': {'status': 'started'},
                 'onFramework': False,
                 'frameworkSlug': 'g-things-1',
@@ -66,6 +67,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
         },
         (2, 'framework-slug'): {
             'frameworkInterest': {
+                'agreementId': None,
                 'declaration': {'status': 'complete'},
                 'onFramework': True,
                 'frameworkSlug': 'g-things-1',
@@ -112,6 +114,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
                 'countersignedAt': '',
                 'onFramework': True,
                 'frameworkSlug': 'g-things-1',
+                'agreementId': ""
             },
             {
                 'supplier': 'supplier 3',
@@ -131,6 +134,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
                 'countersignedAt': '',
                 'onFramework': False,
                 'frameworkSlug': 'g-things-1',
+                'agreementId': ""
             },
             {
                 'supplier': 'supplier 2',
@@ -150,11 +154,22 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
                 'countersignedAt': '2017-01-02T03:04:05.000006Z',
                 'onFramework': True,
                 'frameworkSlug': 'g-things-1',
+                'agreementId': ""
             }
         ]
 
 
 def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
+    mock_data_client.get_framework_agreement.return_value = {'agreement': {'frameworkSlug': 'g-cloud-12',
+                                                                           'id': 31385,
+                                                                           'signedAgreementDetails': {
+                                                                               'signerName': 'gideon',
+                                                                               'signerRole': 'developer',
+                                                                               'uploaderUserId': 10357},
+                                                                           'signedAgreementReturnedAt':
+                                                                               '2020-09-15T15:52:15.677327Z',
+                                                                           'status': 'signed',
+                                                                           'supplierId': 92237}}
     mock_data_client.get_interested_suppliers.return_value = {
         'interestedSuppliers': [4, 3, 2]
     }
@@ -168,6 +183,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
                 'onFramework': True,
                 'countersignedPath': None,
                 'countersignedAt': None,
+                'agreementId': None
             }
         },
         (3, 'framework-slug'): {
@@ -177,6 +193,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
                 'onFramework': False,
                 'countersignedPath': None,
                 'countersignedAt': None,
+                'agreementId': None
             }
         },
         (2, 'framework-slug'): {
@@ -186,6 +203,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
                 'onFramework': True,
                 'countersignedPath': 'some/path',
                 'countersignedAt': '2017-01-02T03:04:05.000006Z',
+                'agreementId': None
             }
         },
     }[args]
@@ -219,7 +237,11 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
             ),
             'countersignedAt': '',
             'onFramework': True,
+            'signedAgreementReturnedAt': '2020-09-15T15:52:15.677327Z',
+            'signerName': 'gideon',
+            'signerRole': 'developer',
             'frameworkSlug': 'g-things-1',
+            'agreementId': ''
         },
         {
             'supplier': {'id': 3, 'name': 'supplier 3'},
@@ -236,7 +258,11 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
             ),
             'countersignedAt': '',
             'onFramework': False,
+            'signedAgreementReturnedAt': '2020-09-15T15:52:15.677327Z',
+            'signerName': 'gideon',
+            'signerRole': 'developer',
             'frameworkSlug': 'g-things-1',
+            'agreementId': ''
         },
         {
             'supplier': {'id': 2, 'name': 'supplier 2'},
@@ -253,7 +279,11 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
             ),
             'countersignedAt': '2017-01-02T03:04:05.000006Z',
             'onFramework': True,
+            'signedAgreementReturnedAt': '2020-09-15T15:52:15.677327Z',
+            'signerName': 'gideon',
+            'signerRole': 'developer',
             'frameworkSlug': 'g-things-1',
+            'agreementId': ''
         }
     ]
 
@@ -303,6 +333,7 @@ def test_add_framework_info(mock_data_client, on_framework):
             'onFramework': on_framework,
             'countersignedPath': None,
             'countersignedAt': None,
+            'agreementId': None
         }
     }
 
@@ -319,6 +350,7 @@ def test_add_framework_info(mock_data_client, on_framework):
         },
         'countersignedPath': '',
         'countersignedAt': '',
+        'agreementId': ''
     }
 
 

--- a/tests/helpers/test_framework_helpers.py
+++ b/tests/helpers/test_framework_helpers.py
@@ -47,7 +47,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
     mock_data_client.get_supplier_framework_info.side_effect = lambda *args: {
         (4, 'framework-slug'): {
             'frameworkInterest': {
-                'agreementId': None,
+                'agreementId': 31385,
                 'declaration': {'status': 'complete'},
                 'onFramework': True,
                 'frameworkSlug': 'g-things-1',
@@ -57,7 +57,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
         },
         (3, 'framework-slug'): {
             'frameworkInterest': {
-                'agreementId': None,
+                'agreementId': 31385,
                 'declaration': {'status': 'started'},
                 'onFramework': False,
                 'frameworkSlug': 'g-things-1',
@@ -67,7 +67,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
         },
         (2, 'framework-slug'): {
             'frameworkInterest': {
-                'agreementId': None,
+                'agreementId': 31385,
                 'declaration': {'status': 'complete'},
                 'onFramework': True,
                 'frameworkSlug': 'g-things-1',
@@ -114,7 +114,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
                 'countersignedAt': '',
                 'onFramework': True,
                 'frameworkSlug': 'g-things-1',
-                'agreementId': ""
+                'agreementId': 31385
             },
             {
                 'supplier': 'supplier 3',
@@ -134,7 +134,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
                 'countersignedAt': '',
                 'onFramework': False,
                 'frameworkSlug': 'g-things-1',
-                'agreementId': ""
+                'agreementId': 31385
             },
             {
                 'supplier': 'supplier 2',
@@ -154,7 +154,7 @@ def test_find_suppliers_with_details_and_draft_services(mock_data_client):
                 'countersignedAt': '2017-01-02T03:04:05.000006Z',
                 'onFramework': True,
                 'frameworkSlug': 'g-things-1',
-                'agreementId': ""
+                'agreementId': 31385
             }
         ]
 

--- a/tests/helpers/test_framework_helpers.py
+++ b/tests/helpers/test_framework_helpers.py
@@ -183,7 +183,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
                 'onFramework': True,
                 'countersignedPath': None,
                 'countersignedAt': None,
-                'agreementId': None
+                'agreementId': 31385
             }
         },
         (3, 'framework-slug'): {
@@ -193,7 +193,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
                 'onFramework': False,
                 'countersignedPath': None,
                 'countersignedAt': None,
-                'agreementId': None
+                'agreementId': 31385
             }
         },
         (2, 'framework-slug'): {
@@ -203,7 +203,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
                 'onFramework': True,
                 'countersignedPath': 'some/path',
                 'countersignedAt': '2017-01-02T03:04:05.000006Z',
-                'agreementId': None
+                'agreementId': 31385
             }
         },
     }[args]
@@ -241,7 +241,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
             'signerName': 'gideon',
             'signerRole': 'developer',
             'frameworkSlug': 'g-things-1',
-            'agreementId': ''
+            'agreementId': 31385
         },
         {
             'supplier': {'id': 3, 'name': 'supplier 3'},
@@ -262,7 +262,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
             'signerName': 'gideon',
             'signerRole': 'developer',
             'frameworkSlug': 'g-things-1',
-            'agreementId': ''
+            'agreementId': 31385
         },
         {
             'supplier': {'id': 2, 'name': 'supplier 2'},
@@ -283,7 +283,7 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
             'signerName': 'gideon',
             'signerRole': 'developer',
             'frameworkSlug': 'g-things-1',
-            'agreementId': ''
+            'agreementId': 31385
         }
     ]
 
@@ -333,7 +333,7 @@ def test_add_framework_info(mock_data_client, on_framework):
             'onFramework': on_framework,
             'countersignedPath': None,
             'countersignedAt': None,
-            'agreementId': None
+            'agreementId': 31385
         }
     }
 
@@ -350,7 +350,7 @@ def test_add_framework_info(mock_data_client, on_framework):
         },
         'countersignedPath': '',
         'countersignedAt': '',
-        'agreementId': ''
+        'agreementId': 31385
     }
 
 

--- a/tests/test_export_framework_applicant_details.py
+++ b/tests/test_export_framework_applicant_details.py
@@ -6,6 +6,9 @@ from dmscripts.export_framework_applicant_details import export_supplier_details
 
 def test_get_csv_rows_returns_headers_and_rows():
     example_record = {
+        "signerName": "",
+        "signerRole": "",
+        "signedAgreementReturnedAt": "",
         "declaration": {"status": "complete"},
         "supplier": {
             "id": 12345,
@@ -59,6 +62,9 @@ def test_get_csv_rows_returns_headers_and_rows():
         'pass_fail': 'pass',
         'primaryContact': '',
         'primaryContactEmail': '',
+        'signed_agreement_returned_at': '',
+        'signer_name': '',
+        'signer_role': '',
         'subcontracting': '',
         'supplierCompanyRegistrationNumber': '',
         'supplierDunsNumber': '',


### PR DESCRIPTION
https://trello.com/c/UfmJ2EOd/308-adapt-countersigning-jenkins-job-for-e-signature-flow

This makes a number of changes to the script to support e-signature counterpart documents

* Script is responsible for automatically approving the agreement using the API (This would have been done previously in admin-frontend)
* Adapt script to handle multiple documents to facilitate generation of a complete contract PDF

Co-authored-by: Laurence de Bruxelles <laurence.debruxelles@digital.cabinet-office.gov.uk>

Note, this is dependent on sister PR https://github.com/alphagov/digitalmarketplace-agreements/pull/10