### PR TITLE
Bump digitalmarketplace-test-utils from git to PyPI

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -12,4 +12,4 @@ mock<4.0.0
 pytest
 requests-mock
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils==2.8.2

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -12,4 +12,4 @@ mock<4.0.0
 pytest
 requests-mock
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils==2.8.2
+digitalmarketplace-test-utils

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,7 +30,7 @@ decorator==4.4.1
     # via
     #   ipython
     #   traitlets
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils==2.8.2
+digitalmarketplace-test-utils==2.8.2
     # via -r requirements-dev.in
 entrypoints==0.3
     # via flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,49 +4,126 @@
 #
 #    pip-compile requirements-dev.in
 #
-appnope==0.1.0            # via ipython
-attrs==19.3.0             # via -c requirements.txt, pytest
-backcall==0.1.0           # via ipython
-certifi==2019.11.28       # via -c requirements.txt, requests
-chardet==3.0.4            # via -c requirements.txt, requests
-click==7.0                # via -c requirements.txt, pip-tools
-cram==0.7                 # via -r requirements-dev.in
-decorator==4.4.1          # via ipython, traitlets
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2  # via -r requirements-dev.in
-entrypoints==0.3          # via flake8
-flake8==3.7.9             # via -r requirements-dev.in
-freezegun==0.3.15         # via -r requirements-dev.in
-idna==2.9                 # via -c requirements.txt, requests
-importlib-metadata==1.5.0  # via -c requirements.txt, pluggy, pytest
-ipython-genutils==0.2.0   # via -r requirements-dev.in, traitlets
-ipython==7.12.0           # via -r requirements-dev.in
-jedi==0.16.0              # via ipython
-lxml==4.5.0               # via -r requirements-dev.in
-mccabe==0.6.1             # via flake8
-mock==3.0.5               # via -r requirements-dev.in
-more-itertools==8.2.0     # via pytest
-packaging==20.1           # via pytest
-parso==0.6.1              # via jedi
-pexpect==4.8.0            # via ipython
-pickleshare==0.7.5        # via ipython
-pip-tools==5.1.0          # via -r requirements-dev.in
-pluggy==0.13.1            # via pytest
-prompt-toolkit==3.0.3     # via ipython
-ptyprocess==0.6.0         # via pexpect
-py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8
-pygments==2.5.2           # via ipython
-pyparsing==2.4.6          # via packaging
-pytest==5.3.5             # via -r requirements-dev.in
-python-dateutil==2.8.1    # via -c requirements.txt, freezegun
-requests-mock==1.7.0      # via -r requirements-dev.in
-requests==2.23.0          # via -c requirements.txt, requests-mock
-six==1.14.0               # via -c requirements.txt, freezegun, mock, packaging, pip-tools, python-dateutil, requests-mock, traitlets
-traitlets==4.3.3          # via ipython
-urllib3==1.25.10          # via -c requirements.txt, requests
-wcwidth==0.1.8            # via prompt-toolkit, pytest
-zipp==3.0.0               # via -c requirements.txt, importlib-metadata
+appnope==0.1.0
+    # via ipython
+attrs==19.3.0
+    # via
+    #   -c requirements.txt
+    #   pytest
+backcall==0.1.0
+    # via ipython
+certifi==2019.11.28
+    # via
+    #   -c requirements.txt
+    #   requests
+chardet==3.0.4
+    # via
+    #   -c requirements.txt
+    #   requests
+click==7.0
+    # via
+    #   -c requirements.txt
+    #   pip-tools
+cram==0.7
+    # via -r requirements-dev.in
+decorator==4.4.1
+    # via
+    #   ipython
+    #   traitlets
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2
+    # via -r requirements-dev.in
+entrypoints==0.3
+    # via flake8
+flake8==3.7.9
+    # via -r requirements-dev.in
+freezegun==0.3.15
+    # via -r requirements-dev.in
+idna==2.9
+    # via
+    #   -c requirements.txt
+    #   requests
+importlib-metadata==1.5.0
+    # via
+    #   -c requirements.txt
+    #   pluggy
+    #   pytest
+ipython-genutils==0.2.0
+    # via
+    #   -r requirements-dev.in
+    #   traitlets
+ipython==7.12.0
+    # via -r requirements-dev.in
+jedi==0.16.0
+    # via ipython
+lxml==4.5.0
+    # via -r requirements-dev.in
+mccabe==0.6.1
+    # via flake8
+mock==3.0.5
+    # via -r requirements-dev.in
+more-itertools==8.2.0
+    # via pytest
+packaging==20.1
+    # via pytest
+parso==0.6.1
+    # via jedi
+pexpect==4.8.0
+    # via ipython
+pickleshare==0.7.5
+    # via ipython
+pip-tools==5.5.0
+    # via -r requirements-dev.in
+pluggy==0.13.1
+    # via pytest
+prompt-toolkit==3.0.3
+    # via ipython
+ptyprocess==0.6.0
+    # via pexpect
+py==1.8.1
+    # via pytest
+pycodestyle==2.5.0
+    # via flake8
+pyflakes==2.1.1
+    # via flake8
+pygments==2.5.2
+    # via ipython
+pyparsing==2.4.6
+    # via packaging
+pytest==5.3.5
+    # via -r requirements-dev.in
+python-dateutil==2.8.1
+    # via
+    #   -c requirements.txt
+    #   freezegun
+requests-mock==1.7.0
+    # via -r requirements-dev.in
+requests==2.23.0
+    # via
+    #   -c requirements.txt
+    #   requests-mock
+six==1.14.0
+    # via
+    #   -c requirements.txt
+    #   freezegun
+    #   mock
+    #   packaging
+    #   python-dateutil
+    #   requests-mock
+    #   traitlets
+traitlets==4.3.3
+    # via ipython
+urllib3==1.25.10
+    # via
+    #   -c requirements.txt
+    #   requests
+wcwidth==0.1.8
+    # via
+    #   prompt-toolkit
+    #   pytest
+zipp==3.0.0
+    # via
+    #   -c requirements.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,7 +30,7 @@ decorator==4.4.1
     # via
     #   ipython
     #   traitlets
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils==2.8.2
     # via -r requirements-dev.in
 entrypoints==0.3
     # via flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,74 +4,191 @@
 #
 #    pip-compile requirements.in
 #
