### PR TITLE
Change script that suspends suppliers to also send a reminder email

### DIFF
--- a/scripts/framework-applications/suspend-suppliers-without-agreements.py
+++ b/scripts/framework-applications/suspend-suppliers-without-agreements.py
@@ -116,6 +116,11 @@ if __name__ == "__main__":
                 client, logger, framework_slug, supplier_id, framework_info, dry_run
             )
 
+            if suspended_service_count > 0:
+                logger.info(f"{prefix}Suspended {suspended_service_count} services for supplier {supplier_id}")
+            else:
+                logger.warning(f"{prefix}Something went wrong - suspended 0 services for supplier {supplier_id}")
+
         # Send the reminder email to all users for that supplier
         for supplier_email in get_all_email_addresses_for_supplier(client, framework_info):
             logger.info(f"{prefix}Sending email to supplier user: {hash_string(supplier_email)}")


### PR DESCRIPTION
Previously this script suspended suppliers who have not signed the framework agreement and exported a CSV of email addresses to notify.
These email addresses were then uploaded to Notify and a reminder email was sent manually.

In the interests of saving time, reducing the scope for errors and not having personal data on our laptops, modify the script so it also sends the emails.

I have checked to make sure this script isn't used by any Jenkins jobs.

https://trello.com/c/ieH4CTed/699-1-make-script-to-suspend-suppliers-who-havent-signed-also-send-the-email

[Notify email template](https://www.notifications.service.gov.uk/services/95316ff0-e555-462d-a6e7-95d26fbfd091/templates/f4224b66-42cc-45c3-b55a-2cf5cb95792f)
Email sent:
![image](https://user-images.githubusercontent.com/6362602/104040166-3a1d2200-51cf-11eb-9aab-48d8e6292b31.png)
