### PR TITLE
Replace make with invoke

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,3 +12,4 @@ max-line-length = 120
 per-file-ignores =
     scripts/** : E402
     scripts/get-model-data.py : E402, C901
+    tasks.py: F401

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,12 @@ jobs:
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
           restore-keys: venv-${{ runner.os }}-${{ matrix.python-version }}-
 
+      - name: Install developer tools
+        run: make bootstrap
+
       - name: Install dependencies
-        run: make requirements-dev
+        run: invoke requirements-dev
         if: steps.python-cache.outputs.cache-hit != 'true'
 
       - name: Run tests
-        run: make test
+        run: invoke test

--- a/Makefile
+++ b/Makefile
@@ -1,51 +1,21 @@
-SHELL := /bin/bash
-VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
-.PHONY: virtualenv
-virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
+.DEFAULT_GOAL := bootstrap
 
-.PHONY: upgrade-pip
-upgrade-pip: virtualenv
-	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip
+%:
+	-@[ -z "$$TERM" ] || tput setaf 1  # red
+	@>&2 echo warning: calling '`make`' is being deprecated in this repo, you should use '`invoke` (https://pyinvoke.org)' instead.
+	-@[ -z "$$TERM" ] || tput setaf 9  # default
+	@# pass goals to '`invoke`'
+	invoke $(or $(MAKECMDGOALS), $@)
+	@exit
 
-.PHONY: requirements
-requirements: virtualenv upgrade-pip requirements.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
+help:
+	invoke --list
 
-.PHONY: requirements-dev
-requirements-dev: virtualenv upgrade-pip requirements.txt requirements-dev.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt -r requirements-dev.txt
-
-.PHONY: freeze-requirements
-freeze-requirements: virtualenv requirements-dev requirements.in requirements-dev.in
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements.in
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements-dev.in
-
-.PHONY: test
-test: test-flake8 test-unit
-
-.PHONY: test-flake8
-test-flake8: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/flake8 .
-
-.PHONY: test-unit
-test-unit: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
-
-.PHONY: functional-tests
-functional-tests: virtualenv requirements-dev
-	./functional-tests/setup.sh
-	${VIRTUALENV_ROOT}/bin/cram -v functional-tests/
-
-.PHONY: docker-build
-docker-build:
-	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
-	@echo "Building a docker image for ${RELEASE_NAME}..."
-	docker build -t digitalmarketplace/scripts --build-arg release_name=${RELEASE_NAME} .
-	docker tag digitalmarketplace/scripts digitalmarketplace/scripts:${RELEASE_NAME}
-
-.PHONY: docker-push
-docker-push:
-	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
-	docker push digitalmarketplace/scripts:${RELEASE_NAME}
+.PHONY: bootstrap
+bootstrap:
+	pip install digitalmarketplace-developer-tools
+	@echo done
+	-@[ -z "$$TERM" ] || tput setaf 2  # green
+	@>&2 echo dmdevtools has been installed globally, run developer tasks with '`invoke`'
+	-@[ -z "$$TERM" ] || tput setaf 9  # default

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,15 @@
+from invoke import task
+
+from dmdevtools.invoke_tasks import library_tasks as ns
+from dmdevtools.invoke_tasks import docker_build, docker_push
+
+
+@task(ns["virtualenv"], ns["requirements-dev"])
+def functional_tests(c):
+    c.run("./functional-tests/setup.sh")
+    c.run("cram -v functional-tests/")
+
+
+ns.add_task(docker_build)
+ns.add_task(docker_push)
+ns.add_task(functional_tests)


### PR DESCRIPTION
We want to be able to reduce duplication of code across our repos; one of the places we have a lot of duplicated code is in our Makefiles; all of our repos have very similar Makefiles with small historical differences.

This commit replaces Make with invoke, using the tasks from alphagov/digitalmarketplace-developer-tools.