### PR TITLE
Change notify scripts to fail fast if there is a template error

### DIFF
--- a/dmscripts/notify_buyers_to_award_closed_briefs.py
+++ b/dmscripts/notify_buyers_to_award_closed_briefs.py
@@ -2,7 +2,7 @@
 from datetime import datetime, date, timedelta
 
 import dmapiclient
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmutils.formats import DATE_FORMAT
 
 from dmscripts.helpers import logging_helpers, brief_data_helpers
@@ -72,6 +72,8 @@ def send_email_to_brief_user_via_notify(notify_client, notify_template_id, user,
                 notify_client.send_email(
                     user['emailAddress'], notify_template_id, email_context_data, allow_resend=False
                 )
+        except EmailTemplateError:
+            raise  # do not try to continue
         except EmailError:
             return user['id']
 

--- a/dmscripts/notify_buyers_when_requirements_close.py
+++ b/dmscripts/notify_buyers_when_requirements_close.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 import dmapiclient
 from dmutils.email.dm_notify import DMNotifyClient
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmutils.env_helpers import get_web_url_from_stage
 from dmutils.formats import DATE_FORMAT
 
@@ -48,6 +48,9 @@ def notify_users(email_api_key, stage, brief):
                 "Email failed to send for brief_id: {brief_id}",
                 extra={'error': e, 'brief_id': brief['id']}
             )
+
+            if isinstance(e, EmailTemplateError):
+                raise  # do not try to continue
 
             return False
 

--- a/dmscripts/notify_suppliers_of_awarded_briefs.py
+++ b/dmscripts/notify_suppliers_of_awarded_briefs.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, date
 
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmutils.email.helpers import get_email_addresses, hash_string, validate_email_address
 from dmutils.formats import DATE_FORMAT
 from dmutils.env_helpers import get_web_url_from_stage
@@ -98,7 +98,7 @@ def _build_and_send_emails(brief_responses, mail_client, stage, dry_run, templat
                         'email_address': hash_string(email_address),
                     }
                 )
-            except EmailError:
+            except EmailError as e:
                 # Log individual failures in more detail
                 logger.error(
                     "Email sending failed for BriefResponse {brief_response_id} (Brief ID {brief_id})",
@@ -107,6 +107,10 @@ def _build_and_send_emails(brief_responses, mail_client, stage, dry_run, templat
                         "brief_response_id": brief_response['id']
                     }
                 )
+
+                if isinstance(e, EmailTemplateError):
+                    raise  # do not try to continue
+
                 failed_brief_responses.append(brief_response['id'])
 
     return failed_brief_responses

--- a/dmscripts/notify_suppliers_of_framework_application_event.py
+++ b/dmscripts/notify_suppliers_of_framework_application_event.py
@@ -8,7 +8,7 @@ from warnings import warn
 from dmapiclient import DataAPIClient
 
 from dmutils.email import DMNotifyClient
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmutils.email.helpers import hash_string
 from dmutils.env_helpers import get_web_url_from_stage
 from dmutils import formats
@@ -123,5 +123,8 @@ def notify_suppliers_of_framework_application_event(
                                 "e": str(e),
                             },
                         )
+
+                        if isinstance(e, EmailTemplateError):
+                            raise  # do not try to continue
 
     return failure_count

--- a/dmscripts/notify_suppliers_of_new_questions_answers.py
+++ b/dmscripts/notify_suppliers_of_new_questions_answers.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from dmscripts.helpers import logging_helpers
 from dmscripts.helpers.logging_helpers import logging
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmutils.email.dm_notify import DMNotifyClient
 from dmutils.formats import DATETIME_FORMAT
 from dmutils.env_helpers import get_web_url_from_stage
@@ -171,6 +171,8 @@ def main(data_api_url, data_api_token, email_api_key, stage, dry_run, supplier_i
             )
             try:
                 send_supplier_emails(email_api_key, email_addresses, supplier_context, logger)
+            except EmailTemplateError:
+                raise  # do not try to continue
             except EmailError:
                 failed_supplier_ids.append(supplier_id)
 

--- a/dmscripts/notify_suppliers_whether_application_made_for_framework.py
+++ b/dmscripts/notify_suppliers_whether_application_made_for_framework.py
@@ -1,4 +1,4 @@
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmutils.email.helpers import hash_string
 from dmscripts.helpers.supplier_data_helpers import AppliedToFrameworkSupplierContextForNotify
 
