### PR TITLE
Remove ',uuu' from logs

### DIFF
--- a/dmscripts/helpers/logging_helpers.py
+++ b/dmscripts/helpers/logging_helpers.py
@@ -8,7 +8,7 @@ from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL, getLogger, Logger  # 
 from dmutils.logging import CustomLogFormatter
 
 LOG_FORMAT = '%(asctime)s %(name)s %(levelname)s %(message)s'
-TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S,uuu %Z'
+TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
 
 
 def get_logger() -> Logger:


### PR DESCRIPTION
We [hoped](https://github.com/alphagov/digitalmarketplace-scripts/pull/570) it would give us the ~microseconds~ milliseconds, but it didn't.