### PR TITLE
Add script for G12 recovery reminder

### DIFF
--- a/scripts/oneoff/send_g12_recovery_reminder_for_suppliers.py
+++ b/scripts/oneoff/send_g12_recovery_reminder_for_suppliers.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""
+Inform suppliers involved in the G12 recovery that the process closes soon.
+
+Usage:
+    scripts/oneoff/send_g12_recovery_reminder_for_suppliers.py <stage> <notify_api_key> [--dry-run]
+
+Parameters:
+    <stage>                     Environment to run script against.
+    <notify_api_key>            API key for GOV.UK Notify.
+
+Options:
+    -n, --dry-run               Run script without sending emails.
+    -h, --help                  Show this screen.
+
+Before running this script, ensure that the list of suppliers in the credentials is correct.
+"""
+
+import sys
+
+from dmapiclient import DataAPIClient
+from dmutils.email.helpers import hash_string
+from dmutils.env_helpers import get_api_endpoint_from_stage
+from docopt import docopt
+
+sys.path.insert(0, ".")
+
+from dmscripts.helpers import logging_helpers
+from dmscripts.helpers.auth_helpers import get_g12_suppliers, get_auth_token
+from dmscripts.helpers.email_helpers import scripts_notify_client
+from dmscripts.helpers.supplier_data_helpers import get_email_addresses_for_supplier
+
+NOTIFY_TEMPLATE_ID = "6cc94b27-e4d7-49e3-b100-8ac349c97d04"
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    stage = arguments["<stage>"]
+    dry_run = arguments["--dry-run"]
+    notify_api_key = arguments["<notify_api_key>"]
+
+    logger = logging_helpers.configure_logger()
+    mail_client = scripts_notify_client(notify_api_key, logger=logger)
+    api_client = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(stage),
+        auth_token=get_auth_token("api", stage),
+    )
+
+    user_emails = [
+        supplier_user
+        for supplier_id in get_g12_suppliers(stage)
+        for supplier_user in get_email_addresses_for_supplier(api_client, supplier_id)
+    ]
+
+    user_count = len(user_emails)
+    prefix = "[Dry Run] " if dry_run else ""
+    for count, email in enumerate(user_emails, start=1):
+        logger.info(
+            f"{prefix}Sending email to supplier user {count} of {user_count}: {hash_string(email)}"
+        )
+        if not dry_run:
+            mail_client.send_email(
+                to_email_address=email,
+                template_name_or_id=NOTIFY_TEMPLATE_ID,
+                personalisation={
+                    "framework_name": "G-Cloud 12",
+                    "applicationsCloseAt_datetimeformat": "2pm on 25 February 2021",
+                    "framework_dashboard_url":
+                        "https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-12/all-services",
+                }
+            )


### PR DESCRIPTION
Trello: https://trello.com/c/M8EeBspq

We're going to send a reminder to the suppliers involved in the recovery. It closes tomorrow at 2pm, and many suppliers have not yet marked their services as complete. Create a script to send this email, copying from open_g12_recovery_for_suppliers.py, which was very similar.

Uses the Notify template (https://www.notifications.service.gov.uk/services/95316ff0-e555-462d-a6e7-95d26fbfd091/templates/6cc94b27-e4d7-49e3-b100-8ac349c97d04). Copied from Nora's agreed draft.

## What it looks like

Subject: "Reminder: complete your G-Cloud 12 services by 2pm on 25 February 2021"

![image](https://user-images.githubusercontent.com/15256121/109026222-6de8d400-76b7-11eb-9661-fb317ba5bb55.png)
