### PR TITLE
Fill in user for API client shell

### DIFF
--- a/dmscripts/helpers/updated_by_helpers.py
+++ b/dmscripts/helpers/updated_by_helpers.py
@@ -1,0 +1,37 @@
+import getpass
+import os
+import subprocess
+
+
+def get_user() -> str:
+    """Find the name of the user running the script for audit purposes
+
+    Digital Marketplace API methods typically take a `user` or `updated_by`
+    parameter that is used to record who or what made a particular change. This
+    function uses a number of heuristics to generate this automatically, to
+    save the script caller having to do it themselves.
+    """
+
+    # if the script is running on Jenkins use the build vars
+    if os.getenv("JENKINS_HOME") and os.getenv("BUILD_TAG"):
+        updated_by = os.environ["BUILD_TAG"]
+        if os.getenv("BUILD_USER"):
+            updated_by += " started by "
+            updated_by += os.environ["BUILD_USER"]
+        return updated_by
+
+    # if possible get the email address from git config
+    try:
+        proc = subprocess.run(
+            ["git", "config", "--get", "user.email"],
+            stdout=subprocess.PIPE, universal_newlines=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    else:
+        git_user_email = proc.stdout.strip()
+        return git_user_email
+
+    # fallback to username, in general this is less preferred
+    return getpass.getuser()

--- a/dmscripts/helpers/updated_by_helpers.py
+++ b/dmscripts/helpers/updated_by_helpers.py
@@ -16,8 +16,7 @@ def get_user() -> str:
     if os.getenv("JENKINS_HOME") and os.getenv("BUILD_TAG"):
         updated_by = os.environ["BUILD_TAG"]
         if os.getenv("BUILD_USER"):
-            updated_by += " started by "
-            updated_by += os.environ["BUILD_USER"]
+            updated_by += f' started by {os.environ["BUILD_USER"]}'
         return updated_by
 
     # if possible get the email address from git config

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ itsdangerous==1.1.0
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.9.0#egg=digitalmarketplace-apiclient==21.9.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.10.0#egg=digitalmarketplace-apiclient==21.10.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.21.0#egg=digitalmarketplace-content-loader==7.21.0
 
 awscli~=1.18.137

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ colorama==0.4.3           # via awscli
 contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.9.0#egg=digitalmarketplace-apiclient==21.9.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.10.0#egg=digitalmarketplace-apiclient==21.10.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.21.0#egg=digitalmarketplace-content-loader==7.21.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via -r requirements.in, notifications-python-client

--- a/scripts/api-clients-shell.py
+++ b/scripts/api-clients-shell.py
@@ -30,6 +30,7 @@ from dmapiclient import DataAPIClient, SearchAPIClient
 
 sys.path.insert(0, '.')
 from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.updated_by_helpers import get_user
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
 
@@ -108,18 +109,23 @@ if __name__ == '__main__':
 
     stage = args.stage.lower()
 
+    user = get_user()
+    print(f"Setting user to '{user}'...")
+
     print('Retrieving credentials...')
     api_token = args.api_token or get_auth_token('api', stage)
     search_api_token = args.search_api_token or get_auth_token('search_api', stage)
 
     print('Creating clients...')
     data = DataAPIClient(
-        args.api_url or get_api_endpoint_from_stage(stage),
-        api_token
+        base_url=args.api_url or get_api_endpoint_from_stage(stage),
+        auth_token=api_token,
+        user=user,
     )
     search = SearchAPIClient(
-        args.search_api_url or get_api_endpoint_from_stage(stage, app='search-api'),
-        search_api_token
+        base_url=args.search_api_url or get_api_endpoint_from_stage(stage, app='search-api'),
+        auth_token=search_api_token,
+        user=user,
     )
 
     if args.read_only:

--- a/tests/helpers/test_updated_by_helpers.py
+++ b/tests/helpers/test_updated_by_helpers.py
@@ -1,0 +1,49 @@
+from unittest import mock
+
+import pytest
+
+from dmscripts.helpers.updated_by_helpers import get_user
+
+
+@pytest.fixture(autouse=True)
+def environ():
+    with mock.patch.dict("os.environ", {}, clear=True):
+        import os
+        yield os.environ
+
+
+@pytest.fixture
+def subprocess_run():
+    with mock.patch("dmscripts.helpers.updated_by_helpers.subprocess.run") as run:
+        yield run
+
+
+def test_get_user_can_use_jenkins_envvars(environ):
+    environ["JENKINS_HOME"] = "/var/lib/jenkins"
+    environ["BUILD_TAG"] = "jenkins-Do a thing-100"
+    environ["BUILD_USER"] = "Reginald Jeeves"
+
+    assert get_user() == "jenkins-Do a thing-100 started by Reginald Jeeves"
+
+    # BUILD_USER relies on a plugin that needs to be enabled for each job, so
+    # we should check get_user() works even if BUILD_USER isn't present for
+    # some reason
+    del environ["BUILD_USER"]
+
+    assert get_user() == "jenkins-Do a thing-100"
+
+
+def test_get_user_can_use_git_user_email(subprocess_run):
+    proc = mock.Mock()
+    proc.return_code = 0
+    proc.stdout = "user.name@example.com"
+    subprocess_run.return_value = proc
+
+    assert get_user() == "user.name@example.com"
+
+
+def test_get_user_fallsback_to_username_if_git_not_installed(environ, subprocess_run):
+    environ["USERNAME"] = "cheeseshop"
+    subprocess_run.side_effect = FileNotFoundError
+
+    assert get_user() == "cheeseshop"


### PR DESCRIPTION
Trello: https://trello.com/c/rACMNlvs/13-can-we-automatically-fill-in-your-email-when-using-the-api-client

Most of the API calls that modify state take a `user` or `updated_by` parameter for audit purposes. Filling in one's email can get rather tedious when using the API client shell.

Create a helper to work out who the user is using some heuristics. Use this to provide the `user` for the API client shell. Should save us a bit of typing and tedium.

Makes use of https://github.com/alphagov/digitalmarketplace-apiclient/pull/235/.