### PR TITLE
filter out e-signature suppliers without an agreementID

### DIFF
--- a/dmscripts/export_framework_applicant_details.py
+++ b/dmscripts/export_framework_applicant_details.py
@@ -130,9 +130,9 @@ def _create_row(
         "pass_fail": _pass_fail_from_record(record),
         "countersigned_at": record["countersignedAt"],
         "countersigned_path": record["countersignedPath"],
-        "signer_name": record["signerName"],
-        "signer_role": record["signerRole"],
-        "signed_agreement_returned_at": record['signedAgreementReturnedAt']
+        "signer_name": record.get("signerName", ""),
+        "signer_role": record.get("signerRole", ""),
+        "signed_agreement_returned_at": record.get("signedAgreementReturnedAt", ""),
     }
     row.update(
         (lot, sum(record["counts"][(lot, status)] for status in count_statuses))

--- a/tests/helpers/test_framework_helpers.py
+++ b/tests/helpers/test_framework_helpers.py
@@ -237,9 +237,6 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
             ),
             'countersignedAt': '',
             'onFramework': True,
-            'signedAgreementReturnedAt': '2020-09-15T15:52:15.677327Z',
-            'signerName': 'gideon',
-            'signerRole': 'developer',
             'frameworkSlug': 'g-things-1',
             'agreementId': 31385
         },
@@ -258,9 +255,6 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
             ),
             'countersignedAt': '',
             'onFramework': False,
-            'signedAgreementReturnedAt': '2020-09-15T15:52:15.677327Z',
-            'signerName': 'gideon',
-            'signerRole': 'developer',
             'frameworkSlug': 'g-things-1',
             'agreementId': 31385
         },
@@ -279,9 +273,6 @@ def test_find_suppliers_with_details_and_draft_service_counts(mock_data_client):
             ),
             'countersignedAt': '2017-01-02T03:04:05.000006Z',
             'onFramework': True,
-            'signedAgreementReturnedAt': '2020-09-15T15:52:15.677327Z',
-            'signerName': 'gideon',
-            'signerRole': 'developer',
             'frameworkSlug': 'g-things-1',
             'agreementId': 31385
         }


### PR DESCRIPTION
In the case where a supplier had not signed the agreement and was on an e-signature framework we were erroneously looking up their agreement which would then 404 and cause an exception on the API client. This filters out suppliers without an agreement ID so that subsequent steps are not run for thm.

Co-authored-by: Laurence de Bruxelles <laurence.debruxelles@digital.cabinet-office.gov.uk>