### PR TITLE
Escape dictionary for logging

### DIFF
--- a/dmscripts/publish_draft_services.py
+++ b/dmscripts/publish_draft_services.py
@@ -102,7 +102,7 @@ def copy_draft_documents(
             "supplier %s: draft %s: dry run: skipped updating document URLs: %s",
             draft_service["supplierId"],
             draft_service['id'],
-            document_updates,
+            str(document_updates).replace("{", "{{").replace("}", "}}"),
         )
     else:
         client.update_service(service_id, document_updates, user='publish_draft_services.py')


### PR DESCRIPTION
It needs to be escaped, otherwise CustomLogFormatter tries to double-format it. This is harmless, but it does produce an extra log message: https://github.com/alphagov/digitalmarketplace-utils/commit/d4a0591962d613cdb7f1a3c7fe995bb4f9bab233

Escape the dictionary to reduce the log spam.