### PR TITLE
Only error if all emails invalid

### DIFF
--- a/dmscripts/notify_suppliers_of_awarded_briefs.py
+++ b/dmscripts/notify_suppliers_of_awarded_briefs.py
@@ -55,20 +55,19 @@ def _build_and_send_emails(brief_responses, mail_client, stage, dry_run, templat
 
     # Now email everyone whose Brief got awarded
     for brief_response in brief_responses:
-        # Although we don't officially support it, in some cases users
-        # have multiple email addresses in their respondToEmailAddress field
         email_addresses = get_email_addresses(brief_response["respondToEmailAddress"])
 
+        # Users can enter multiple email addresses, but our input validation is very basic. So it's OK if some of the
+        # addresses are invalid, as long as there is at least one valid address.
         invalid_email_addresses = [a for a in email_addresses if not validate_email_address(a)]
         if invalid_email_addresses:
-            logger.error(
+            logger.warning(
                 "Invalid email address(es) for BriefResponse {brief_response_id} (Brief ID {brief_id})",
                 extra={
                     "brief_id": brief_response['brief']['id'],
                     "brief_response_id": brief_response['id'],
                 }
             )
-            failed_brief_responses.append(brief_response['id'])
 
         for invalid_email_address in invalid_email_addresses:
             email_addresses.remove(invalid_email_address)


### PR DESCRIPTION
I think the previous behaviour was probably wrong. We do officially support multiple email addresses in this field - the hint text is "You can add more than one email address. Use a comma between each email address."

Users sometimes enter things that aren't emails - for instance names or URLs. This happens quite commonly - I've seen [4 such awarded brief responses in the past month](https://ci.marketplace.team/job/notify-suppliers-of-awarded-briefs-production/).

In no cases have we taken any action as a result of only some of the email addresses being invalid. So I don't think it's useful to fail the script in this case. Instead, downgrade to a warning. We will still error if there is no valid email address.

I've raised a story to improve our input validation: https://trello.com/c/Yld4r8Px/2178-users-can-enter-invalid-email-addresses