### PR TITLE
remove unneeded ubuntu dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Ubuntu packages
-        run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,15 @@ jobs:
 
       - name: Setup Python cache
         uses: actions/cache@v2
+        id: python-cache
         with:
           path: venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: venv-${{ runner.os }}-${{ matrix.python-version }}-
 
       - name: Install dependencies
         run: make requirements-dev
+        if: steps.python-cache.outputs.cache-hit != 'true'
 
       - name: Run tests
         run: make test


### PR DESCRIPTION
Since `lxml` upgrade in #604 we no longer need additional ubuntu dependencies to build against python 3.9.