### PR TITLE
Get all drafts before filtering

### DIFF
--- a/scripts/oneoff/remove-dos4-questions-from-dos5-drafts.py
+++ b/scripts/oneoff/remove-dos4-questions-from-dos5-drafts.py
@@ -12,9 +12,9 @@ from typing import List
 
 
 def get_affected_drafts_services(api_client: DataAPIClient) -> List[dict]:
-    all_drafts = api_client.find_draft_services_by_framework(
+    all_drafts = api_client.find_draft_services_by_framework_iter(
         'digital-outcomes-and-specialists-5', status='not-submitted'
-    )["services"]
+    )
 
     return [draft for draft in all_drafts if draft_service_contains_dos4_answer(draft)]
 


### PR DESCRIPTION
Trello: https://trello.com/c/n5p5CgRz/1983-ccsrequests-re-problem-with-dos5-application-on-digital-marketplace

`find_draft_services_by_framework` produces paged output, so we were missing lots of affected draft services. Instead use the `iter` variant which allows us to search all drafts.

This should let us fix the 122 affected drafts we'd previously missed.