### PR TITLE
Add script to export details about service edits

### DIFF
--- a/dmscripts/export_service_edits.py
+++ b/dmscripts/export_service_edits.py
@@ -1,0 +1,129 @@
+import csv
+import datetime
+import difflib
+from typing import Iterator, Optional
+
+from dmapiclient.audit import AuditTypes
+from dmutils.email.helpers import validate_email_address
+
+from dmscripts.helpers.datetime_helpers import audit_date
+
+
+def filter_scripts_from_service_edits(audit_events):
+    # filter out acknowledgedBy which aren't email addresses (more likely to be scripts)
+    return filter(
+        lambda e: validate_email_address(e["acknowledgedBy"]), audit_events
+    )
+
+
+def find_service_edits(
+    data_api_client,
+    service_id: str,
+    from_date: Optional[datetime.date] = None,
+    to_date: Optional[datetime.date] = None,
+    *,
+    latest_first=True,
+    exclude_scripts=True,
+) -> Iterator:
+    """Generate a list of edits to a service
+
+    Find changes made to a service, optionally within a time period. By default
+    the most recent change is returned first.
+
+    If `exclude_scripts` is true then service edits which were made by scripts
+    will not be included in the result.
+    """
+    # I think this is the easiest way to get service edits
+    audit_events = data_api_client.find_audit_events_iter(
+        audit_date=audit_date(from_date, to_date),
+        audit_type=AuditTypes.update_service,
+        latest_first=latest_first,
+        object_type="services",
+        object_id=service_id,
+    )
+
+    if exclude_scripts:
+        audit_events = filter_scripts_from_service_edits(audit_events)
+
+    return audit_events
+
+
+def diff_archived_services(a: dict, b: dict) -> str:
+    if "services" in a:
+        a = a["services"]
+    if "services" in b:
+        b = b["services"]
+    if not (a["frameworkFamily"] == b["frameworkFamily"] and a["lot"] == b["lot"]):
+        raise ValueError("archived services to compare must be from same framework family and lot")
+
+    assert a.keys() == b.keys()
+
+    def do_diff(a, b, key) -> str:
+        assert type(a) == type(b)
+        assert a != b
+        if isinstance(a, list):
+            addnewlines = lambda l: list(map(lambda s: s + "\n", l))  # noqa: E731
+            return "".join(difflib.Differ().compare(addnewlines(a), addnewlines(b)))
+        elif isinstance(a, str):
+            addnewline = lambda s: s + "\n" if not s.endswith("\n") else s  # noqa: E731
+            return "".join(difflib.Differ().compare(
+                addnewline(a).splitlines(keepends=True),
+                addnewline(b).splitlines(keepends=True)
+            ))
+        else:
+            raise TypeError(f"cannot compare type '{type(a)}' at '{key}'")
+
+    changes = (
+        "\n\n".join(
+            f"{k}:\n{do_diff(a[k], b[k], k)}"
+            for k in a
+            if a[k] != b[k]
+            and k not in ("links", "updatedAt")
+        )
+    )
+
+    return changes
+
+
+def service_edit_diff(data_api_client, audit_event) -> str:
+    assert audit_event["type"] == "update_service"
+
+    new = data_api_client.get_archived_service(audit_event["data"]["newArchivedServiceId"])
+    old = data_api_client.get_archived_service(audit_event["data"]["oldArchivedServiceId"])
+
+    return diff_archived_services(new, old)
+
+
+def write_service_edits_csv(f, audit_events, data_api_client, *, include_diffs=True):
+    """Write a CSV including details of service edits to `f`
+
+    Optionally includes the textual changes in a simple diff-like format.
+    """
+    writer = csv.writer(f)
+
+    writer.writerow(
+        [
+            "date of edit",
+            "date of approval",
+            "approved by",
+            "supplier name",
+            "supplier ID",
+            "service ID",
+        ] + [
+            "service changes",
+        ] if include_diffs else []
+    )
+
+    for e in audit_events:
+        writer.writerow(
+            [
+                e["createdAt"],
+                e["acknowledgedAt"],
+                e["acknowledgedBy"],
+                e["data"].get("supplierName"),
+                e["data"].get("supplierId"),
+                e["data"].get("serviceId"),
+            ] + [
+                service_edit_diff(data_api_client, e),
+            ] if include_diffs else []
+        )