@@ -35,6 +35,10 @@ def notify_suppliers_whether_application_made(
                 mail_client.send_email(user_email, template, personalisation, allow_resend=False)
             except EmailError as e:
                 logger.error(f"Error sending email to supplier '{supplier_id}' user '{hash_string(user_email)}': {e}")
+
+                if isinstance(e, EmailTemplateError):
+                    raise  # do not try to continue
+
                 error_count += 1
 
     return error_count

--- a/dmscripts/notify_suppliers_with_incomplete_applications.py
+++ b/dmscripts/notify_suppliers_with_incomplete_applications.py
@@ -1,5 +1,5 @@
 from dmscripts.helpers.email_helpers import scripts_notify_client
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmutils.email.helpers import hash_string
 from dmutils.formats import utctoshorttimelongdateformat
 
@@ -39,6 +39,10 @@ def send_notification(mail_client, message, framework, email, supplier_id, dry_r
                 f"Error sending email to supplier '{supplier_id}' "
                 f"user '{hash_string(email)}': {e}"
             )
+
+            if isinstance(e, EmailTemplateError):
+                raise  # do not try to continue
+
             return 1
     return 0
 

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ Flask==1.0.4
 itsdangerous==1.1.0
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8
-git+https://github.com/alphagov/digitalmarketplace-utils.git@54.1.1#egg=digitalmarketplace-utils==54.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@55.2.1#egg=digitalmarketplace-utils==55.2.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.10.0#egg=digitalmarketplace-apiclient==21.10.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.21.0#egg=digitalmarketplace-content-loader==7.21.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ backoff==1.10.0           # via -r requirements.in
 blinker==1.4              # via gds-metrics
 boto3==1.14.34            # via digitalmarketplace-utils
 botocore==1.17.60         # via awscli, boto3, s3transfer
+cachelib==0.1.1           # via flask-session
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
@@ -21,13 +22,14 @@ cryptography==3.2.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.10.0#egg=digitalmarketplace-apiclient==21.10.0  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.21.0#egg=digitalmarketplace-content-loader==7.21.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@54.1.1#egg=digitalmarketplace-utils==54.1.1  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-utils.git@55.2.1#egg=digitalmarketplace-utils==55.2.1  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via -r requirements.in, notifications-python-client
 docutils==0.15.2          # via awscli, botocore
 flask-gzip==0.2           # via digitalmarketplace-utils
 flask-login==0.5.0        # via digitalmarketplace-utils
+flask-session==0.3.2      # via digitalmarketplace-utils
 flask-wtf==0.14.3         # via digitalmarketplace-utils
-flask==1.0.4              # via -r requirements.in, digitalmarketplace-content-loader, digitalmarketplace-utils, flask-gzip, flask-login, flask-wtf, gds-metrics
+flask==1.0.4              # via -r requirements.in, digitalmarketplace-content-loader, digitalmarketplace-utils, flask-gzip, flask-login, flask-session, flask-wtf, gds-metrics
 fleep==1.0.1              # via digitalmarketplace-utils
 future==0.18.2            # via notifications-python-client
 gds-metrics==0.2.0        # via digitalmarketplace-utils
@@ -56,6 +58,7 @@ python-dateutil==2.8.1    # via -r requirements.in, botocore
 git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8  # via -r requirements.in, digitalmarketplace-utils
 pytz==2019.3              # via digitalmarketplace-utils
 pyyaml==5.3.1             # via awscli, digitalmarketplace-content-loader, yq
+redis==3.5.3              # via digitalmarketplace-utils
 requests==2.23.0          # via digitalmarketplace-apiclient, digitalmarketplace-utils, mailchimp3, notifications-python-client
 rsa==4.5                  # via awscli
 s3transfer==0.3.3         # via awscli, boto3

--- a/scripts/framework-applications/notify-successful-suppliers-for-framework.py
+++ b/scripts/framework-applications/notify-successful-suppliers-for-framework.py
@@ -36,7 +36,7 @@ sys.path.insert(0, '.')
 from docopt import docopt
 
 from dmapiclient import DataAPIClient
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmutils.email.helpers import hash_string
 from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmscripts.helpers.auth_helpers import get_auth_token
@@ -91,3 +91,6 @@ if __name__ == '__main__':
             mail_client.send_email(user_email, GOVUK_NOTIFY_TEMPLATE_ID, personalisation, allow_resend=False)
         except EmailError as e:
             logger.error(f"Error sending email to supplier user '{hash_string(user_email)}': {e}")
+
+            if isinstance(e, EmailTemplateError):
+                raise  # do not try to continue

--- a/tests/test_notify_buyers_to_award_closed_briefs.py
+++ b/tests/test_notify_buyers_to_award_closed_briefs.py
@@ -3,7 +3,7 @@ from freezegun import freeze_time
 import datetime
 import pytest
 
-from dmutils.email import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmscripts import notify_buyers_to_award_closed_briefs
 
 
@@ -116,6 +116,15 @@ class TestSendEmailToBriefUserViaNotify:
             )
 
         assert failed_user == 999
