### PR TITLE
Remove DOS4 questions from DOS5 drafts

### DIFF
--- a/scripts/oneoff/remove-dos4-questions-from-dos5-drafts.py
+++ b/scripts/oneoff/remove-dos4-questions-from-dos5-drafts.py
@@ -50,7 +50,7 @@ def draft_service_contains_dos4_answer(draft: dict) -> bool:
         "designerAccessibleApplications"
     }
 
-    return invalid_answers.intersection(draft)
+    return bool(invalid_answers.intersection(draft))
 
 
 def remove_dos4_answers(api_client: DataAPIClient, draft: dict, developer_email: str) -> dict:

--- a/scripts/oneoff/remove-dos4-questions-from-dos5-drafts.py
+++ b/scripts/oneoff/remove-dos4-questions-from-dos5-drafts.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+
+sys.path.insert(0, '.')
+from dmapiclient import DataAPIClient
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmutils.env_helpers import get_api_endpoint_from_stage
+
+from typing import List
+
+
+def get_affected_drafts_services(api_client: DataAPIClient) -> List[dict]:
+    all_drafts = api_client.find_draft_services_by_framework('digital-outcomes-and-specialists-5')["services"]
+
+    return [draft for draft in all_drafts if draft_service_contains_dos4_answer(draft)]
+
+
+def draft_service_contains_dos4_answer(draft: dict) -> bool:
+    invalid_answers = {
+        "agileCoachPriceMin",
+        "businessAnalystPriceMin",
+        "communicationsManagerPriceMin",
+        "contentDesignerPriceMin",
+        "dataArchitectPriceMin",
+        "dataEngineerPriceMin",
+        "dataScientistPriceMin",
+        "deliveryManagerPriceMin",
+        "designerPriceMin",
+        "developerPriceMin",
+        "performanceAnalystPriceMin",
+        "portfolioManagerPriceMin",
+        "productManagerPriceMin",
+        "programmeManagerPriceMin",
+        "qualityAssurancePriceMin",
+        "securityConsultantPriceMin",
+        "serviceManagerPriceMin",
+        "technicalArchitectPriceMin",
+        "userResearcherPriceMin",
+        "webOperationsPriceMin",
+        "developerAccessibleApplications",
+        "contentDesignerAccessibleApplications",
+        "qualityAssuranceAccessibleApplications",
+        "technicalArchitectAccessibleApplications",
+        "webOperationsAccessibleApplications",
+        "serviceManagerAccessibleApplications",
+        "designerAccessibleApplications"
+    }
+
+    return len(invalid_answers.union(set(draft["services"].keys()))) > 0
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("stage", type=str)
+
+    args = parser.parse_args()
+
+    data = DataAPIClient(
+        get_api_endpoint_from_stage(args.stage),
+        get_auth_token('api', args.stage)
+    )
+
+    affected_drafts = get_affected_drafts_services(data)
+    print(affected_drafts)

--- a/scripts/oneoff/remove-dos4-questions-from-dos5-drafts.py
+++ b/scripts/oneoff/remove-dos4-questions-from-dos5-drafts.py
@@ -48,13 +48,50 @@ def draft_service_contains_dos4_answer(draft: dict) -> bool:
         "designerAccessibleApplications"
     }
 
-    return len(invalid_answers.union(set(draft["services"].keys()))) > 0
+    return len(invalid_answers.union(set(draft.keys()))) > 0 and draft['status'] == 'not-submitted'
+
+
+def remove_dos4_answers(api_client: DataAPIClient, draft: dict, developer_email: str) -> dict:
+    return api_client.update_draft_service(
+        draft['id'],
+        {
+            "agileCoachPriceMin": None,
+            "businessAnalystPriceMin": None,
+            "communicationsManagerPriceMin": None,
+            "contentDesignerPriceMin": None,
+            "dataArchitectPriceMin": None,
+            "dataEngineerPriceMin": None,
+            "dataScientistPriceMin": None,
+            "deliveryManagerPriceMin": None,
+            "designerPriceMin": None,
+            "developerPriceMin": None,
+            "performanceAnalystPriceMin": None,
+            "portfolioManagerPriceMin": None,
+            "productManagerPriceMin": None,
+            "programmeManagerPriceMin": None,
+            "qualityAssurancePriceMin": None,
+            "securityConsultantPriceMin": None,
+            "serviceManagerPriceMin": None,
+            "technicalArchitectPriceMin": None,
+            "userResearcherPriceMin": None,
+            "webOperationsPriceMin": None,
+            "developerAccessibleApplications": None,
+            "contentDesignerAccessibleApplications": None,
+            "qualityAssuranceAccessibleApplications": None,
+            "technicalArchitectAccessibleApplications": None,
+            "webOperationsAccessibleApplications": None,
+            "serviceManagerAccessibleApplications": None,
+            "designerAccessibleApplications": None
+        },
+        developer_email
+    )
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     parser.add_argument("stage", type=str)
+    parser.add_argument("developer_email", type=str)
 
     args = parser.parse_args()
 
@@ -62,6 +99,12 @@ if __name__ == '__main__':
         get_api_endpoint_from_stage(args.stage),
         get_auth_token('api', args.stage)
     )
-
-    affected_drafts = get_affected_drafts_services(data)
-    print(affected_drafts)
+    
+    updated_drafts = [
+        remove_dos4_answers(data, draft, args.developer_email) for draft
+        in get_affected_drafts_services(data)
+    ]
+    
+    for draft in updated_drafts:
+        print(f"Supplier id: {draft['supplierId']}")
+        print(f"Draft id: {draft['id']}")

--- a/scripts/oneoff/remove-dos4-questions-from-dos5-drafts.py
+++ b/scripts/oneoff/remove-dos4-questions-from-dos5-drafts.py
@@ -99,12 +99,12 @@ if __name__ == '__main__':
         get_api_endpoint_from_stage(args.stage),
         get_auth_token('api', args.stage)
     )
-    
+
     updated_drafts = [
         remove_dos4_answers(data, draft, args.developer_email) for draft
         in get_affected_drafts_services(data)
     ]
-    
+
     for draft in updated_drafts:
         print(f"Supplier id: {draft['supplierId']}")
         print(f"Draft id: {draft['id']}")


### PR DESCRIPTION
Script to update services from this ticket

https://trello.com/c/lNqAe34j/68-fix-dos-5-draft-services-with-improperly-copied-dos-4-answers

Some questions were removed from DOS5 but not flagged to not be copied from a DOS4 service. Affected draft services would always fail validation because they had answers to questions which don't exist.

This script finds affected draft services and deletes the answers to the removed questions.