### PR TITLE
add enable local file access flag

### DIFF
--- a/dmscripts/generate_framework_agreement_signature_pages.py
+++ b/dmscripts/generate_framework_agreement_signature_pages.py
@@ -151,6 +151,7 @@ def render_pdf_for_each_html_page(html_pages, html_dir, pdf_dir):
                             2: "4"}
 
             exit_code = subprocess.call(['wkhtmltopdf',
+                                         '--enable-local-file-access',
                                          '--footer-right',
                                          page_numbers.get(index, ""),
                                          '--margin-bottom',


### PR DESCRIPTION
This flag is required in 0.12.6 of `wkhtmltopdf` to enable access to external resources (linked static files) For more context see: https://stackoverflow.com/questions/62315246/wkhtmltopdf-0-12-6-warning-blocked-access-to-file/62315247#62315247