### PR TITLE
Fix logging for framework application stats snapshot script

### DIFF
--- a/scripts/framework-applications/snapshot-framework-stats.py
+++ b/scripts/framework-applications/snapshot-framework-stats.py
@@ -13,7 +13,6 @@ Example:
 
 from docopt import docopt
 import json
-import logging
 import sys
 import datetime
 
@@ -22,11 +21,11 @@ from dmapiclient.audit import AuditTypes
 
 sys.path.insert(0, '.')
 from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.logging_helpers import configure_logger
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
 
-logger = logging.getLogger('script')
-logging.basicConfig(level=logging.INFO)
+logger = configure_logger()
 
 
 def log_human_readable_stats(stats):


### PR DESCRIPTION
I noticed that when this script runs we get unformatted log messages such as

    INFO:dmapiclient.base:API {api_method} request on {api_url} finished in {api_time}

See https://ci.marketplace.team/view/Framework%20lifecycle%20jobs/job/hourly-stats-snapshot-digital-outcomes-and-specialists-5-production/27/console for an example of this.

I think this is because we are using the `logging` module directly rather than the dmscripts logging configuration. This commit changes the script to use `dmscripts.helpers.logging.configure_logger`.