### PR TITLE
Add admin-only CSV with buyer user details to DOS opportunities export script

### DIFF
--- a/scripts/export-dos-opportunities.py
+++ b/scripts/export-dos-opportunities.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 """Generate DOS opportunity data export CSV
 
-Loads data from the Brief and BriefResponse API models, filters for closed/awarded briefs and stores the output
-in the CSV.
+Loads data from the Brief and BriefResponse API models, filters for
+closed/awarded briefs and stores the output in the CSV.
+
+This script generates two CSVs, one with buyer user details and one without.
+
+The CSV without buyer user details is made publically available by uploading to
+the communications bucket, the CSV with buyer user details should be available
+to admins only so it is uploaded to the reports bucket.
 
 Usage:
     scripts/export-dos-opportunities.py [options] <stage>

--- a/scripts/export-dos-opportunities.py
+++ b/scripts/export-dos-opportunities.py
@@ -13,7 +13,6 @@ Options:
     --dry-run       Generate the file but do not upload to S3
     --output-dir=<output_dir>  Directory to write csv files to [default: data]
 """
-import os
 import sys
 sys.path.insert(0, '.')
 
@@ -23,12 +22,8 @@ from dmapiclient import DataAPIClient
 
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.logging_helpers import logging, configure_logger
-from dmscripts.helpers.s3_helpers import get_bucket_name
-from dmscripts.export_dos_opportunities import (
-    get_latest_dos_framework, get_brief_data, write_rows_to_csv, upload_file_to_s3
-)
+from dmscripts.export_dos_opportunities import export_dos_opportunities
 from dmutils.env_helpers import get_api_endpoint_from_stage
-from dmutils.s3 import S3
 
 
 if __name__ == '__main__':
@@ -38,41 +33,11 @@ if __name__ == '__main__':
     OUTPUT_DIR = arguments['--output-dir']
     DRY_RUN = arguments['--dry-run']
 
-    logging_config = {'dmapiclient': logging.INFO} if bool(arguments.get('--verbose')) \
+    logging_config = {
+        'dmapiclient': logging.INFO} if bool(arguments.get('--verbose')) \
         else {'dmapiclient': logging.WARNING}
     logger = configure_logger(logging_config)
 
-    # TODO: use pathlib
-    if not os.path.exists(OUTPUT_DIR):
-        logger.info("Creating {} directory".format(OUTPUT_DIR))
-        os.makedirs(OUTPUT_DIR)
-
     client = DataAPIClient(get_api_endpoint_from_stage(STAGE), get_auth_token('api', STAGE))
 
-    latest_framework_slug = get_latest_dos_framework(client)
-
-    DOWNLOAD_FILE_NAME = 'opportunity-data.csv'
-    file_path = os.path.join(OUTPUT_DIR, DOWNLOAD_FILE_NAME)
-    bucket_name = get_bucket_name(STAGE, 'communications')
-    key_name = '{}/communications/data/{}'.format(latest_framework_slug, DOWNLOAD_FILE_NAME)
-
-    logger.info('Exporting DOS opportunity data to CSV')
-
-    # Get the data
-    rows = get_brief_data(client, logger)
-
-    # Construct CSV
-    write_rows_to_csv(rows, file_path, logger)
-
-    # Grab bucket
-    bucket = S3(bucket_name)
-
-    # Upload to S3
-    upload_file_to_s3(
-        file_path,
-        bucket,
-        key_name,
-        DOWNLOAD_FILE_NAME,
-        dry_run=DRY_RUN,
-        logger=logger
-    )
+    export_dos_opportunities(client, logger, STAGE, OUTPUT_DIR, DRY_RUN)

--- a/tests/test_export_dos_opportunities.py
+++ b/tests/test_export_dos_opportunities.py
@@ -1,8 +1,10 @@
 import builtins
+from collections import OrderedDict
 from pathlib import Path
 
 import mock
 import pytest
+
 from dmapiclient import DataAPIClient
 from dmtestutils.api_model_stubs import BriefResponseStub, FrameworkStub
 
@@ -120,30 +122,36 @@ class TestGetBriefData:
 
         rows = get_brief_data(client, logger)
 
+        for row in rows:
+            assert isinstance(row, OrderedDict)
+
         assert rows == [
-            [
-                12345,
-                'My Brilliant Brief',
-                'https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/12345',
-                'digital-outcomes-and-specialists-3',
-                'digital-specialists',
-                'technicalArchitect',
-                "HM Dept of Doing Stuff",
-                "example.gov.uk",
-                "London",
-                "2019-01-01",
-                "2 weeks",
-                "6 months",
-                2,
-                0,
-                2,
-                "awarded",
-                "Foo Inc",
-                "small",
-                "2345678",
-                "2019-06-02",
-                1
-            ]
+            OrderedDict((
+                ("ID", 12345),
+                ("Opportunity", "My Brilliant Brief"),
+                (
+                    "Link",
+                    "https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/12345"
+                ),
+                ("Framework", "digital-outcomes-and-specialists-3"),
+                ("Category", "digital-specialists"),
+                ("Specialist", "technicalArchitect"),
+                ("Organisation Name", "HM Dept of Doing Stuff"),
+                ("Buyer Domain", "example.gov.uk"),
+                ("Location Of The Work", "London"),
+                ("Published At", "2019-01-01"),
+                ("Open For", "2 weeks"),
+                ("Expected Contract Length", "6 months"),
+                ("Applications from SMEs", 2),
+                ("Applications from Large Organisations", 0),
+                ("Total Organisations", 2),
+                ("Status", "awarded"),
+                ("Winning supplier", "Foo Inc"),
+                ("Size of supplier", "small"),
+                ("Contract amount", "2345678"),
+                ("Contract start date", "2019-06-02"),
+                ("Clarification questions", 1),
+            ))
         ]
 
         assert client.find_briefs_iter.call_args_list == [


### PR DESCRIPTION
Ticket: https://trello.com/c/s5IrVY70/2122-ccsrequest-queries-relating-to-the-digital-marketplace-for-dos-team

Currently CSS admins have to cross-reference buyer user details with an opportunity by hand, which is time-consuming for them.

This commit expands the export-dos-opportunities script to generate an additional CSV with extra details about the buyer user. As we don't want to make this information publicly available, this new CSV is uploaded to the reports bucket with private permissions; a change to the admin frontend will be needed to allow admins to download this file.