### PR TITLE
Inform users when the G12 recovery process opens 

### DIFF
--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -1,5 +1,7 @@
 import os
 import subprocess
+from typing import Optional, List
+
 import yaml
 
 DEV_ALIASES = ('dev', 'development', 'local')
@@ -12,6 +14,14 @@ def _decrypt_yaml_file_with_sops(credentials_repo_path, credentials_filename):
         "{}/{}".format(credentials_repo_path, credentials_filename)
     ])
     return yaml.safe_load(creds_output)
+
+
+def get_g12_suppliers(stage: str) -> Optional[List[int]]:
+    if stage.lower() in DEV_ALIASES:
+        return [577184]  # The ID of our test supplier.
+
+    credentials_repo = os.environ.get('DM_CREDENTIALS_REPO', '../digitalmarketplace-credentials')
+    return _decrypt_yaml_file_with_sops(credentials_repo, f'vars/{stage.lower()}.yaml').get("g12_recovery_supplier_ids")
 
 
 def get_auth_token(api, stage):

--- a/dmscripts/helpers/supplier_data_helpers.py
+++ b/dmscripts/helpers/supplier_data_helpers.py
@@ -3,7 +3,9 @@
 from collections import OrderedDict
 from datetime import date, timedelta, datetime
 from functools import lru_cache
+from typing import List
 
+from dmapiclient import DataAPIClient
 from dmapiclient.audit import AuditTypes
 from itertools import groupby
 from operator import itemgetter
@@ -383,3 +385,12 @@ def unsuspend_suspended_supplier_services(record, suspending_user, client, logge
             logger.info(f"[DRY RUN] Would unsuspend service {service_id} for supplier {supplier_id}")
         else:
             client.update_service_status(service_id, new_service_status, "Unsuspend services helper")
+
+
+def get_email_addresses_for_supplier(api_client: DataAPIClient, supplier_id: int) -> List[str]:
+    """
+    Get the email addresses for each user belonging to `supplier_id`. Use `SupplierFrameworkData.get_supplier_users`
+    instead if you need to get email addresses for a large number of suppliers.
+    """
+    supplier_users = api_client.find_users_iter(supplier_id=supplier_id, personal_data_removed=False)
+    return [user["emailAddress"] for user in supplier_users if user["active"]]

--- a/scripts/framework-applications/remind-suppliers-to-sign-framework-agreement.py
+++ b/scripts/framework-applications/remind-suppliers-to-sign-framework-agreement.py
@@ -40,7 +40,7 @@ from dmcontent.content_loader import ContentLoader
 from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers import logging_helpers
-from dmscripts.helpers.supplier_data_helpers import get_supplier_ids_from_args
+from dmscripts.helpers.supplier_data_helpers import get_supplier_ids_from_args, get_email_addresses_for_supplier
 from dmutils.email.helpers import hash_string
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
@@ -54,12 +54,6 @@ def get_supplier_ids_not_signed(api_client: DataAPIClient, framework_slug: str) 
     """
     return [supplier["supplierId"] for supplier in
             api_client.find_framework_suppliers_iter(framework_slug, agreement_returned=False, with_declarations=False)]
-
-
-def get_email_addresses_for_supplier(api_client: DataAPIClient, supplier_id: int) -> List[str]:
-    """Get the email addresses for each user belonging to `supplier_id`"""
-    supplier_users = api_client.find_users_iter(supplier_id=supplier_id, personal_data_removed=False)
-    return [user["emailAddress"] for user in supplier_users if user["active"]]
 
 
 def get_framework_contract_title(content_path: str, framework_slug: str) -> str:

--- a/scripts/oneoff/open_g12_recovery_for_suppliers.py
+++ b/scripts/oneoff/open_g12_recovery_for_suppliers.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""
+Inform suppliers involved in the G12 recovery that the process is now open for them.
+
+Usage:
+    scripts/oneoff/open_g12_recovery_for_suppliers.py <stage> <notify_api_key> [--dry-run]
+
+Parameters:
+    <stage>                     Environment to run script against.
+    <notify_api_key>            API key for GOV.UK Notify.
+
+Options:
+    -n, --dry-run               Run script without sending emails.
+    -h, --help                  Show this screen.
+
+Before running this script, ensure that the list of suppliers in the credentials is correct.
+"""
+
+import sys
+
+from dmapiclient import DataAPIClient
+from dmutils.email.helpers import hash_string
+from dmutils.env_helpers import get_api_endpoint_from_stage
+from docopt import docopt
+
+sys.path.insert(0, ".")
+
+from dmscripts.helpers import logging_helpers
+from dmscripts.helpers.auth_helpers import get_g12_suppliers, get_auth_token
+from dmscripts.helpers.email_helpers import scripts_notify_client
+from dmscripts.helpers.supplier_data_helpers import get_email_addresses_for_supplier
+
+NOTIFY_TEMPLATE_ID = "347e1ed7-ec83-45a0-bb16-832f244f8919"
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    stage = arguments["<stage>"]
+    dry_run = arguments["--dry-run"]
+    notify_api_key = arguments["<notify_api_key>"]
+
+    logger = logging_helpers.configure_logger()
+    mail_client = scripts_notify_client(notify_api_key, logger=logger)
+    api_client = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(stage),
+        auth_token=get_auth_token("api", stage),
+    )
+
+    user_emails = [
+        supplier_user
+        for supplier_id in get_g12_suppliers(stage)
+        for supplier_user in get_email_addresses_for_supplier(api_client, supplier_id)
+    ]
+
+    print(user_emails)
+
+    user_count = len(user_emails)
+    prefix = "[Dry Run] " if dry_run else ""
+    for count, email in enumerate(user_emails, start=1):
+        logger.info(
+            f"{prefix}Sending email to supplier user {count} of {user_count}: {hash_string(email)}"
+        )
+        if not dry_run:
+            mail_client.send_email(
+                to_email_address=email,
+                template_name_or_id=NOTIFY_TEMPLATE_ID,
+            )

--- a/scripts/oneoff/open_g12_recovery_for_suppliers.py
+++ b/scripts/oneoff/open_g12_recovery_for_suppliers.py
@@ -52,8 +52,6 @@ if __name__ == "__main__":
         for supplier_user in get_email_addresses_for_supplier(api_client, supplier_id)
     ]
 
-    print(user_emails)
-
     user_count = len(user_emails)
     prefix = "[Dry Run] " if dry_run else ""
     for count, email in enumerate(user_emails, start=1):


### PR DESCRIPTION
Trello: https://trello.com/c/0g9FxjRJ/680-1-as-a-developer-i-can-run-a-script-to-let-all-recovery-users-know-the-recovery-process-is-open

We have drafted an email we're going to send to users when the G12 recovery process opens. The email will tell the users what they need to do. This script will be used to send that email.

Add some helpers to make this a bit easier. 

The Notify template is: https://www.notifications.service.gov.uk/services/95316ff0-e555-462d-a6e7-95d26fbfd091/templates/347e1ed7-ec83-45a0-bb16-832f244f8919. Note that we're currently missing the closing date. There's a story that tracks getting that filled in once we know the dates.