+
+    def test_send_email_to_brief_user_via_notify_does_not_catch_email_template_errors(self):
+        notify_client = mock.Mock()
+        notify_client.send_email.side_effect = EmailTemplateError
+
+        with pytest.raises(EmailTemplateError):
+            notify_buyers_to_award_closed_briefs.send_email_to_brief_user_via_notify(
+                notify_client, 'NOTIFY_TEMPLATE_ID', self.brief['users'][2], self.brief, None, None
+            )
 
     @mock.patch('dmscripts.notify_buyers_to_award_closed_briefs.logger', autospec=True)
     def test_send_email_to_brief_user_via_notify_logs_instead_of_sending_for_dry_runs(self, logger):

--- a/tests/test_notify_buyers_when_requirements_close.py
+++ b/tests/test_notify_buyers_when_requirements_close.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 from freezegun import freeze_time
 
 import datetime
@@ -8,7 +9,7 @@ from dmscripts.notify_buyers_when_requirements_close import (
     notify_users,
     main
 )
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 
 
 NOTIFY_API_KEY = "1" * 73
@@ -97,6 +98,23 @@ def test_notify_users_returns_false_on_error(send_email):
             {'emailAddress': 'c@example.com', 'active': True},
         ],
     })
+
+
+@mock.patch('dmscripts.notify_buyers_when_requirements_close.DMNotifyClient.send_email', autospec=True)
+def test_notify_users_raises_email_template_error(send_email):
+    send_email.side_effect = EmailTemplateError('Error')
+    with pytest.raises(EmailTemplateError):
+        notify_users(NOTIFY_API_KEY, 'preview', {
+            'id': 100,
+            'title': 'My brief title',
+            'lotSlug': 'lot-slug',
+            'frameworkSlug': 'framework-slug',
+            'users': [
+                {'emailAddress': 'a@example.com', 'active': True},
+                {'emailAddress': 'b@example.com', 'active': False},
+                {'emailAddress': 'c@example.com', 'active': True},
+            ],
+        })
 
 
 @mock.patch('dmscripts.notify_buyers_when_requirements_close.notify_users')

--- a/tests/test_notify_suppliers_whether_application_made_for_framework.py
+++ b/tests/test_notify_suppliers_whether_application_made_for_framework.py
@@ -1,7 +1,10 @@
 from logging import Logger
+
 import mock
+import pytest
+
 from dmutils.email import DMNotifyClient
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmapiclient import DataAPIClient
 from dmscripts.notify_suppliers_whether_application_made_for_framework import (
     notify_suppliers_whether_application_made,
@@ -198,6 +201,30 @@ class TestNotifySuppliersWhetherApplicationMade:
                 "Sending 'application_made' email to supplier '712346' "
                 "user 'iYYo4oiQ-Te98Ak5He9Ch5xAGkvPG1_STnONn12oy7s='"
             )
