### PR TITLE
Fix to filter to only suppliers who have made a successful application

### DIFF
--- a/scripts/framework-applications/remind-suppliers-to-sign-framework-agreement.py
+++ b/scripts/framework-applications/remind-suppliers-to-sign-framework-agreement.py
@@ -53,7 +53,8 @@ def get_supplier_ids_not_signed(api_client: DataAPIClient, framework_slug: str) 
     the framework agreement
     """
     return [supplier["supplierId"] for supplier in
-            api_client.find_framework_suppliers_iter(framework_slug, agreement_returned=False, with_declarations=False)]
+            api_client.find_framework_suppliers_iter(framework_slug, agreement_returned=False, with_declarations=False)
+            if supplier["onFramework"]]
 
 
 def get_email_addresses_for_supplier(api_client: DataAPIClient, supplier_id: int) -> List[str]:


### PR DESCRIPTION
Previously the script filtered for all suppliers who had an interest in a framework and who hadn't signed their framework agreement. This includes the users we wanted to email, but mistakenly also sent emails to supplier users who had started an application but not completed it, or those who were unsuccessful in their application.

We want to email just the suppliers who have made a successful application and not yet signed their agreement. This script is run towards the end of standstill so by that point we'll have run the script to mark automatic successes, CCS will have made decisions on all discretionary applications and therefore all suppliers who have successfully applied will have `onFramework` set to `True` in the database.

To get to the users we want we can get all the suppliers who haven't signed their agreement in the same way, but crucially we now **also** filter for just the suppliers who are marked as on the framework.

https://trello.com/c/AWM8eJYY/2159-p4-incident-ccsrequests-fwd-you-must-sign-your-digital-outcomes-and-specialists-5-framework-award-form