### PR TITLE
Scripts to identify and delete Trello CSV attachments containing PII

### DIFF
--- a/scripts/oneoff/delete_trello_pii.py
+++ b/scripts/oneoff/delete_trello_pii.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+Process the list of Trello attachments produced by get_trello_attachments.py. Delete all attachments that contain
+personal information.
+"""
+import csv
+import os
+import requests
+
+headers = {"Accept": "application/json"}
+query = {
+    "key": os.environ["TRELLO_KEY"],
+    "token": os.environ["TRELLO_TOKEN"],
+}
+
+
+def delete_attachment(attachment_url):
+    requests.delete(attachment_url, headers=headers, params=query).raise_for_status()
+
+
+with open("attachments.csv") as csvfile:
+    attachments = list(csv.DictReader(csvfile))
+
+for attachment_data in attachments:
+    response = requests.get(attachment_data["attachment_url"], headers=headers, params=query)
+    response.raise_for_status()
+
+    print(f"CARD: {attachment_data['card_name']}")
+    print(f"ATTACHMENT: {attachment_data['attachment_name']}")
+    print(f"DATA: {response.text[:1000]}")
+
+    if input("Does this contain personal information? (y/n)") == "y":
+        print(f"Deleting {attachment_data['attachment_name']}")
+        delete_attachment(attachment_data["attachment_url"])

--- a/scripts/oneoff/get_trello_attachments.py
+++ b/scripts/oneoff/get_trello_attachments.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+import csv
+import itertools
+import os
+import requests
+import json
+import time
+
+url = "https://api.trello.com/1/search"
+headers = {"Accept": "application/json"}
+query = {
+    "key": os.environ["TRELLO_KEY"],
+    "token": os.environ["TRELLO_TOKEN"],
+    "query": "has:attachment",
+    "card_fields": "name,url,id",
+    "modelTypes": "cards",
+    "card_attachments": "true",
+    "cards_limit": 100,
+}
+
+attachments = []
+for page in itertools.count(start=0):
+    query["cards_page"] = page
+
+    response = requests.request("GET", url, headers=headers, params=query)
+
+    response.raise_for_status()
+
+    cards = json.loads(response.text)["cards"]
+
+    if not cards:
+        break
+
+    attachments.extend(
+        [
+            {
+                "card_name": card["name"],
+                "card_url": card["url"],
+                "card_id": card["id"],
+                "attachment_name": attachment["name"],
+                "attachment_id": attachment["id"],
+                "attachment_url": attachment["url"],
+            }
+            for card in cards
+            for attachment in card["attachments"]
+            if attachment["name"].endswith(".csv")
+        ]
+    )
+
+    time.sleep(1)
+    print(page)
+
+print(attachments)
+print(len(attachments))
+
+with open("attachments.csv", "w", newline="") as csvfile:
+    writer = csv.DictWriter(csvfile, fieldnames=attachments[0].keys())
+    writer.writeheader()
+    writer.writerows(attachments)


### PR DESCRIPTION
Trello: https://trello.com/c/tq75g1XZ/2148-what-do-we-do-about-historic-lists-of-user-emails-stored-in-trello

Some of our CSV attachments in Trello contain user data (emails, mostly). We want to find and delete all such attachments.

Create a script to get us all our Trello cards with CSV attachments. This needs to be run by someone with access to all our Trello teams/boards. They'll need to get a Trello API key and token and provide them as environment variables.

Create a second script that reads the list of attachments and presents them for a human to determine whether they contain PII. If the human says yes, the script deletes the attachment.

Note - this is all quite rough and of generally poor quality. However, we're only going to run this once, so I think that's OK