+        ]
+        assert self.logger.error.call_args_list == [
+            mock.call(
+                "Error sending email to supplier '712345' user 's2qDcB8cMZHhlyLW-QJ0vBtVAf5p6_MzE-RA_ksP4hA=': Arghhh!"
+            )
+        ]
+
+    def test_notify_suppliers_whether_application_made_raises_email_template_error(self):
+        self.notify_client.send_email.side_effect = EmailTemplateError("Arghhh!")
+
+        with pytest.raises(EmailTemplateError):
+            notify_suppliers_whether_application_made(
+                self.data_api_client,
+                self.notify_client,
+                'g-cloud-12',
+                self.logger
+            )
+
+        assert self.logger.info.call_args_list == [
+            mock.call("Supplier '712345'"),
+            mock.call(
+                "Sending 'application_not_made' email to supplier '712345' "
+                "user 's2qDcB8cMZHhlyLW-QJ0vBtVAf5p6_MzE-RA_ksP4hA='"
+            ),
         ]
         assert self.logger.error.call_args_list == [
             mock.call(

--- a/tests/test_upload_counterpart_agreements.py
+++ b/tests/test_upload_counterpart_agreements.py
@@ -1,10 +1,11 @@
+from contextlib import contextmanager
+from sys import version_info
+
 import mock
 import pytest
-from sys import version_info
-from contextlib import contextmanager
 from freezegun import freeze_time
-from dmutils.email.exceptions import EmailError
 
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmscripts.upload_counterpart_agreements import upload_counterpart_file
 
 if version_info.major == 2:
@@ -233,6 +234,137 @@ def test_upload_counterpart_file_sends_correct_emails(
         }
 
         if notify_raise_email_error and notify_fail_early:
+            # we don't want to dictate anything about the order emails are tried in so we can't know which one it will
+            # have tried first - this is probably the only useful thing we can assert
+            assert len(dm_notify_client.send_email.call_args_list) == 1
+        else:
+            assert sorted(dm_notify_client.send_email.call_args_list) == sorted(
+                (
+                    (email, "dead-beef-baad-f00d", expected_personalisation),
+                    {"allow_resend": True},
+                ) for email in expected_send_email_emails
+            )
+
+
+@pytest.mark.parametrize("find_users_iterable,expected_send_email_emails", (
+    (
+        (  # find_users_iterable
+            {
+                "id": 111322,
+                "emailAddress": "user.111322@example.com",
+                "supplierId": 123456,
+                "active": True,
+            },
+            {
+                "id": 111321,
+                "emailAddress": "user.111321@example.com",
+                "supplierId": 123456,
+                "active": True,
+            },
+            {
+                "id": 111320,
+                "emailAddress": "user.111320@example.com",
+                "supplierId": 123456,
+                "active": False,
+            },
+            {
+                "id": 111323,
+                "emailAddress": "supplier.primary@example.com",
+                "supplierId": 123456,
+                "active": True,
+            },
+        ),
+        (  # expected_send_email_emails
+            "supplier.primary@example.com",
+            "user.111321@example.com",
+            "user.111322@example.com",
+        ),
+    ),
+    (
+        (  # find_users_iterable
+            {
+                "id": 111329,
+                "emailAddress": "user.111329@example.com",
+                "supplierId": 123456,
+                "active": True,
+            },
+            {
+                "id": 111320,
+                "emailAddress": "user.111320@example.com",
+                "supplierId": 123456,
+                "active": False,
+            },
+        ),
+        (  # expected_send_email_emails
+            "supplier.primary@example.com",
+            "user.111329@example.com",
+        ),
+    ),
+    (
+        (  # find_users_iterable
+            {
+                "id": 222765,
+                "emailAddress": "user.222765@example.com",
+                "supplierId": 123456,
+                "active": False,
+            },
+        ),
+        (  # expected_send_email_emails
+            "supplier.primary@example.com",
+        ),
+    ),
+))
+@pytest.mark.parametrize("notify_fail_early", (False, True,))
+@pytest.mark.parametrize("notify_raise_email_error", (False, True,))
+def test_fails_if_email_template_error(
+    notify_raise_email_error,
+    notify_fail_early,
+    find_users_iterable,
+    expected_send_email_emails,
+):
+    bucket = mock.Mock()
+    data_api_client = mock.Mock()
+    data_api_client.get_supplier_framework_info.return_value = {
+        "frameworkInterest": {
+            "agreementId": 23,
+            "declaration": {
+                "supplierRegisteredName": "The supplier who signed",
+                "primaryContactEmail": "supplier.primary@example.com",
+            },
+        },
+    }
+    data_api_client.find_users_iter.side_effect = lambda *args, **kwargs: iter(find_users_iterable)
+    dm_notify_client = mock.Mock()
+    if notify_raise_email_error:
+        dm_notify_client.send_email.side_effect = EmailTemplateError("Forgot the stamp")
+
+    with mock.patch.object(builtins, 'open', mock.mock_open(read_data='foo')):
+        with (pytest.raises(EmailTemplateError) if notify_raise_email_error else _empty_context_manager()):
+            upload_counterpart_file(
+                bucket,
+                {
+                    "name": "Dos Two",
+                    "slug": "digital-outcomes-and-specialists-2",
+                },
+                'pdfs/123456-file.pdf',
+                False,
+                data_api_client,
+                dm_notify_client=dm_notify_client,
+                notify_template_id="dead-beef-baad-f00d",
+                notify_fail_early=notify_fail_early,
+            )
+
+        assert bucket.save.called is True
+        assert data_api_client.update_framework_agreement.called is True
+        data_api_client.find_users_iter.assert_called_with(supplier_id=123456)
+
+        expected_personalisation = {
+            "framework_slug": "digital-outcomes-and-specialists-2",
+            "framework_name": "Dos Two",
+            "supplier_name": "The supplier who signed",
+        }
+
+        if notify_raise_email_error:
             # we don't want to dictate anything about the order emails are tried in so we can't know which one it will
             # have tried first - this is probably the only useful thing we can assert
             assert len(dm_notify_client.send_email.call_args_list) == 1


### PR DESCRIPTION
For Notify batch scripts an issue with a template such as a missing personalisation will cause all emails that would be sent by the script to fail. In this situation the script should fail fast, rather than try and continue and waste cycles.

This also reduces the possibility of https://trello.com/c/kwVKRjEm/1460-jenkins-job-notify-suppliers-of-framework-application-event-production-keeps-running-even-after-being-aborted happening again, because the script should hopefully stop itself instead of having to be killed.