### PR TITLE
Get one draft ID for each G12 recovery service

### DIFF
--- a/scripts/oneoff/get_g12_recovery_services.py
+++ b/scripts/oneoff/get_g12_recovery_services.py
@@ -21,12 +21,15 @@ from dmscripts.helpers.auth_helpers import get_auth_token
 def _normalise_service_name(name):
     """
     To be able to safely compare service names. The output is not meant to be human-readable.
+
+    Copied from `upload_draft_service_pdfs.py`
     """
     return (
         name.lower()
         .replace("-", "")
+        .replace("_", "")
+        .replace(":", "")
         .replace(" ", "")
-        .replace("/", ":")
         .replace(".csv", "")
     )
 

--- a/scripts/oneoff/get_g12_recovery_services.py
+++ b/scripts/oneoff/get_g12_recovery_services.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""
+Get the drafts that correspond to G12 recovery services. Note that there can be 0 or multiple drafts for one service.
+You will need to process the output to get a one-to-one mapping.
+
+Usage:
+    scripts/get_g12_recovery_services.py <stage> <phase_file> <output_file>
+"""
+import csv
+import sys
+
+from dmapiclient import DataAPIClient
+from dmutils.env_helpers import get_api_endpoint_from_stage
+from docopt import docopt
+
+sys.path.insert(0, ".")
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+
+
+def _normalise_service_name(name):
+    """
+    To be able to safely compare service names. The output is not meant to be human-readable.
+    """
+    return (
+        name.lower()
+        .replace("-", "")
+        .replace(" ", "")
+        .replace("/", ":")
+        .replace(".csv", "")
+    )
+
+
+def get_drafts_for_supplier(supplier_id, api_client):
+    return api_client.find_draft_services_by_framework(
+        "g-cloud-12", supplier_id=supplier_id, status="not-submitted"
+    )["services"]
+
+
+if __name__ == "__main__":
+    args = docopt(__doc__)
+
+    api_client = DataAPIClient(
+        get_api_endpoint_from_stage(args["<stage>"]),
+        get_auth_token("api", args["<stage>"]),
+    )
+
+    with open(args["<phase_file>"]) as phase_file:
+        services = list(csv.DictReader(phase_file))
+
+    suppliers = {service["Supplier ID"] for service in services}
+
+    for supplier_id in suppliers:
+        expected_services = [
+            service for service in services if service["Supplier ID"] == supplier_id
+        ]
+        actual_drafts = get_drafts_for_supplier(supplier_id, api_client)
+
+        for expected_service in expected_services:
+            matching_drafts = [
+                str(draft["id"])
+                for draft in actual_drafts
+                if _normalise_service_name(draft["serviceName"])
+                == _normalise_service_name(expected_service["Service Name"])
+            ]
+
+            expected_service["serviceId"] = ";".join(matching_drafts)
+
+    print([s.get("serviceId") for s in services])
+
+    with open(args["<output_file>"], "w") as output_file:
+        writer = csv.DictWriter(output_file, services[0].keys())
+        writer.writeheader()
+        writer.writerows(services)

--- a/scripts/oneoff/handle_missing_g12_recovery_services.py
+++ b/scripts/oneoff/handle_missing_g12_recovery_services.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""
+Process the output of `get_g12_recovery_services.py`. Create new empty drafts for all services that do not yet have a
+draft.
+
+Usage:
+    scripts/oneoff/handle_missing_g12_recovery_services.py <stage> <input_file> <output_file> [--dry-run]
+"""
+import csv
+import sys
+
+from dmapiclient import DataAPIClient
+from dmutils.env_helpers import get_api_endpoint_from_stage
+from docopt import docopt
+
+sys.path.insert(0, ".")
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.updated_by_helpers import get_user
+
+
+if __name__ == "__main__":
+    args = docopt(__doc__)
+
+    api_client = DataAPIClient(
+        get_api_endpoint_from_stage(args["<stage>"]),
+        get_auth_token("api", args["<stage>"]),
+        user=get_user(),
+    )
+
+    with open(args["<input_file>"]) as input_file:
+        services = list(csv.DictReader(input_file))
+
+    missing_services = [s for s in services if not s["serviceId"]]
+
+    for service in missing_services:
+        name = service["Service Name"].replace(".csv", "")[:100]
+        supplier_id = service["Supplier ID"]
+        lot = {
+            "Software": "cloud-software",
+            "Support": "cloud-support",
+        }.get(service["Lot"])
+
+        if not lot:
+            print(f"No lot for '{name}'/'{service['File Name']}' - {supplier_id}")
+            continue
+
+        if args["--dry-run"]:
+            print(f"Would create '{name}'")
+            continue
+
+        new_draft = api_client.create_new_draft_service(
+            "g-cloud-12", lot, supplier_id, {"serviceName": name}
+        )["services"]
+        print(f"Created '{name}': {new_draft['id']}")
+        service["serviceId"] = str(new_draft["id"])
+
+    print([s.get("serviceId") for s in services])
+
+    with open(args["<output_file>"], "w") as output_file:
+        writer = csv.DictWriter(output_file, services[0].keys())
+        writer.writeheader()
+        writer.writerows(services)

