### PR TITLE
only log message if service ids

### DIFF
--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -374,9 +374,10 @@ def unsuspend_suspended_supplier_services(record, suspending_user, client, logge
     )
     service_ids = suspended_services_on_framework & services_suspended_by_script
     # Unsuspend all services for supplier (the API will re-index the services for search results)
-    logger.info(
-        f"Setting {len(service_ids)} services to '{new_service_status}' for supplier {supplier_id}."
-    )
+    if service_ids:
+        logger.info(
+            f"Setting {len(service_ids)} services to '{new_service_status}' for supplier {supplier_id}."
+        )
     for service_id in service_ids:
         if dry_run:
             logger.info(f"[DRY RUN] Would unsuspend service {service_id} for supplier {supplier_id}")

--- a/scripts/generate-framework-agreement-counterpart-signature-pages.py
+++ b/scripts/generate-framework-agreement-counterpart-signature-pages.py
@@ -125,6 +125,11 @@ if __name__ == '__main__':
                 if dry_run:
                     logger.info(f"DRY-RUN would countersign agreement {agreement_id} for supplier {supplier_id}")
                     record["countersignedAt"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    unsuspend_suspended_supplier_services(record,
+                                                          AUTOMATED_SUSPENDING_USER,
+                                                          client,
+                                                          logger,
+                                                          dry_run)
                 else:
                     logger.info(f"countersigning agreement {agreement_id} for supplier {supplier_id}")
                     try:

--- a/tests/helpers/test_supplier_data_helpers.py
+++ b/tests/helpers/test_supplier_data_helpers.py
@@ -354,7 +354,7 @@ class TestUnsuspendSuspendedSupplierServices:
                  call.update_service_status('1', 'published', 'Unsuspend services helper')]
         data_api_client.assert_has_calls(calls, any_order=True)
 
-    def test_dry_run_does_not_supplier_services(self, record, logger, data_api_client):
+    def test_dry_run_does_not_update_supplier_services(self, record, logger, data_api_client):
         data_api_client.find_services.return_value = {'meta': {'total': 2}, 'services': [
             {'id': '1'}, {'id': '2'}
         ]}


### PR DESCRIPTION
Minor followup to https://github.com/alphagov/digitalmarketplace-scripts/pull/562
I noticed from the Jenkins logs we are needlessly duplicate logging when there are no services to suspend e.g.
```
2020-10-03 03:16:53,431 script INFO Supplier 705880 has no disabled services on the framework.
2020-10-03 03:16:53,536 script INFO Setting 0 services to 'published' for supplier 705880.
2020-10-03 03:19:43,451 script INFO countersigning agreement 36250 for supplier 707725
```