### PR TITLE
Install awscli in seperate virtual environment to other Python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@ RUN wget --quiet -O /usr/local/bin/docopts.sh https://raw.githubusercontent.com/
     && echo 'd117d3290def71d6a7fdc5b67efddfc3a9299f146bb4f98f96e322222957d1ce /usr/local/bin/docopts.sh' | sha256sum -c - \
     && chmod 0755 /usr/local/bin/docopts.sh
 
+RUN pip install --no-cache-dir --upgrade pip==21.0.1
+
+ENV PATH "/root/.local/bin:$PATH"
+RUN pip install --no-cache-dir pipx \
+    && pipx install --pip-args="--no-cache-dir" awscli==1.19.5 \
+    && pip uninstall -y pipx
+
 ENV APP_DIR /app
 WORKDIR ${APP_DIR}
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,48 +4,126 @@
 #
 #    pip-compile requirements-dev.in
 #
-attrs==19.3.0             # via -c requirements.txt, pytest
-backcall==0.1.0           # via ipython
-certifi==2019.11.28       # via -c requirements.txt, requests
-chardet==3.0.4            # via -c requirements.txt, requests
-click==7.0                # via -c requirements.txt, pip-tools
-cram==0.7                 # via -r requirements-dev.in
-decorator==4.4.1          # via ipython, traitlets
-digitalmarketplace-test-utils==2.8.2  # via -r requirements-dev.in
-entrypoints==0.3          # via flake8
-flake8==3.7.9             # via -r requirements-dev.in
-freezegun==0.3.15         # via -r requirements-dev.in
-idna==2.9                 # via -c requirements.txt, requests
-importlib-metadata==1.5.0  # via -c requirements.txt, pluggy, pytest
-ipython-genutils==0.2.0   # via -r requirements-dev.in, traitlets
-ipython==7.12.0           # via -r requirements-dev.in
-jedi==0.16.0              # via ipython
-lxml==4.6.2               # via -r requirements-dev.in
-mccabe==0.6.1             # via flake8
-mock==3.0.5               # via -r requirements-dev.in
-more-itertools==8.2.0     # via pytest
-packaging==20.1           # via pytest
-parso==0.6.1              # via jedi
-pexpect==4.8.0            # via ipython
-pickleshare==0.7.5        # via ipython
-pip-tools==5.5.0          # via -r requirements-dev.in
-pluggy==0.13.1            # via pytest
-prompt-toolkit==3.0.3     # via ipython
-ptyprocess==0.6.0         # via pexpect
-py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8
-pygments==2.5.2           # via ipython
-pyparsing==2.4.6          # via packaging
-pytest==5.3.5             # via -r requirements-dev.in
-python-dateutil==2.8.1    # via -c requirements.txt, freezegun
-requests-mock==1.7.0      # via -r requirements-dev.in
-requests==2.23.0          # via -c requirements.txt, requests-mock
-six==1.14.0               # via -c requirements.txt, freezegun, mock, packaging, python-dateutil, requests-mock, traitlets
-traitlets==4.3.3          # via ipython
-urllib3==1.25.10          # via -c requirements.txt, requests
-wcwidth==0.1.8            # via prompt-toolkit, pytest
-zipp==3.0.0               # via -c requirements.txt, importlib-metadata
+appnope==0.1.2
+    # via ipython
+attrs==19.3.0
+    # via
+    #   -c requirements.txt
+    #   pytest
+backcall==0.1.0
+    # via ipython
+certifi==2019.11.28
+    # via
+    #   -c requirements.txt
+    #   requests
+chardet==3.0.4
+    # via
+    #   -c requirements.txt
+    #   requests
+click==7.0
+    # via
+    #   -c requirements.txt
+    #   pip-tools
+cram==0.7
+    # via -r requirements-dev.in
+decorator==4.4.1
+    # via
+    #   ipython
+    #   traitlets
+digitalmarketplace-test-utils==2.8.2
+    # via -r requirements-dev.in
+entrypoints==0.3
+    # via flake8
+flake8==3.7.9
+    # via -r requirements-dev.in
+freezegun==0.3.15
+    # via -r requirements-dev.in
+idna==2.9
+    # via
+    #   -c requirements.txt
+    #   requests
+importlib-metadata==1.5.0
+    # via
+    #   -c requirements.txt
+    #   pluggy
+    #   pytest
+ipython-genutils==0.2.0
+    # via
+    #   -r requirements-dev.in
+    #   traitlets
+ipython==7.12.0
+    # via -r requirements-dev.in
+jedi==0.16.0
+    # via ipython
+lxml==4.6.2
+    # via -r requirements-dev.in
+mccabe==0.6.1
+    # via flake8
+mock==3.0.5
+    # via -r requirements-dev.in
+more-itertools==8.2.0
+    # via pytest
+packaging==20.1
+    # via pytest
+parso==0.6.1
+    # via jedi
+pexpect==4.8.0
+    # via ipython
+pickleshare==0.7.5
+    # via ipython
+pip-tools==5.5.0
+    # via -r requirements-dev.in
+pluggy==0.13.1
+    # via pytest
+prompt-toolkit==3.0.3
+    # via ipython
+ptyprocess==0.6.0
+    # via pexpect
+py==1.8.1
+    # via pytest
+pycodestyle==2.5.0
+    # via flake8
+pyflakes==2.1.1
+    # via flake8
+pygments==2.5.2
+    # via ipython
+pyparsing==2.4.6
+    # via packaging
+pytest==5.3.5
+    # via -r requirements-dev.in
+python-dateutil==2.8.1
+    # via
+    #   -c requirements.txt
+    #   freezegun
+requests-mock==1.7.0
+    # via -r requirements-dev.in
+requests==2.23.0
+    # via
+    #   -c requirements.txt
+    #   requests-mock
+six==1.14.0
+    # via
+    #   -c requirements.txt
+    #   freezegun
+    #   mock
+    #   packaging
+    #   python-dateutil
+    #   requests-mock
+    #   traitlets
+traitlets==4.3.3
+    # via ipython
+urllib3==1.25.10
+    # via
+    #   -c requirements.txt
+    #   requests
+wcwidth==0.1.8
+    # via
+    #   prompt-toolkit
+    #   pytest
+zipp==3.0.0
+    # via
+    #   -c requirements.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,6 @@ git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logg
 git+https://github.com/alphagov/digitalmarketplace-utils.git@55.2.1#egg=digitalmarketplace-utils==55.2.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.10.0#egg=digitalmarketplace-apiclient==21.10.0
 