--- a/dmscripts/helpers/datetime_helpers.py
+++ b/dmscripts/helpers/datetime_helpers.py
@@ -1,0 +1,47 @@
+import datetime
+from typing import Optional
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+DEFAULT_DATETIME = "1970-01-01T00:00:00.000000Z"
+
+
+def audit_date(
+    from_date: Optional[datetime.date] = None,
+    to_date: Optional[datetime.date] = None
+) -> Optional[str]:
+    """Returns a string acceptable to the find_audit_events `audit-date` parameter
+
+    >>> audit_date(from_date=datetime.date(year=2020, month=9, day=28))
+    '>=2020-09-28'
+    >>> audit_date(to_date=datetime.date(year=2020, month=10, day=28))
+    '<2020-10-28'
+    >>> audit_date(
+    ...     from_date=datetime.date(year=2020, month=9, day=28),
+    ...     to_date=datetime.date(year=2020, month=10, day=28),
+    ... )
+    '2020-09-28..2020-10-28'
+    """
+    format_spec = "%Y-%m-%d"
+    if from_date and not to_date:
+        return f">={from_date:{format_spec}}"
+    elif to_date and not from_date:
+        return f"<{to_date:{format_spec}}"
+    elif from_date and to_date:
+        return f"{from_date:{format_spec}}..{to_date:{format_spec}}"
+    else:
+        return None
+
+
+def parse_datetime(s: str) -> datetime.datetime:
+    """Parse a datetime from a string that might not include all of the datetime parts
+
+    >>> parse_datetime('2020-10')
+    datetime.datetime(2020, 10, 1, 0, 0)
+    """
+    try:
+        return datetime.datetime.strptime(s, ISO_FORMAT)
+    except ValueError as e:
+        if len(s) < len(DEFAULT_DATETIME):
+            return datetime.datetime.strptime(s + DEFAULT_DATETIME[len(s):], ISO_FORMAT)
+        else:
+            raise e

--- a/scripts/oneoff/export-approved-service-edits.py
+++ b/scripts/oneoff/export-approved-service-edits.py
@@ -21,7 +21,6 @@ Example:
 """
 
 
-import csv
 import itertools
 import sys
 from datetime import datetime, timedelta
@@ -37,20 +36,8 @@ from dmutils.env_helpers import get_api_endpoint_from_stage
 sys.path.insert(0, ".")
 
 from dmscripts.helpers.auth_helpers import get_auth_token
-
-
-ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
-DEFAULT_DATETIME = "1970-01-01T00:00:00.000000Z"
-
-
-def parse_datetime(s: str) -> datetime:
-    try:
-        return datetime.strptime(s, ISO_FORMAT)
-    except ValueError as e:
-        if len(s) < len(DEFAULT_DATETIME):
-            return datetime.strptime(s + DEFAULT_DATETIME[len(s):], ISO_FORMAT)
-        else:
-            raise e
+from dmscripts.helpers.datetime_helpers import ISO_FORMAT, parse_datetime
+from dmscripts.export_service_edits import write_service_edits_csv
 
 
 def find_approved_service_edits(
@@ -120,28 +107,4 @@ if __name__ == "__main__":
         lambda e: validate_email_address(e["acknowledgedBy"]), audit_events
     )
 
-    # write details as csv
-    writer = csv.writer(sys.stdout)
-
-    writer.writerow(
-        [
-            "date of edit",
-            "date of approval",
-            "approved by",
-            "supplier name",
-            "supplier ID",
-            "service ID",
-        ]
-    )
-
-    for e in audit_events:
-        writer.writerow(
-            [
-                e["createdAt"],
-                e["acknowledgedAt"].strftime(ISO_FORMAT),
-                e["acknowledgedBy"],
-                e["data"].get("supplierName"),
-                e["data"].get("supplierId"),
-                e["data"].get("serviceId"),
-            ]
-        )
+    write_service_edits_csv(sys.stdout, audit_events, data_api_client)

--- a/scripts/oneoff/export-service-edits.py
+++ b/scripts/oneoff/export-service-edits.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+"""Get details about edits to a service in a period.
+
+Outputs a CSV.
+
+Usage: export-service-edits.py [-h] [options] <service_id> [<from>] [<to>]
+
+    <service_id>  Public ID of the service.
+    <from>        Beginning of time range in ISO 8601 format.
+    <to>          End of time range in ISO 8601 format.
+
+Options:
+    --stage=<stage>  Stage to run script against [default: production].
+    -h, --help       Show this help text.
+
+Example:
+
+    Write service edits since October 2020 to a file
+
+    ./scripts/oneoff/export-approved-service-edits.py 11111111111 2020-10 > service_edits_11111111111.csv
+"""
+import sys
+
+from docopt import docopt
+
+from dmapiclient.data import DataAPIClient
+from dmutils.env_helpers import get_api_endpoint_from_stage
+
+sys.path.insert(0, ".")
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.datetime_helpers import parse_datetime
+from dmscripts.export_service_edits import find_service_edits, write_service_edits_csv
+
+if __name__ == "__main__":
+
+    args = docopt(__doc__)
+
+    stage = args["--stage"]
+
+    from_datetime = parse_datetime(args["<from>"]) if args["<from>"] else None
+    to_datetime = parse_datetime(args["<to>"]) if args["<to>"] else None
+
+    data_api_client = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(stage),
+        auth_token=get_auth_token("api", stage),
+    )
+
+    audit_events = find_service_edits(
+        data_api_client, args["<service_id>"],
+        from_datetime, to_datetime
+    )
+
+    write_service_edits_csv(sys.stdout, audit_events, data_api_client)


### PR DESCRIPTION
Occasionally we get asked to provide details about historical changes to a service. This script should make answering those requests a little easier.