### PR TITLE
Fix bugs in export-dos-opportunities script

### DIFF
--- a/dmscripts/export_dos_opportunities.py
+++ b/dmscripts/export_dos_opportunities.py
@@ -127,13 +127,13 @@ def upload_file_to_s3(
     logger,
 ):
     with open(file_path, 'br') as source_file:
-        acl = "public-read" if public else "private"
+        acl = "public-read" if public else "bucket-owner-full-control"
 
-        logger.info("{}UPLOAD: {} to {}::{} with acl {}".format(
+        logger.info("{}UPLOAD: {} to s3://{}/{} with acl {}".format(
             '[Dry-run]' if dry_run else '',
             file_path,
             bucket.bucket_name,
-            download_name,
+            remote_key_name,
             acl
         ))
 

--- a/tests/test_export_dos_opportunities.py
+++ b/tests/test_export_dos_opportunities.py
@@ -216,10 +216,10 @@ class TestUploadFileToS3:
         ])
         assert logger.info.call_args_list == ([
             mock.call(
-                "[Dry-run]UPLOAD: local/path to mybucket::opportunity-data.csv with acl public-read"
+                "[Dry-run]UPLOAD: local/path to s3://mybucket/remote/key/name with acl public-read"
             )
         ] if dry_run else [
-            mock.call("UPLOAD: local/path to mybucket::opportunity-data.csv with acl public-read")
+            mock.call("UPLOAD: local/path to s3://mybucket/remote/key/name with acl public-read")
         ])
 
 
@@ -332,7 +332,7 @@ class TestExportDOSOpportunities:
             assert mock.call(
                 "digital-outcomes-and-specialists-3/reports/opportunity-data.csv",
                 mock.ANY,  # CSV file
-                acl="private",
+                acl="bucket-owner-full-control",
                 download_filename="opportunity-data.csv",
             ) in s3().save.call_args_list
             assert Path(s3().save.call_args_list[0][0][1].name) \


### PR DESCRIPTION
* Log messages now show the key for the uploaded file
* Admin-only CSV has the correct permissions to allow download via signed url

There is more detail in the commit message.