-awscli~=1.18.137
 backoff==1.10.0
 docopt==0.6.2
 jsonschema==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ argcomplete==1.11.1
     # via yq
 attrs==19.3.0
     # via jsonschema
-awscli==1.18.137
-    # via -r requirements.in
 backoff==1.10.0
     # via -r requirements.in
 blinker==1.4
@@ -18,7 +16,6 @@ boto3==1.14.34
     # via digitalmarketplace-utils
 botocore==1.17.60
     # via
-    #   awscli
     #   boto3
     #   s3transfer
 cachelib==0.1.1
@@ -31,8 +28,6 @@ chardet==3.0.4
     # via requests
 click==7.0
     # via flask
-colorama==0.4.3
-    # via awscli
 contextlib2==0.6.0.post1
     # via digitalmarketplace-utils
 cryptography==3.2.1
@@ -52,9 +47,7 @@ docopt==0.6.2
     #   -r requirements.in
     #   notifications-python-client
 docutils==0.15.2
-    # via
-    #   awscli
-    #   botocore
+    # via botocore
 flask-gzip==0.2
     # via digitalmarketplace-utils
 flask-login==0.5.0
@@ -120,8 +113,6 @@ odfpy==1.4.1
     # via digitalmarketplace-utils
 prometheus-client==0.2.0
     # via gds-metrics
-pyasn1==0.4.8
-    # via rsa
 pycparser==2.19
     # via cffi
 pyjwt==1.7.1
@@ -142,7 +133,6 @@ pytz==2019.3
     # via digitalmarketplace-utils
 pyyaml==5.3.1
     # via
-    #   awscli
     #   digitalmarketplace-content-loader
     #   yq
 redis==3.5.3
@@ -153,12 +143,8 @@ requests==2.23.0
     #   digitalmarketplace-utils
     #   mailchimp3
     #   notifications-python-client
-rsa==4.5
-    # via awscli
 s3transfer==0.3.3
-    # via
-    #   awscli
-    #   boto3
+    # via boto3
 six==1.14.0
     # via
     #   cryptography


### PR DESCRIPTION
Currently we have awscli in our requirements files with other Python packages, however this makes upgrading very hard because awscli always requires a specific version of botocore, and this causes lots of depenendency conflicts with boto3. To get around this we instead install awscli into it's own venv with it's own version of botocore using [pipx].

[pipx]: https://pipxproject.github.io/pipx/