### PR TITLE
Add timezone to timestamp logging format

### DIFF
--- a/dmscripts/helpers/logging_helpers.py
+++ b/dmscripts/helpers/logging_helpers.py
@@ -8,6 +8,7 @@ from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL, getLogger, Logger  # 
 from dmutils.logging import CustomLogFormatter
 
 LOG_FORMAT = '%(asctime)s %(name)s %(levelname)s %(message)s'
+TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S,uuu %Z'
 
 
 def get_logger() -> Logger:
@@ -33,7 +34,7 @@ def configure_logger(log_levels: Optional[Mapping] = None) -> Logger:
     log_levels = merge_log_levels(log_levels or {})
 
     handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(CustomLogFormatter(LOG_FORMAT))
+    handler.setFormatter(CustomLogFormatter(LOG_FORMAT, datefmt=TIMESTAMP_FORMAT))
 
     for logger_name, level in log_levels.items():
         logging.getLogger(logger_name).addHandler(handler)


### PR DESCRIPTION
Add the timezone identifier to timestamps when logging from scripts. This will make it easier to consolidate logs across multiple events or scripts.

Closes ticket https://trello.com/c/wRGIKhhf/1091-05-add-timezone-identifier-to-timestamps-in-logging-format-of-scripts