--- a/scripts/oneoff/handle_too_many_g12_recovery_services.py
+++ b/scripts/oneoff/handle_too_many_g12_recovery_services.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""
+Process the output of `get_g12_recovery_services.py`. For services with multiple drafts, choose the one with the most
+completed answers. If there is a tie, the winner will be chosen arbitrarily.
+
+Usage:
+    scripts/oneoff/handle_too_many_g12_recovery_services.py <stage> <input_file> <output_file>
+"""
+import csv
+import sys
+
+from dmapiclient import DataAPIClient
+from dmutils.env_helpers import get_api_endpoint_from_stage
+from docopt import docopt
+
+sys.path.insert(0, ".")
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+
+
+def _count_draft_answers(draft):
+    non_answer_service_key_count = 17
+    return len(draft["services"].keys()) - non_answer_service_key_count
+
+
+def _get_most_complete_draft_id(api_client, draft_ids):
+    drafts = [api_client.get_draft_service(draft_id) for draft_id in draft_ids]
+
+    drafts.sort(key=_count_draft_answers, reverse=True)
+    most_complete = drafts[0]
+    updater = (
+        most_complete["auditEvents"]["user"]
+        if most_complete.get("auditEvents")
+        else "?"
+    )
+    print(
+        f"Choosing '{most_complete['services']['id']}', last updated by '{updater}' "
+        f"with '{_count_draft_answers(most_complete)}' answers"
+    )
+    return most_complete["services"]["id"]
+
+
+if __name__ == "__main__":
+    args = docopt(__doc__)
+
+    api_client = DataAPIClient(
+        get_api_endpoint_from_stage(args["<stage>"]),
+        get_auth_token("api", args["<stage>"]),
+    )
+
+    with open(args["<input_file>"]) as input_file:
+        services = list(csv.DictReader(input_file))
+
+    for service in services:
+        draft_ids = service["serviceId"].split(";")
+
+        if len(draft_ids) <= 1:
+            continue
+
+        service["serviceId"] = str(_get_most_complete_draft_id(api_client, draft_ids))
+
+    print([s.get("serviceId") for s in services])
+
+    with open(args["<output_file>"], "w") as output_file:
+        writer = csv.DictWriter(output_file, services[0].keys())
+        writer.writeheader()
+        writer.writerows(services)


### PR DESCRIPTION
Trello: https://trello.com/c/13Ryt5o5

As part of the G12 recovery, we need a list of the IDs of the recovery drafts. This will allow us to hide irrelevant drafts to avoid confusion.

We have a CSV containing the un-normalised service names. For each, get all drafts for that supplier that have a matching service name when normalised. Output the same CSV with the new data in a new column.

Then create new empty drafts for any missing drafts. This depends on https://github.com/alphagov/digitalmarketplace-api/pull/1083

Some services have multiple drafts, which is not what we want. So choose the draft with the most completed answers.

My plan is to merge this, run the scripts, and then update the G12 recovery spreadsheet with the results.