-argcomplete==1.11.1       # via yq
-attrs==19.3.0             # via jsonschema
-awscli==1.18.137          # via -r requirements.in
-backoff==1.10.0           # via -r requirements.in
-blinker==1.4              # via gds-metrics
-boto3==1.14.34            # via digitalmarketplace-utils
-botocore==1.17.60         # via awscli, boto3, s3transfer
-cachelib==0.1.1           # via flask-session
-certifi==2019.11.28       # via requests
-cffi==1.14.0              # via cryptography
-chardet==3.0.4            # via requests
-click==7.0                # via flask
-colorama==0.4.3           # via awscli
-contextlib2==0.6.0.post1  # via digitalmarketplace-utils
-cryptography==3.2.1       # via digitalmarketplace-utils
-defusedxml==0.6.0         # via odfpy
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.10.0#egg=digitalmarketplace-apiclient==21.10.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.21.0#egg=digitalmarketplace-content-loader==7.21.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@55.2.1#egg=digitalmarketplace-utils==55.2.1  # via -r requirements.in, digitalmarketplace-content-loader
-docopt==0.6.2             # via -r requirements.in, notifications-python-client
-docutils==0.15.2          # via awscli, botocore
-flask-gzip==0.2           # via digitalmarketplace-utils
-flask-login==0.5.0        # via digitalmarketplace-utils
-flask-session==0.3.2      # via digitalmarketplace-utils
-flask-wtf==0.14.3         # via digitalmarketplace-utils
-flask==1.0.4              # via -r requirements.in, digitalmarketplace-content-loader, digitalmarketplace-utils, flask-gzip, flask-login, flask-session, flask-wtf, gds-metrics
-fleep==1.0.1              # via digitalmarketplace-utils
-future==0.18.2            # via notifications-python-client
-gds-metrics==0.2.0        # via digitalmarketplace-utils
-govuk-country-register==0.5.0  # via digitalmarketplace-utils
-idna==2.9                 # via requests
-importlib-metadata==1.5.0  # via argcomplete, jsonschema
-inflection==0.3.1         # via digitalmarketplace-content-loader
-itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf
-jinja2==2.10.3            # via digitalmarketplace-content-loader, flask
-jmespath==0.9.5           # via boto3, botocore
-jsonschema==3.2.0         # via -r requirements.in
-lorem==0.1.1              # via -r requirements.in
-mailchimp3==3.0.6         # via digitalmarketplace-utils
-markdown==2.6.11          # via digitalmarketplace-content-loader
-markupsafe==1.1.1         # via jinja2
-monotonic==1.5            # via notifications-python-client
-notifications-python-client==5.5.1  # via digitalmarketplace-utils
-odfpy==1.4.1              # via digitalmarketplace-utils
-prometheus-client==0.2.0  # via gds-metrics
-pyasn1==0.4.8             # via rsa
-pycparser==2.19           # via cffi
-pyjwt==1.7.1              # via notifications-python-client
-pypdf2==1.26.0            # via -r requirements.in
-pyrsistent==0.15.7        # via jsonschema
-python-dateutil==2.8.1    # via -r requirements.in, botocore
-git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8  # via -r requirements.in, digitalmarketplace-utils
-pytz==2019.3              # via digitalmarketplace-utils
-pyyaml==5.3.1             # via awscli, digitalmarketplace-content-loader, yq
-redis==3.5.3              # via digitalmarketplace-utils
-requests==2.23.0          # via digitalmarketplace-apiclient, digitalmarketplace-utils, mailchimp3, notifications-python-client
-rsa==4.5                  # via awscli
-s3transfer==0.3.3         # via awscli, boto3
-six==1.14.0               # via cryptography, jsonschema, pyrsistent, python-dateutil
-unicodecsv==0.14.1        # via -r requirements.in, digitalmarketplace-utils
-urllib3==1.25.10          # via botocore, requests
-werkzeug==1.0.0           # via digitalmarketplace-utils, flask
-workdays==1.4             # via digitalmarketplace-utils
-wtforms==2.2.1            # via flask-wtf
-xeger==0.3.5              # via -r requirements.in
-xmltodict==0.12.0         # via yq
-yq==2.11.1                # via -r requirements.in
-zipp==3.0.0               # via importlib-metadata
+argcomplete==1.11.1
+    # via yq
+attrs==19.3.0
+    # via jsonschema
+awscli==1.18.137
+    # via -r requirements.in
+backoff==1.10.0
+    # via -r requirements.in
+blinker==1.4
+    # via gds-metrics
+boto3==1.14.34
+    # via digitalmarketplace-utils
+botocore==1.17.60
+    # via
+    #   awscli
+    #   boto3
+    #   s3transfer
+cachelib==0.1.1
+    # via flask-session
+certifi==2019.11.28
+    # via requests
+cffi==1.14.0
+    # via cryptography
+chardet==3.0.4
+    # via requests
+click==7.0
+    # via flask
+colorama==0.4.3
+    # via awscli
+contextlib2==0.6.0.post1
+    # via digitalmarketplace-utils
+cryptography==3.2.1
+    # via digitalmarketplace-utils
+defusedxml==0.6.0
+    # via odfpy
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.10.0#egg=digitalmarketplace-apiclient==21.10.0
+    # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.21.0#egg=digitalmarketplace-content-loader==7.21.0
+    # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-utils.git@55.2.1#egg=digitalmarketplace-utils==55.2.1
+    # via
+    #   -r requirements.in
+    #   digitalmarketplace-content-loader
+docopt==0.6.2
+    # via
+    #   -r requirements.in
+    #   notifications-python-client
+docutils==0.15.2
+    # via
+    #   awscli
+    #   botocore
+flask-gzip==0.2
+    # via digitalmarketplace-utils
+flask-login==0.5.0
+    # via digitalmarketplace-utils
+flask-session==0.3.2
+    # via digitalmarketplace-utils
+flask-wtf==0.14.3
+    # via digitalmarketplace-utils
+flask==1.0.4
+    # via
+    #   -r requirements.in
+    #   digitalmarketplace-content-loader
+    #   digitalmarketplace-utils
+    #   flask-gzip
+    #   flask-login
+    #   flask-session
+    #   flask-wtf
+    #   gds-metrics
+fleep==1.0.1
+    # via digitalmarketplace-utils
+future==0.18.2
+    # via notifications-python-client
+gds-metrics==0.2.0
+    # via digitalmarketplace-utils
+govuk-country-register==0.5.0
+    # via digitalmarketplace-utils
+idna==2.9
+    # via requests
+importlib-metadata==1.5.0
+    # via
+    #   argcomplete
+    #   jsonschema
+inflection==0.3.1
+    # via digitalmarketplace-content-loader
+itsdangerous==1.1.0
+    # via
+    #   -r requirements.in
+    #   flask
+    #   flask-wtf
+jinja2==2.10.3
+    # via
+    #   digitalmarketplace-content-loader
+    #   flask
+jmespath==0.9.5
+    # via
+    #   boto3
+    #   botocore
+jsonschema==3.2.0
+    # via -r requirements.in
+lorem==0.1.1
+    # via -r requirements.in
+mailchimp3==3.0.6
+    # via digitalmarketplace-utils
+markdown==2.6.11
+    # via digitalmarketplace-content-loader
+markupsafe==1.1.1
+    # via jinja2
+monotonic==1.5
+    # via notifications-python-client
+notifications-python-client==5.5.1
+    # via digitalmarketplace-utils
+odfpy==1.4.1
+    # via digitalmarketplace-utils
+prometheus-client==0.2.0
+    # via gds-metrics
+pyasn1==0.4.8
+    # via rsa
+pycparser==2.19
+    # via cffi
+pyjwt==1.7.1
+    # via notifications-python-client
+pypdf2==1.26.0
+    # via -r requirements.in
+pyrsistent==0.15.7
+    # via jsonschema
+python-dateutil==2.8.1
+    # via
+    #   -r requirements.in
+    #   botocore
+git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8
+    # via
+    #   -r requirements.in
+    #   digitalmarketplace-utils
+pytz==2019.3
+    # via digitalmarketplace-utils
+pyyaml==5.3.1
+    # via
+    #   awscli
+    #   digitalmarketplace-content-loader
+    #   yq
+redis==3.5.3
+    # via digitalmarketplace-utils
+requests==2.23.0
+    # via
+    #   digitalmarketplace-apiclient
+    #   digitalmarketplace-utils
+    #   mailchimp3
+    #   notifications-python-client
+rsa==4.5
+    # via awscli
+s3transfer==0.3.3
+    # via
+    #   awscli
+    #   boto3
+six==1.14.0
+    # via
+    #   cryptography
+    #   jsonschema
+    #   pyrsistent
+    #   python-dateutil
+unicodecsv==0.14.1
+    # via
+    #   -r requirements.in
+    #   digitalmarketplace-utils
+urllib3==1.25.10
+    # via
+    #   botocore
+    #   requests
+werkzeug==1.0.0
+    # via
+    #   digitalmarketplace-utils
+    #   flask
+workdays==1.4
+    # via digitalmarketplace-utils
+wtforms==2.2.1
+    # via flask-wtf
+xeger==0.3.5
+    # via -r requirements.in
+xmltodict==0.12.0
+    # via yq
+yq==2.11.1
+    # via -r requirements.in
+zipp==3.0.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from mock import Mock
 import requests_mock
 
-from dmtestutils.api_model_stubs import FrameworkStub
+from dmtestutils.api_model_stubs import FrameworkStub, LotStub
 
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
@@ -17,7 +17,10 @@ def mock_data_client():
     """Mock data client for use in tests. These can be overwritten in individual tests."""
     mock_data_client = Mock()
     mock_data_client.get_framework.return_value = FrameworkStub(
-        lots=[{"slug": "test_lot_slug_1"}, {"slug": "test_lot_slug_2"}],
+        lots=[
+            LotStub(slug="test_lot_slug_1").response(),
+            LotStub(slug="test_lot_slug_2").response(),
+        ],
     ).single_result_response()
 
     mock_data_client.find_draft_services_iter.return_value = {}


### PR DESCRIPTION
We want to install digitalmarketplace-test-utils from PyPI instead of VCS, so we can rely on Dependabot to update our apps automatically when a new version is available.