### PR TITLE
Add email engine framework for writing scripts that send emails

### DIFF
--- a/dmscripts/email_engine/__init__.py
+++ b/dmscripts/email_engine/__init__.py
@@ -19,8 +19,14 @@ default it is saved in the `tmp` folder where it shouldn't stick around for
 more than a week.
 
 All emails sent with email_engine will have the same Notify reference; by
-default (see email_engine.cli) this is the name of the script (sys.argv[0]).
-The reference is also used as the name of the logfile by default.
+default (see email_engine.cli) this is the name of the script. Alternatively,
+you can override the reference with a command line argument. The reference is
+also used as the name of the logfile by default.
+
+A hash of the command line arguments is always appended to the reference,
+whether provided on the command line or not. This means running the same script
+with the same arguments will always have the same hash, but the same script
+with different arguments will have a slightly different reference.
 
 How to use as a script runner
 -----------------------------

--- a/dmscripts/email_engine/__init__.py
+++ b/dmscripts/email_engine/__init__.py
@@ -37,7 +37,11 @@ to; this can be supplied using the DM_ENVIRONMENT environment variable, or the
 --stage command line flag.
 
 Both the reference and the logfile path can be overridden at the command line,
-with the `--reference` and `--logfile` flags.
+with the `--reference` and `--logfile` flags. This could be useful for a server
+that runs email scripts unsupervised (i.e. Jenkins); the reference could be a
+job parameter that by default is the name of the job and the date, and the
+logfile could be located in a directory that is preserved between runs. Then
+re-running a job with the same parameters would resume the previous run.
 
 How to use as a script writer
 -----------------------------

--- a/dmscripts/email_engine/__init__.py
+++ b/dmscripts/email_engine/__init__.py
@@ -1,0 +1,216 @@
+"""Framework for sending emails from scripts via Notify
+
+This module aims to reduce a lot of the boilerplate involved in writing a
+script that sends a batch of emails using Notify.
+
+It handles
+
+    - most command line arguments
+    - logging
+    - recovery/resume after failures
+    - sending requests to Notify
+
+The theory is that the email script logs notifications to be sent to a log
+file, so that if the script fails partway through it can read the logfile and
+pick up where it left off.
+
+Note that this log will contain Personally Identifiable Information, so by
+default it is saved in the `tmp` folder where it shouldn't stick around for
+more than a week.
+
+All emails sent with email_engine will have the same Notify reference; by
+default (see email_engine.cli) this is the name of the script (sys.argv[0]).
+The reference is also used as the name of the logfile by default.
+
+How to use as a script runner
+-----------------------------
+
+For each script the command line arguments will vary slightly, but some
+arguments will be common to all and enforced by `email_engine.cli`.
+
+Sending notifications via Notify requires a Notify API key; this can be
+supplied either using the DM_NOTIFY_API_KEY environment variable, or the
+--notify-api-key command line flag.
+
+Normally a script will also need to know which environment to make API calls
+to; this can be supplied using the DM_ENVIRONMENT environment variable, or the
+--stage command line flag.
+
+Both the reference and the logfile path can be overridden at the command line,
+with the `--reference` and `--logfile` flags.
+
+How to use as a script writer
+-----------------------------
+
+For the developer writing a script, the only function you *need* from this
+module is `email_engine()`; given a generator that yields dictionaries with
+details of notifications to send, it will take care of the rest::
+
+    from dmapiclient import DataAPIClient
+    from dmscripts.email_engine import email_engine
+
+    def notifications(stage, **kwargs):
+        # generate emails to be sent by calling the DMp API
+        # and email_engine will deal with sending them for you
+        data_api_client = DataAPIClient.from_stage(stage)
+        for ... in data_api_client.find_some_iter(...):
+            yield {
+                "email_address": ...,
+                "template_id": ...,
+                "personalisation": ...
+            }
+
+    if __name__ == "__main__":
+        email_engine(notifications)
+
+The email_engine package knows about common options that a generator might
+need, such as the DMp environment to connect the API client to, and will call
+the generator with all of those options as keyword arguments. See the `cli`
+module in this package for details on what options are available.
+
+You can override some defaults by adding keyword arguments to the
+`email_engine()` call; for instance, if you want to use a different string for
+the default reference and require the script runner to provide a template ID on
+the command line, you can call::
+
+    email_engine(
+        notifications,
+        reference="my-reference",
+        notify_template_id_required=True
+    )
+
+As a script writer, if you need to add command line arguments that aren't
+included by default or aren't used by any other scripts, you can customise the
+argument parser before `email_engine()` uses it::
+
+    from dmapiclient import DataAPIClient
+    from dmscripts.email_engine import argument_parser_factory, email_engine
+
+    def notifications(stage, **kwargs):
+        ...
+
+    if __name__ == "__main__":
+        arg_parser = argument_parser_factory()
+        arg_parser.add_argument(...)
+        args = arg_parser.parse_args()
+        email_engine(notifications, args=args)
+
+See scripts/notify-suppliers-of-awarded-briefs.py for a more detailed example.
+
+For more complicated scenarios you can also start the generator yourself::
+
+    from dmapiclient import DataAPIClient
+    from dmscripts.email_engine import argument_parser_factory, email_engine
+
+    def notifications(stage, **kwargs):
+        ...
+
+    if __name__ == "__main__":
+        arg_parser = argument_parser_factory()
+        arg_parser.add_argument(...)
+        args = arg_parser.parse_args()
+        email_engine(
+            notifications(args.stage, some_other_global),
+            args=args
+        )
+"""
+from pathlib import Path
+import argparse
+import logging
+
+from notifications_python_client.notifications import NotificationsAPIClient
+
+from dmscripts.helpers.logging_helpers import configure_logger
+
+from .cli import argument_parser_factory
+from .typing import EmailNotification, NotificationResponse, Notifications
+from .logger import STATE, logger
+from .queue import run
+
+
+def email_engine(
+    notifications: Notifications,
+    *,
+    args: argparse.Namespace = None,
+    **kwargs,
+):
+    """Send emails via Notify
+
+    Send emails produced by generator function `notifications` and log progress to disk.
+    If interrupted `email_engine()` has the ability to resume by reading its own log file.
+
+    Any keyword arguments are passed to `argument_parser_factory()`, so the
+    command line can be simply customised. For instance, to override the default reference,
+    you can use `email_engine(notifications, reference="my-reference")`.
+
+    :param notifications: a generator that yields `EmailNotification`s to send
+    :param args: parsed command line arguments, if not provided email_engine.cli will be used to parse sys.argv
+    """
+
+    if args is None:
+        # get the configuration from the command line arguments
+        args = argument_parser_factory(**kwargs).parse_args()
+
+    reference: str = args.reference
+    logfile: Path = args.logfile
+
+    # configure logging
+    #
+    loglevel = logging.INFO if args.verbose else logging.WARN
+    configure_logger({"dmapiclient": loglevel})
+
+    # We add the logfile handler to the root logger so all useful information
+    # will be captured to the file.
+    #
+    root_logger = logging.getLogger()
+    log_handler = logging.FileHandler(logfile)
+    root_logger.addHandler(log_handler)
+    root_logger.setLevel(STATE)
+    #
+    # Note: you might notice that in a log file there are log messages with
+    # un-interpolated format strings, for example you might see:
+    #
+    #     {api_method} request on {api_url} finished in {api_time}
+    #
+    # On seeing this you might think, oh, I need to add CustomLogFormatter to
+    # the log handler. Well guess what: you can't. Doing so would mean that all
+    # of our state messages with dictionaries using curly braces will try and
+    # be formatted as if they were referencing fields, and that will fail, and
+    # then you will just get an error message saying `failed to format log
+    # message`. So don't do that.
+
+    # prepare the state, call the generator (if not already called) with the
+    # command line arguments as keyword arguments
+    if callable(notifications):
+        notifications = notifications(**vars(args))
+
+    notify_client = NotificationsAPIClient(args.notify_api_key)
+
+    if args.dry_run:
+
+        def send_email_notification(
+            notification: EmailNotification,
+        ) -> NotificationResponse:
+            logger.info(f"[DRY-RUN] would send email notification {notification}")
+            return NotificationResponse()
+
+    else:
+
+        def send_email_notification(
+            notification: EmailNotification,
+        ) -> NotificationResponse:
+            # note that all notifications will have the same reference
+            return notify_client.send_email_notification(
+                **notification,
+                reference=reference,
+            )
+
+    try:
+        # do the thing
+        done = run(
+            send_email_notification, notifications=notifications, logfile=logfile
+        )
+    except KeyboardInterrupt:
+        logger.critical("email engine interrupted by user")
+
+    logger.info(f"sent {len(done)} email notifications with reference {reference}")

--- a/dmscripts/email_engine/cli.py
+++ b/dmscripts/email_engine/cli.py
@@ -1,0 +1,159 @@
+"""Standard command line arguments for an email script
+
+For notes on how this module works for a user running a script, have a look at
+the docstring for the email_engine module.
+
+Scripts that send emails tend to have a lot of options in common; this module
+gathers them together to reduce repetition and increase consistency.
+
+The main function is `argument_parser_factory()`: it takes a bunch of keyword
+arguments that configure how the command line will appear. It returns a
+subclass of `argparse.ArgumentParser`, so you can configure the command line
+more if necessary before parsing args.
+
+For some command line options, we want to allow values to be supplied by
+environment variable as well as a flag; the `EnvDefaultAction` class supports
+this.
+
+Running this module will show the default command line arguments::
+    python dmscripts/email_engine/cli.py
+"""
+from pathlib import Path
+import argparse
+import os
+import sys
+
+
+__all__ = ["argument_parser_factory"]
+
+
+def argument_parser_factory(
+    *,
+    reference: str = None,
+    logfile: Path = None,
+    **kwargs
+) -> argparse.ArgumentParser:
+    """Create an ArgumentParser to read options for an email script
+
+    Feel free to add command line arguments to this function, you may want to
+    put them behind a kwarg flag if they are not needed for all scripts.
+    Remember to document them here so that script writers know about them, you
+    can avoid duplication by not adding them to the function signature though.
+
+    :param reference: default reference if none is supplied at command line,
+        if None the script name will be used
+    :param logfile: default path to the logfile if none is supplied at command line,
+        if None /tmp/<reference>.log will be used
+
+    :param description: Text to display before the argument help
+    :param epilog: Text to display after the argument help
+
+    :param stage_required: If true then parser will raise an exception if stage
+        cannot be found from the environment or command line (default: true).
+    :param notify_api_key_required: If true then parser will raise an exception
+        if a Notify API key cannot be found from the environment or command line
+        (default: true).
+    :param notify_template_id_required: Some scripts may expect to a template
+        ID be supplied on the command line, rather than have it hardcoded. If
+        notify_template_id_required is true then the command line arguments will
+        include a required flag to specify the template ID (default: false).
+    """
+
+    p = _ArgumentParser(
+        description=kwargs.get("description"),
+        epilog=kwargs.get("epilog"),
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    p.add_argument(
+        "-n", "--dry-run", action="store_true", help="Do not send notifications."
+    )
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print more detail about what the script is doing.",
+    )
+
+    p.add_argument(
+        "--stage",
+        action=EnvDefault,
+        choices=["local", "preview", "staging", "production"],
+        envvar="DM_ENVIRONMENT",
+        help="Stage/environment to make API calls to. Can also be set with environment variable DM_ENVIRONMENT.",
+        required=kwargs.get("stage_required", True),
+    )
+
+    if kwargs.get("notify_template_id_required") is True:
+        p.add_argument(
+            "--notify-template-id",
+            help="Notify template ID for notifications.",
+            required=True,
+        )
+
+    p.add_argument(
+        "--notify-api-key",
+        action=EnvDefault,
+        envvar="DM_NOTIFY_API_KEY",
+        help="Can also be set with environment variable DM_NOTIFY_API_KEY.",
+        required=kwargs.get("notify_api_key_required", True),
+    )
+
+    p.add_argument(
+        "--reference",
+        default=reference or Path(sys.argv[0]).stem,
+        help=(
+            "Identifer to reference all the emails sent by this script (sent to Notify)."
+            " Defaults to the name of the script."
+        ),
+    )
+
+    # As this log will contain PII, we want to make sure it doesn't sit on
+    # a developers drive for too long, however, we do need to be able to
+    # find the logs again for resuming a run or for audit purposes.
+    #
+    # So for a default we just go ahead and assume that there is a /tmp folder,
+    # which is true everywhere except Windows.
+    p.add_argument(
+        "--logfile",
+        # the handling of this argument is a little special, see _ArgumentParser
+        default=logfile or "/tmp/{reference}.log",
+        help=(
+            "File where log messages will be saved so that the script can resume if interrupted."
+            " By default logs are saved in the system tmp folder with the name of the script."
+        ),
+    )
+
+    return p
+
+
+# copied from https://stackoverflow.com/a/10551190
+class EnvDefault(argparse.Action):
+    def __init__(self, envvar, required=True, default=None, **kwargs):
+        if not default and envvar:
+            if envvar in os.environ:
+                default = os.environ[envvar]
+        if required and default:
+            required = False
+        super(EnvDefault, self).__init__(default=default, required=required, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+
+
+# We subclass `argparse.ArgumentParser` to add a small bit of specialised
+# functionality; we want the logfile to default to a file with the same name as
+# the reference, but we won't know the reference until all the arguments are
+# parsed; the only way I could find to achieve this is to tweak `parse_args()`.
+#
+class _ArgumentParser(argparse.ArgumentParser):
+    def parse_known_args(self, args=None, namespace=None):
+        namespace, args = super().parse_known_args(args, namespace)
+        if isinstance(namespace.logfile, str) and "{reference}" in namespace.logfile:
+            namespace.logfile = namespace.logfile.format(reference=namespace.reference)
+        namespace.logfile = Path(namespace.logfile)
+        return namespace, args
+
+
+if __name__ == "__main__":
+    argument_parser_factory().parse_args(["--help"])

--- a/dmscripts/email_engine/logger.py
+++ b/dmscripts/email_engine/logger.py
@@ -1,0 +1,40 @@
+"""Shared loggers for email_engine package
+
+We want to ensure that certain log messages (state updates for a
+email_engine.LoggingQueue) always reach the root logger.
+
+This module creates a new log level STATE and a `state_logger` with a method
+`state()` to log messages at that level. That logger is attached directly to
+the root logger, so if the root logger level is STATE or higher and has a
+handler attached then state updates will be logged (currently this is the
+responsibility of email_engine.email_engine). We do this because we also want
+to have ancillary information about the script execution in the log file
+alongside the state updates; this will aid debugging issues in future.
+
+We also create `logger` attached to the usual dmscripts logger for logging to
+stderr for messages that are not state updates.
+"""
+
+import logging
+
+
+# define a new log level for logging queue log levels
+# not as high as INFO, but not as low as DEBUG
+STATE = 15
+
+
+logging.addLevelName(STATE, "STATE")
+
+
+class StateLogger(logging.LoggerAdapter):
+    def __init__(self, logger: logging.Logger):
+        super().__init__(logger, {})
+
+    def state(self, msg, *args, **kwargs) -> None:
+        self.log(STATE, msg, *args, **kwargs)
+
+
+logger = logging.getLogger("script.email_engine")
+state_logger = StateLogger(logging.getLogger("email_engine_audit_logger"))
+
+state_logger.setLevel(STATE)

--- a/dmscripts/email_engine/queue.py
+++ b/dmscripts/email_engine/queue.py
@@ -1,0 +1,301 @@
+"""Takes a source of notifications to be sent and logs sending them so we can
+easily re-run if something breaks
+
+This module mainly exists to seperate the process logic from outputs and
+inputs, so we can unit test the logic. It shouldn't be used outside of
+EmailEngine or tests. It doesn't handle anything that interacts with the
+outside world (except logging), and takes more generic types.
+
+Most of the work happens in this module happens in the `run()` function. You
+really shouldn't use the LoggingQueue class outside of run() and tests.
+Creating a LoggingQueue doesn't do much.
+
+Design notes
+------------
+
+This code is designed specifically for the email_engine use case, so it is less
+generic than it perhaps could be.
+
+Currently this module doesn't do error handling or recovery, or allow for any
+concurrency. Whether or not this module should handle those things is an open
+question.
+
+At the moment there is also an implicit state machine whose logic is shared
+between LoggingQueue and run(). LoggingQueue could probably be tweaked to make
+it clearer that, for instance, you shouldn't put notifications in the queue
+after resuming from a logfile, but rather than spending a lot of time thinking
+about the best API design I just decided to encapsulate it in the run()
+function.  With some more thought perhaps the LoggingQueue could be made to
+enforce the state logic itself.
+"""
+
+from collections import deque
+from pathlib import Path
+from typing import (
+    Callable,
+    Dict,
+    Deque,
+    Iterable,
+    Tuple,
+)
+import sys
+
+from .typing import EmailNotification, NotificationResponse
+from .logger import logger, state_logger
+
+
+def run(
+    send_email_notification: Callable[[EmailNotification], NotificationResponse],
+    *,
+    notifications: Iterable[EmailNotification],
+    logfile: Path,
+) -> Dict[EmailNotification, NotificationResponse]:
+    """Send notifications using `send_email_notification`
+
+    Reads email notifications from `notifications`, then sends them using
+    `send_email_notification`. When a notification is read from the iterable it
+    is logged, and when a notification is sent it is again logged.
+
+    Progress is logged using the built-in logging module; `logfile` should be
+    attached to a file handler so that the state is saved to disk.
+
+    If `logfile` contains logging messages from a previous call, then
+    `notifications` will be discarded without being iterated. This should mean
+    that this function is idempotent.
+    """
+    queue = LoggingQueue()
+
+    resuming, exhausted = queue.put_from_logfile(logfile)
+
+    # If you are doing a a re-run and the iterator of notifications in the
+    # original run was exhausted, then we don't iterate again.
+    #
+    # If the notifications are being output by a generator (and they should
+    # be) then this has some nice side-effects:
+    #
+    # 1. runs are deterministic, you always know the same people will be emailed
+    # 2. re-runs don't need to make API calls to DMp and so are faster
+    # 3. you can make the generator non-idempotent if you really want to
+    #
+    # The downside is how do you handle the scenario where the original
+    # generator wasn't exhausted... for now we just crash.
+    if resuming and not queue.todo:
+        logger.info("nothing left to do! exiting")
+        sys.exit(0)
+
+    elif queue.todo and exhausted:
+        # throw the generator away
+        logger.info("resuming from log file")
+        del notifications
+
+    elif queue.todo and not exhausted:
+        # not sure what to do in this situation, maybe in future we can add a flag to proceed anyway
+        raise RuntimeError(
+            "in the logs for the original run the notifications generator was not exhausted, refusing to proceed"
+        )
+
+    elif not resuming:
+        state_logger.info("OFFICIAL SENSITIVE - do not distribute - this file contains email addresses and other PII")
+        logger.info("getting notifications to send from API")
+        queue.put_from(notifications)
+
+    else:
+        # this should never be reached
+        assert True, "non-exhaustive if-else statement"
+
+    # main loop
+    # this could probably be asynchronous
+    try:
+        while queue.todo:
+            queue.send_next(send_email_notification)
+    except Exception as e:
+        # we want to log how many are left to send
+        logger.warning(
+            f"sending emails was stopped by {e.__class__.__name__} with {len(queue.todo)} notifications left to send"
+        )
+        raise
+
+    return queue.done
+
+
+class LoggingQueue:
+    """Queue that streams state to logs and can be recreated from logs
+
+    Thread-safety
+    -------------
+
+    Sending is (probably) currently thread-safe because of the design of
+    `send_next()` (but it has not been proven to be so). Because we need to log
+    when the notification has been sent (and we want to log the API response),
+    rather than letting users get a notification from the queue and then
+    requiring them to give us the response, we just ask them to give us the
+    callable they would use anyway. This does means that the interface for
+    LoggingQueue is a bit more `concurrent.futures.Executor` than
+    `queue.Queue`, but it makes things simpler in the end.
+
+    Putting is currently not thread-safe, because the de-duplication can cause
+    a race condition. This could be fixed with a lock, or (better) by
+    using different primitives, or (best) maybe by not allowing putting at all.
+    """
+
+    send_msg = "queue update: send notification {notification} response {response}"
+    put_msg = "queue update: queued notification {notification}"
+    put_from_msg = (
+        "queue update: generator is exhausted, read {count} notifications into queue"
+    )
+
+    def __init__(self) -> None:
+        self.todo: Deque[EmailNotification] = deque()
+        self.done: Dict[EmailNotification, NotificationResponse] = {}
+
+    def __contains__(self, notification: EmailNotification) -> bool:
+        """Return true if `notification` has been queued or sent"""
+        return notification in self.todo or notification in self.done
+
+    def put(self, notification: EmailNotification, *, log=True) -> None:
+        """Put `notification` into the queue
+
+        Logs `repr(notification)` when it is added to the queue if `log` is
+        true. If `notification` has already been queued or sent, does nothing.
+        """
+
+        # TODO: make this thread-safe
+        if notification in self:
+            logger.warning(f"ignoring duplicate notification {notification}")
+            return
+
+        self.todo.append(notification)
+
+        if log:
+            state_logger.state(self.put_msg.format(notification=notification))
+
+    def send_next(
+        self,
+        send_email_notification: Callable[[EmailNotification], NotificationResponse],
+    ) -> None:
+        """Send the next notification in the queue
+
+        Calls `send_email_notification()` with the next notification in the
+        queue and logs the result of the call.
+        """
+
+        # TODO: this should be thread-safe, test that it is
+        notification = self.todo.popleft()
+        logger.debug(f"popping notification {notification} to send it")
+        assert notification not in self, "duplicate notification in queue"
+
+        response = send_email_notification(notification)
+
+        state_logger.state(self.send_msg.format(notification=notification, response=response))
+
+        self.done[notification] = response
+
+    def put_from(self, notifications: Iterable[EmailNotification]) -> int:
+        """Put notifications from the iterable into the queue
+
+        :returns: the number of notifications added to the queue
+        """
+        count = 0
+        for notification in notifications:
+            # TODO: this is a hack to allow a plain dict
+            # it can be removed with a postional only arg
+            # in EmailNotification.__init__
+            # when on Python 3.8
+            self.put(EmailNotification(**notification))
+            count += 1
+        state_logger.state(self.put_from_msg.format(generator=notifications, count=count))
+        return count
+
+    def put_from_logfile(self, f: Path) -> Tuple[int, bool]:
+        """Reload queue from log file `f`
+
+        If the log file contains log messages from a `LoggingQueue` then try
+        and recreate the state based on the log messages.
+
+        This function returns two values. The first is the number of
+        notifications added to the queue (but not the number of notifications
+        outstanding!). It is mainly useful to be able to tell whether there was
+        a previous run in the log file or not. The second is a bool that
+        indicates whether the previous queue had been interrupted while adding
+        notifications from an iterable with `put_from()`; if the second return
+        value is false then that means that whatever was adding notifications
+        to the queue wasn't finished doing so.
+
+        :returns: the number of notifications added to the queue and whether
+                  the previous had completed all `put_from()` calls successfully
+        """
+        # we read the whole file into memory at once to avoid reading our own tail
+        loglines = f.read_text().splitlines()
+        if not loglines:
+            return 0, False
+        logger.info(f"logging queue reading from logfile {f}")
+        return self._read_log(loglines)
+
+    def _read_log(self, logstream: Iterable[str]) -> Tuple[int, bool]:
+        count = 0
+        line_count = 0
+        exhausted = False
+
+        # this is a hand-crafted parser for log lines
+        # maybe it could be generated from the format spec?
+        for logline in logstream:
+            # ignore lines that don't begin with the magic words
+            # (modulo any prefixes from logging)
+            magic_words = "queue update: "
+            if magic_words not in logline:
+                continue
+
+            update = logline[logline.find(magic_words) + len(magic_words):]
+
+            if update.startswith("queued"):
+                notification = EmailNotification.from_str(
+                    update[len("queued notification "):]
+                )
+                self.put(notification, log=False)
+                count += 1
+            elif update.startswith("send"):
+                # this will probably break if notification personalisation
+                # contains the word "response"
+                notification = EmailNotification.from_str(
+                    update[len("send notification "):update.find(" response ")]
+                )
+                response = NotificationResponse.from_str(
+                    update[update.find(" response ") + len(" response "):]
+                )
+
+                if notification not in self.todo:
+                    raise RuntimeError(
+                        f"log is invalid, notification {notification} was sent before it was queued"
+                    )
+
+                self.todo.remove(notification)
+                self.done[notification] = response
+            elif update.startswith("generator is exhausted"):
+                exhausted = True
+                original_count = int(
+                    update[
+                        len("generator is exhausted, read "):
+                        update.find("notifications")
+                    ]
+                )
+                assert original_count == len(self.todo) + 2 * len(
+                    self.done
+                ), "number of log lines parsed does not match number of notifications originally queued"
+            else:
+                raise RuntimeError(f"unable to parse log line {logline}")
+
+            line_count += 1
+
+        assert (
+            line_count == len(self.todo) + 2 * len(self.done) + exhausted
+        ), "number of log lines parsed does not match number of notifications queued"
+
+        if line_count:
+            logger.debug(
+                f"logging queue read {line_count} log lines"
+            )
+            logger.info(
+                f"queue has {len(self.todo)} notifications outstanding and {len(self.done)} already sent"
+            )
+
+        return count, exhausted

--- a/dmscripts/email_engine/typing.py
+++ b/dmscripts/email_engine/typing.py
@@ -1,0 +1,74 @@
+"""Types and classes for typing Notify calls
+
+We want to be able to use static typing on email_engine so that coding mistakes
+can be caught before run time.
+
+Also, we create some classes to help with saving a notification to a file and
+reading it back into memory in a human readable fashion.
+"""
+
+from ast import literal_eval
+from typing import Callable, Dict, Generator, Union
+
+
+class EmailNotification(dict):
+    """A typed, hashable, serder-able, frozen dict subclass
+
+    This class packages the arguments to to
+    NotificationsAPIClient.send_email_notification()
+
+    It supports the following behaviours we need to support email_engine
+    functionality:
+
+        - compare two notifications to remove duplicates
+        - allow using notifications as keys to a dictionary
+        - write and read a human-readable string representation
+    """
+
+    def __init__(
+        self,
+        *,
+        email_address: str,
+        template_id: str,
+        personalisation: Dict[str, str] = None
+    ):
+        super().__init__(
+            email_address=email_address,
+            template_id=template_id,
+            personalisation=personalisation,
+        )
+
+    def __setitem__(self, key: str, value: str) -> None:
+        raise RuntimeError("EmailNotification instances are frozen")
+
+    def __hash__(self) -> int:  # type: ignore[override]  # noqa: F821
+        # dicts are usually unhashable, but we want to use EmailNotifications
+        # as the key to another dict, so we cheat and find the hash of the
+        # string representation. The order of keys is going to be important for
+        # this, so we make it explicit
+        return (
+            dict(
+                email_address=self["email_address"],
+                template_id=self["template_id"],
+                personalisation=self["personalisation"],
+            )
+            .__repr__()
+            .__hash__()
+        )
+
+    @classmethod
+    def from_str(cls, s: str) -> "EmailNotification":
+        """Parse a dict literal representation of a notification"""
+        return cls(**literal_eval(s))
+
+
+class NotificationResponse(dict):
+    @classmethod
+    def from_str(cls, s: str) -> "NotificationResponse":
+        """parse a dict literal representation of a NotificationResponse"""
+        return cls(**literal_eval(s))
+
+
+NotificationsGenerator = Generator[EmailNotification, None, None]
+NotificationsGeneratorFunction = Callable[..., NotificationsGenerator]
+Notifications = Union[NotificationsGenerator, NotificationsGeneratorFunction]

--- a/dmscripts/notify_suppliers_of_awarded_briefs.py
+++ b/dmscripts/notify_suppliers_of_awarded_briefs.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timedelta, date
 
-from dmutils.email.exceptions import EmailError, EmailTemplateError
-from dmutils.email.helpers import get_email_addresses, hash_string, validate_email_address
+from dmapiclient import DataAPIClient
+from dmutils.email.helpers import get_email_addresses, validate_email_address
 from dmutils.formats import DATE_FORMAT
-from dmutils.env_helpers import get_web_url_from_stage
+from dmutils.env_helpers import get_api_endpoint_from_stage, get_web_url_from_stage
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.logging_helpers import get_logger
 
 
 def _create_context_for_brief(stage, brief):
@@ -19,39 +22,30 @@ def _create_context_for_brief(stage, brief):
 
 
 def _get_brief_responses_to_be_notified(data_api_client, brief_response_ids, awarded_at):
-    brief_responses = []
 
     if brief_response_ids:
         # Used for re-running failed email sending
         for brief_response_id in brief_response_ids:
-            brief_responses.append(data_api_client.get_brief_response(brief_response_id)['briefResponses'])
+            yield data_api_client.get_brief_response(brief_response_id)['briefResponses']
     else:
         awarded_at_date = awarded_at or (datetime.utcnow() - timedelta(days=1)).strftime(DATE_FORMAT)
         awarded_brief_responses = data_api_client.find_brief_responses_iter(awarded_at=awarded_at_date)
 
         for abr in awarded_brief_responses:
             # Add the awarded BriefResponse
-            brief_responses.append(abr)
+            yield abr
             # Get the other non-awarded BriefResponses for the same Brief
-            brief_responses.extend(
-                data_api_client.find_brief_responses_iter(brief_id=abr['briefId'], status='submitted')
-            )
+            yield from data_api_client.find_brief_responses_iter(brief_id=abr['briefId'], status='submitted')
 
         # Get BriefResponses for any Briefs cancelled or unsuccessful on the same date
         for brief in data_api_client.find_briefs_iter(cancelled_on=awarded_at_date):
-            brief_responses.extend(
-                data_api_client.find_brief_responses_iter(brief_id=brief['id'])
-            )
+            yield from data_api_client.find_brief_responses_iter(brief_id=brief['id'])
+
         for brief in data_api_client.find_briefs_iter(unsuccessful_on=awarded_at_date):
-            brief_responses.extend(
-                data_api_client.find_brief_responses_iter(brief_id=brief['id'])
-            )
-
-    return brief_responses
+            yield from data_api_client.find_brief_responses_iter(brief_id=brief['id'])
 
 
-def _build_and_send_emails(brief_responses, mail_client, stage, dry_run, template_id, logger):
-    failed_brief_responses = []
+def _build_emails(brief_responses, stage, template_id, logger):
 
     # Now email everyone whose Brief got awarded
     for brief_response in brief_responses:
@@ -84,54 +78,25 @@ def _build_and_send_emails(brief_responses, mail_client, stage, dry_run, templat
 
         brief_email_context = _create_context_for_brief(stage, brief_response['brief'])
         for email_address in email_addresses:
-            try:
-                if not dry_run:
-                    mail_client.send_email(
-                        email_address, template_id, brief_email_context, allow_resend=False
-                    )
-                logger.info(
-                    "{dry_run}EMAIL: Award of Brief Response ID: {brief_response_id} to {email_address}",
-                    extra={
-                        'dry_run': '[Dry-run] - ' if dry_run else '',
-                        'brief_response_id': brief_response['id'],
-                        'email_address': hash_string(email_address),
-                    }
-                )
-            except EmailError as e:
-                # Log individual failures in more detail
-                logger.error(
-                    "Email sending failed for BriefResponse {brief_response_id} (Brief ID {brief_id})",
-                    extra={
-                        "brief_id": brief_response['brief']['id'],
-                        "brief_response_id": brief_response['id']
-                    }
-                )
-
-                if isinstance(e, EmailTemplateError):
-                    raise  # do not try to continue
-
-                failed_brief_responses.append(brief_response['id'])
-
-    return failed_brief_responses
+            yield {
+                "email_address": email_address,
+                "template_id": template_id,
+                "personalisation": brief_email_context
+            }
 
 
 def main(
-    data_api_client, mail_client, template_id, stage, logger,
-    dry_run=False, brief_response_ids=None, awarded_at=None
+    notify_template_id, stage, brief_response_ids=None, awarded_at=None, data_api_client=None, **kwargs
 ):
-    brief_responses = _get_brief_responses_to_be_notified(data_api_client, brief_response_ids, awarded_at)
-
-    failed_brief_responses = _build_and_send_emails(brief_responses, mail_client, stage, dry_run, template_id, logger)
-
-    # Log a summary of failures at the end of the job
-    if failed_brief_responses:
-        logger.error(
-            "Email sending failed for the following {count} BriefResponses: {brief_response_ids}",
-            extra={
-                "brief_response_ids": ",".join(map(str, failed_brief_responses)),
-                "count": len(failed_brief_responses)
-            }
+    if data_api_client is None:
+        data_api_client = DataAPIClient(
+            base_url=get_api_endpoint_from_stage(stage),
+            auth_token=get_auth_token("api", stage),
         )
-        return False
 
-    return True
+    logger = get_logger()
+
+    brief_responses = _get_brief_responses_to_be_notified(data_api_client, brief_response_ids, awarded_at)
+    notifications = _build_emails(brief_responses, stage, notify_template_id, logger)
+
+    yield from notifications

--- a/scripts/notify-suppliers-of-awarded-briefs.py
+++ b/scripts/notify-suppliers-of-awarded-briefs.py
@@ -1,75 +1,48 @@
 #!/usr/bin/env python3
 """
-If a brief has been awarded suppliers need to be notified. This
-script notifies suppliers of all awarded briefs in the previous day by default.
-Alternatively, when supplied with a list of BriefResponse IDs, it will notify just the suppliers for those responses.
+If a brief has been awarded suppliers need to be notified. This script notifies
+suppliers of all awarded briefs in the previous day by default.
 
-Usage:
-    notify-suppliers-of-awarded-briefs.py <stage> <govuk_notify_api_key> <govuk_notify_template_id>
-        [options]
-
-Options:
-    -h, --help                                      Display this screen
-    -v, --verbose                                   Verbosity level
-    --dry-run                                       Log without sending emails
-    --awarded_at=<awarded_at>                       Notify applicants to briefs awarded on this date, defaults to
-                                                    # yesterday (date format: YYYY-MM-DD)
-    --brief_response_ids=<brief_response_ids>       List of brief response IDs to send to (for resending failures)
-
-Examples:
-    ./scripts/notify-suppliers-of-awarded-briefs.py preview myToken notifyToken t3mp1at3id --awarded_at=2017-10-27
-    ./scripts/notify-suppliers-of-awarded-briefs.py preview myToken notifyToken t3mp1at3id --dry-run --verbose
-
+Alternatively, when supplied with a list of BriefResponse IDs, it will notify
+just the suppliers for those responses.
 """
 
-import logging
+__examples__ = r"""
+Examples:
+    ./scripts/notify-suppliers-of-awarded-briefs.py \
+        --stage=preview --notify-api-key=notifyToken --notify-template-id=t3mp1at3id --awarded-at=2017-10-27
+    ./scripts/notify-suppliers-of-awarded-briefs.py \
+        --stage=preview --notify-api-key=notifyToken --notify-template-id=t3mp1at3id --dry-run --verbose
+"""
+
 import sys
-from docopt import docopt
 
-from dmapiclient import DataAPIClient
+sys.path.insert(0, ".")
 
-sys.path.insert(0, '.')
-
-from dmscripts.helpers.email_helpers import scripts_notify_client
-from dmscripts.helpers.auth_helpers import get_auth_token
-from dmscripts.helpers import logging_helpers
 from dmscripts.notify_suppliers_of_awarded_briefs import main
-from dmutils.env_helpers import get_api_endpoint_from_stage
+from dmscripts.email_engine import email_engine, argument_parser_factory
 
 
 if __name__ == "__main__":
-    arguments = docopt(__doc__)
+    arg_parser = argument_parser_factory(
+        description=__doc__, epilog=__examples__, notify_template_id_required=True
+    )
 
     # Get arguments
-    stage = arguments['<stage>']
-    govuk_notify_api_key = arguments['<govuk_notify_api_key>']
-    govuk_notify_template_id = arguments['<govuk_notify_template_id>']
-    awarded_at = arguments.get('--awarded_at', None)
-    brief_response_ids = arguments.get('--brief_response_ids', None)
-    dry_run = arguments['--dry-run']
-    verbose = arguments['--verbose']
-
-    # Set defaults, instantiate clients
-    logger = logging_helpers.configure_logger(
-        {"dmapiclient": logging.INFO} if verbose else {"dmapiclient": logging.WARN}
+    arg_parser.add_argument(
+        "--awarded-at",
+        help="Notify applicants to briefs awarded on this date, defaults to yesterday (date format: YYYY-MM-DD).",
     )
-    notify_client = scripts_notify_client(govuk_notify_api_key, logger=logger)
-    data_api_client = DataAPIClient(base_url=get_api_endpoint_from_stage(stage),
-                                    auth_token=get_auth_token('api', stage))
+    arg_parser.add_argument(
+        "--brief-response-ids",
+        help="Comma-seperated list of brief response IDs to send to.",
+        type=lambda s: [int(i) for i in s.split(",")]
+    )
 
-    list_of_brief_response_ids = list(map(int, brief_response_ids.split(','))) if brief_response_ids else None
+    args = arg_parser.parse_args()
 
     # Do send
-    ok = main(
-        data_api_client=data_api_client,
-        mail_client=notify_client,
-        template_id=govuk_notify_template_id,
-        stage=stage,
-        logger=logger,
-        awarded_at=awarded_at,
-        brief_response_ids=list_of_brief_response_ids,
-        dry_run=dry_run,
+    email_engine(
+        main,
+        args=args,
     )
-
-    if not ok:
-        sys.exit(1)

--- a/tests/email_engine/conftest.py
+++ b/tests/email_engine/conftest.py
@@ -1,0 +1,67 @@
+from unittest import mock
+
+import pytest
+
+from dmscripts.email_engine.cli import argument_parser_factory
+from dmscripts.email_engine.typing import EmailNotification
+
+
+@pytest.fixture
+def caplog(caplog):
+    with caplog.at_level(15):
+        yield caplog
+
+
+@pytest.fixture
+def default_argument_parser_factory():
+    """Patch email_engine's argument_parser_factory so that it will not require any arguments"""
+
+    def factory(*args, **kwargs):
+        return argument_parser_factory(
+            *args,
+            **kwargs,
+            notify_api_key_required=False,
+            notify_template_id_required=False,
+            stage_required=False,
+        )
+
+    with mock.patch("dmscripts.email_engine.cli.argument_parser_factory", factory):
+        with mock.patch("dmscripts.email_engine.argument_parser_factory", factory):
+            with mock.patch("sys.argv", ["email_engine"]):
+                yield factory
+
+
+@pytest.fixture
+def notifications_generator():
+    def g(*args, **kwargs):
+        for i in range(10):
+            yield EmailNotification(
+                email_address=f"{i}@example.com", template_id="0000-0003"
+            )
+
+    return mock.Mock(wraps=g)
+
+
+@pytest.fixture
+def send_notification():
+    def f(*args, **kwargs):
+        return {"id": str(id((args, kwargs)))}
+
+    return mock.Mock(wraps=f)
+
+
+@pytest.fixture
+def crashing_send_notification(send_notification):
+    def factory(crash_after: int, crash_with=RuntimeError):
+        countdown = crash_after
+
+        def crasher(*args, **kwargs):
+            nonlocal countdown
+            countdown -= 1
+            if countdown == 0:
+                raise crash_with
+            return send_notification(*args, **kwargs)
+
+        return crasher
+
+    return factory

--- a/tests/email_engine/conftest.py
+++ b/tests/email_engine/conftest.py
@@ -12,7 +12,7 @@ def caplog(caplog):
         yield caplog
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def default_argument_parser_factory():
     """Patch email_engine's argument_parser_factory so that it will not require any arguments"""
 

--- a/tests/email_engine/test_cli.py
+++ b/tests/email_engine/test_cli.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+class TestArgumentParser:
+
+    @pytest.fixture
+    def argument_parser_factory(self, default_argument_parser_factory):
+        return default_argument_parser_factory
+
+    def test_dry_run(self, argument_parser_factory):
+        argument_parser = argument_parser_factory()
+        assert argument_parser.parse_args([]).dry_run is False
+        assert argument_parser.parse_args(["--dry-run"]).dry_run is True
+        assert argument_parser.parse_args(["-n"]).dry_run is True
+
+    def test_notify_api_key_from_envvar(self, argument_parser_factory):
+        with mock.patch.dict("os.environ", {"DM_NOTIFY_API_KEY": "test-api-key"}):
+            args = argument_parser_factory().parse_args([])
+
+        assert args.notify_api_key == "test-api-key"
+
+    def test_notify_api_key_from_envvar_and_argv(self, argument_parser_factory):
+        with mock.patch.dict("os.environ", {"DM_NOTIFY_API_KEY": "old-api-key"}):
+            args = argument_parser_factory().parse_args(
+                ["--notify-api-key=new-api-key"]
+            )
+
+        assert args.notify_api_key == "new-api-key"
+
+    def test_notify_api_key_is_none_if_not_set_by_environment_or_cli(self, argument_parser_factory):
+        with mock.patch.dict("os.environ", clear=True):
+            args = argument_parser_factory().parse_args([])
+
+        assert args.notify_api_key is None
+
+    def test_reference_default_is_sys_argv_0(self, argument_parser_factory):
+        with mock.patch("sys.argv", ["foobar"]):
+            args = argument_parser_factory().parse_args([])
+
+        assert args.reference == "foobar"
+
+    def test_reference_default_removes_suffix_dot_py(self, argument_parser_factory):
+        with mock.patch("sys.argv", ["foobar.py"]):
+            args = argument_parser_factory().parse_args([])
+
+        assert args.reference == "foobar"
+
+    def test_reference_default_removes_path_components(self, argument_parser_factory):
+        with mock.patch("sys.argv", ["./scripts/foobar"]):
+            args = argument_parser_factory().parse_args([])
+
+        assert args.reference == "foobar"
+
+    def test_reference_default_overridable_by_factory_arg(self, argument_parser_factory):
+        with mock.patch("sys.argv", ["foo"]):
+            args = argument_parser_factory(reference="bar").parse_args([])
+
+        assert args.reference == "bar"
+
+    def test_reference_cli_argument_overrides_factory_arg(self, argument_parser_factory):
+        with mock.patch("sys.argv", ["foo"]):
+            args = argument_parser_factory(reference="bar").parse_args(
+                ["--reference=baz"]
+            )
+
+        assert args.reference == "baz"
+
+    def test_default_logfile_path_is_derived_from_reference(self, argument_parser_factory):
+        with mock.patch("sys.argv", ["foo"]):
+            args = argument_parser_factory().parse_args([])
+
+        assert args.logfile == Path("/tmp/foo.log")
+
+        with mock.patch("sys.argv", ["foo"]):
+            args = argument_parser_factory(reference="bar").parse_args([])
+
+        assert args.logfile == Path("/tmp/bar.log")

--- a/tests/email_engine/test_email_engine.py
+++ b/tests/email_engine/test_email_engine.py
@@ -55,13 +55,13 @@ class TestEmailEngine:
                 email_address="test1@example.com",
                 template_id="000-001",
                 personalisation={"name": "test1"},
-                reference="test_email_engine",
+                reference="test_email_engine-f558d11a",
             ),
             mock.call(
                 email_address="test2@example.com",
                 template_id="000-001",
                 personalisation={"name": "test2"},
-                reference="test_email_engine",
+                reference="test_email_engine-f558d11a",
             ),
         ]
 
@@ -138,5 +138,5 @@ class TestEmailEngine:
             "queue update: generator is exhausted, read 2 notifications into queue",
             "queue update: send notification {'email_address': 'test1@example.com', 'template_id': '000-001', 'personalisation': {'name': 'test1'}} response {}",
             "queue update: send notification {'email_address': 'test2@example.com', 'template_id': '000-001', 'personalisation': {'name': 'test2'}} response {}",
-            "sent 2 email notifications with reference test_email_engine_logfile",
+            "sent 2 email notifications with reference test_email_engine_logfile-a16feb2f",
         ]

--- a/tests/email_engine/test_email_engine.py
+++ b/tests/email_engine/test_email_engine.py
@@ -1,0 +1,142 @@
+# this file needs a lot of long lines because we are testing examples of logfiles
+# flake8: noqa E501
+
+from unittest import mock
+
+import pytest
+
+from dmscripts.email_engine import EmailNotification, email_engine
+
+
+pytestmark = pytest.mark.usefixtures("default_argument_parser_factory")
+
+
+class TestEmailEngine:
+    @pytest.fixture(autouse=True)
+    def notifications_api_client(self):
+        with mock.patch(
+            "dmscripts.email_engine.NotificationsAPIClient", autospec=True
+        ) as NotificationsAPIClient:
+            with mock.patch.dict("os.environ", {"DM_NOTIFY_API_KEY": "test-api-key"}):
+                yield NotificationsAPIClient
+
+    @pytest.fixture
+    def logfile(self, tmp_path):
+        return tmp_path / "log.txt"
+
+    def test_email_engine(self, caplog, notifications_api_client, logfile):
+        def notifications_generator(**kwargs):
+            yield EmailNotification(
+                email_address="test1@example.com",
+                template_id="000-001",
+                personalisation={"name": "test1"},
+            )
+            yield EmailNotification(
+                email_address="test2@example.com",
+                template_id="000-001",
+                personalisation={"name": "test2"},
+            )
+
+        notifications_generator = mock.Mock(wraps=notifications_generator)
+
+        email_engine(
+            notifications_generator,
+            argv=[],
+            reference="test_email_engine",
+            logfile=logfile,
+        )
+
+        assert notifications_generator.called
+        assert notifications_api_client.call_args == mock.call("test-api-key")
+        assert notifications_api_client(
+            "test-api-key"
+        ).send_email_notification.call_args_list == [
+            mock.call(
+                email_address="test1@example.com",
+                template_id="000-001",
+                personalisation={"name": "test1"},
+                reference="test_email_engine",
+            ),
+            mock.call(
+                email_address="test2@example.com",
+                template_id="000-001",
+                personalisation={"name": "test2"},
+                reference="test_email_engine",
+            ),
+        ]
+
+        caplog.messages[
+            -1
+        ] == "sent 2 email notifications with reference test_email_engine"
+
+    def test_email_engine_resume(
+        self,
+        caplog,
+        notifications_api_client,
+        logfile,
+        notifications_generator,
+        crashing_send_notification,
+        send_notification,
+    ):
+        notifications_api_client(
+            "test_api_key"
+        ).send_email_notification = crashing_send_notification(crash_after=3)
+
+        with pytest.raises(RuntimeError):
+            email_engine(
+                notifications_generator,
+                argv=[],
+                reference="test_email_engine_resume",
+                logfile=logfile,
+            )
+
+        notifications_api_client(
+            "test_api_key"
+        ).send_email_notification = send_notification
+
+        email_engine(
+            notifications_generator,
+            argv=[],
+            reference="test_email_engine_resume",
+            logfile=logfile,
+        )
+
+        caplog.messages[
+            -1
+        ] == "sent 10 email notifications with reference test_email_engine"
+
+    def test_email_engine_logfile(self, notifications_api_client, logfile):
+        def notifications_generator(**args):
+            yield EmailNotification(
+                email_address="test1@example.com",
+                template_id="000-001",
+                personalisation={"name": "test1"},
+            )
+            yield EmailNotification(
+                email_address="test2@example.com",
+                template_id="000-001",
+                personalisation={"name": "test2"},
+            )
+
+        notifications_api_client(
+            "test_api_key"
+        ).send_email_notification.return_value = {}
+
+        email_engine(
+            notifications_generator,
+            argv=[],
+            reference="test_email_engine_logfile",
+            logfile=logfile,
+        )
+
+        loglines = logfile.read_text().splitlines()
+        assert loglines == [
+            "OFFICIAL SENSITIVE - do not distribute - this file contains email addresses and other PII",
+            "getting notifications to send from API",
+            "queue update: queued notification {'email_address': 'test1@example.com', 'template_id': '000-001', 'personalisation': {'name': 'test1'}}",
+            "queue update: queued notification {'email_address': 'test2@example.com', 'template_id': '000-001', 'personalisation': {'name': 'test2'}}",
+            "queue update: generator is exhausted, read 2 notifications into queue",
+            "queue update: send notification {'email_address': 'test1@example.com', 'template_id': '000-001', 'personalisation': {'name': 'test1'}} response {}",
+            "queue update: send notification {'email_address': 'test2@example.com', 'template_id': '000-001', 'personalisation': {'name': 'test2'}} response {}",
+            "sent 2 email notifications with reference test_email_engine_logfile",
+        ]

--- a/tests/email_engine/test_queue.py
+++ b/tests/email_engine/test_queue.py
@@ -1,0 +1,263 @@
+# this file needs a lot of long lines because we are testing examples of logfiles
+# flake8: noqa E501
+
+from textwrap import dedent
+from unittest import mock
+
+import pytest
+
+from notifications_python_client.errors import APIError
+
+from dmscripts.email_engine.queue import EmailNotification, LoggingQueue, run
+
+
+class TestRun:
+    @pytest.fixture
+    def queue(self):
+        queue = LoggingQueue()
+        with mock.patch("dmscripts.email_engine.queue.LoggingQueue") as constructor:
+            constructor.return_value = queue
+            yield queue
+
+    @pytest.fixture
+    def logfile(self, tmp_path):
+        logfile = tmp_path / "log.txt"
+        logfile.touch()
+        return logfile
+
+    def test_run(self, notifications_generator, send_notification, logfile, queue):
+        run(send_notification, notifications=notifications_generator(), logfile=logfile)
+
+        assert len(queue.todo) == 0
+        assert len(queue.done) == 10
+
+    def test_run_with_logfile(self, send_notification, logfile, queue):
+        logfile.write_text(
+            dedent(
+                """\
+                queue update: queued notification {"email_address": "hello@example.com", "template_id": "0000-0001"}
+                queue update: queued notification {"email_address": "test@example.com", "template_id": "0000-0002"}
+                queue update: generator is exhausted, read 2 notifications into queue
+                queue update: send notification {"email_address": "hello@example.com", "template_id": "0000-0001"} response {"id": "1001-1000"}
+                """
+            )
+        )
+
+        run(send_notification, notifications=[], logfile=logfile)
+
+        assert len(queue.todo) == 0
+        assert len(queue.done) == 2
+
+    def test_run_aborts_if_generator_was_not_exhausted_in_logfile(self, logfile):
+        logfile.write_text(
+            dedent(
+                """\
+                queue update: queued notification {"email_address": "hello@example.com", "template_id": "0000-0001"}
+                queue update: queued notification {"email_address": "test@example.com", "template_id": "0000-0002"}
+                """
+            )
+        )
+
+        with pytest.raises(RuntimeError):
+            run(mock.Mock(), notifications=[], logfile=logfile)
+
+    def test_run_logs_remaining_todo_if_interrupted_by_exception(
+        self, caplog, notifications_generator, logfile, crashing_send_notification
+    ):
+        send_notification = crashing_send_notification(
+            crash_after=3, crash_with=APIError(message="woops")
+        )
+
+        with pytest.raises(APIError):
+            run(
+                send_notification,
+                notifications=notifications_generator(),
+                logfile=logfile,
+            )
+
+        assert (
+            caplog.messages[-1]
+            == "sending emails was stopped by APIError with 7 notifications left to send"
+        )
+
+
+class TestLoggingQueue:
+    def test_put(self):
+        queue = LoggingQueue()
+
+        queue.put(
+            EmailNotification(
+                email_address="hello@example.com", template_id="0000-000a"
+            )
+        )
+
+        assert len(queue.todo) == 1
+
+    def test_put_logs_notification(self, caplog):
+        queue = LoggingQueue()
+
+        queue.put(
+            EmailNotification(
+                email_address="hello@example.com", template_id="0000-000a"
+            )
+        )
+
+        assert caplog.messages[-1] == (
+            "queue update: queued notification {'email_address': 'hello@example.com', 'template_id': '0000-000a', 'personalisation': None}"
+        )
+
+    def test_put_does_not_add_duplicate_notifications(self, caplog):
+        queue = LoggingQueue()
+
+        queue.put(
+            EmailNotification(
+                email_address="hello@example.com", template_id="0000-000a"
+            )
+        )
+        queue.put(
+            EmailNotification(
+                email_address="hello@example.com", template_id="0000-000a"
+            )
+        )
+
+        assert caplog.messages[-1] == (
+            "ignoring duplicate notification {'email_address': 'hello@example.com', 'template_id': '0000-000a', 'personalisation': None}"
+        )
+        assert len(queue.todo) == 1
+
+    def test_send_next(self, send_notification):
+        queue = LoggingQueue()
+
+        queue.put(
+            EmailNotification(
+                email_address="hello@example.com", template_id="0000-000a"
+            )
+        )
+
+        queue.send_next(send_notification)
+
+        assert len(queue.todo) == 0
+        assert len(queue.done) == 1
+
+    def test_send_next_logs_notification_and_response(self, caplog, send_notification):
+        queue = LoggingQueue()
+
+        queue.put(
+            EmailNotification(
+                email_address="hello@example.com", template_id="0000-000a"
+            )
+        )
+
+        queue.send_next(lambda x: {"id": "cafe"})
+
+        assert caplog.messages[-1] == (
+            "queue update: send notification {'email_address': 'hello@example.com', 'template_id': '0000-000a', 'personalisation': None} response {'id': 'cafe'}"
+        )
+
+    def test_read_log(self):
+        loglines = """
+            2021-04-08T10:42:00Z queue update: queued notification {"email_address": "hello@example.com", "template_id": "0000-0001"}
+            2021-04-08T10:42:00Z queue update: queued notification {"email_address": "test@example.com", "template_id": "0000-0002"}
+            2021-04-08T10:43:05Z boring log line about things not queue related
+            2021-04-08T10:44:10Z queue update: send notification {"email_address": "hello@example.com", "template_id": "0000-0001"} response {"id": "1001-1000"}
+        """
+
+        queue = LoggingQueue()
+        queue._read_log(loglines.splitlines())
+
+        assert list(queue.todo) == [
+            EmailNotification(template_id="0000-0002", email_address="test@example.com")
+        ]
+        assert queue.done == {
+            EmailNotification(
+                template_id="0000-0001", email_address="hello@example.com"
+            ): {"id": "1001-1000"}
+        }
+
+    def test_read_log_returns_true_if_original_generator_was_exhausted(self):
+        queue = LoggingQueue()
+        _, exhausted = queue._read_log(
+            ["queue update: generator is exhausted, read 0 notifications into queue"]
+        )
+        assert exhausted is True
+
+    def test_read_log_returns_false_if_original_generator_was_not_exhausted(self):
+        queue = LoggingQueue()
+        _, exhausted = queue._read_log(
+            [
+                "queue update: queued notification {'email_address': 'test@example.com', 'template_id': 'a'}"
+            ]
+        )
+        assert exhausted is False
+
+    @pytest.mark.parametrize(
+        "invalid_loglines",
+        (
+            # out of order lines
+            """
+            queue update: send notification {"email_address": "hello@example.com", "template_id": "0000-0001"} response {"id": "1001-1000"}
+            queue update: queued notification {"email_address": "hello@example.com", "template_id": "0000-0001"}
+            """,
+            # missing lines
+            """
+            queue update: send notification {"email_address": "hello@example.com", "template_id": "0000-0001"} response {"id": "1001-1000"}
+            """,
+            # line that has typo
+            """
+            queue update: sned notification {"email_address": "hello@example.com", "template_id": "0000-0001"} response {"id": "1001-1000"}
+            """,
+        ),
+    )
+    def test_read_state_raises_error_if_log_has_invalid_lines(self, invalid_loglines):
+        queue = LoggingQueue()
+        with pytest.raises(RuntimeError):
+            queue._read_log(invalid_loglines.splitlines())
+
+    def test_put_from_logfile(self, tmp_path):
+        log_file = tmp_path / "log.txt"
+
+        log_file.write_text(
+            """2021-04-08T10:42:00Z queue update: queued notification {"email_address": "hello@example.com", "template_id": "0000-0001"}\n"""
+        )
+
+        queue = LoggingQueue()
+        queue.put_from_logfile(log_file)
+
+        assert list(queue.todo) == [
+            EmailNotification(
+                template_id="0000-0001", email_address="hello@example.com"
+            )
+        ]
+
+    def test_put_from_generator(self, notifications_generator):
+        queue = LoggingQueue()
+        queue.put_from(notifications_generator())
+
+    def test_put_from_logs_when_generator_is_exhausted(
+        self, caplog, notifications_generator
+    ):
+        queue = LoggingQueue()
+        queue.put_from(notifications_generator())
+
+        assert caplog.messages[-1] == (
+            "queue update: generator is exhausted, read 10 notifications into queue"
+        )
+
+    def test_put_from_logs_roundtrip_with_read_log(
+        self, caplog, send_notification, notifications_generator
+    ):
+        notifications = list(notifications_generator())
+
+        queue_a = LoggingQueue()
+        queue_a.put_from(notifications)
+
+        assert list(queue_a.todo) == notifications
+
+        for _ in range(2):
+            queue_a.send_next(send_notification)
+
+        queue_b = LoggingQueue()
+        queue_b._read_log(caplog.text.splitlines())
+
+        assert queue_b.todo == queue_a.todo
+        assert queue_b.done == queue_a.done

--- a/tests/email_engine/test_typing.py
+++ b/tests/email_engine/test_typing.py
@@ -1,0 +1,63 @@
+from collections.abc import Hashable
+
+import pytest
+
+from dmscripts.email_engine.typing import EmailNotification
+
+
+class TestEmailNotification:
+    def test_is_hashable(self):
+        isinstance(EmailNotification, Hashable)
+
+        assert hash(
+            EmailNotification(
+                email_address="hello@example.com",
+                template_id="0000-0000",
+                personalisation={"name": "Hello"},
+            )
+        )
+
+    def test_is_comparable(self):
+        a = EmailNotification(
+            email_address="hello@example.com",
+            template_id="0000-0000",
+            personalisation={"name": "Hello"},
+        )
+        b = EmailNotification(
+            template_id="0000-0000",
+            email_address="hello@example.com",
+            personalisation={"name": "Hello"},
+        )
+        c = EmailNotification(
+            email_address="different@example.com",
+            template_id="0000-0001",
+            personalisation={"name": "Hello"},
+        )
+
+        assert id(a) != id(b) != id(c)
+
+        assert a == b
+
+        assert a != c
+        assert b != c
+
+    def test_is_frozen(self):
+        a = EmailNotification(
+            email_address="hello@example.com",
+            template_id="0000-0000",
+            personalisation={"name": "Hello"},
+        )
+
+        with pytest.raises(RuntimeError):
+            a["email_address"] = "hello1@example.com"
+
+    def test_str_notification_can_be_parsed_using_from_str(self):
+        a = EmailNotification(
+            email_address="hello@example.com",
+            template_id="0000-0000",
+            personalisation={"name": "Hello"},
+        )
+
+        b = EmailNotification.from_str(str(a))
+
+        assert a == b

--- a/tests/test_notify_suppliers_of_awarded_briefs.py
+++ b/tests/test_notify_suppliers_of_awarded_briefs.py
@@ -1,11 +1,8 @@
 import mock
-import pytest
 
 from freezegun import freeze_time
 
 from dmscripts import notify_suppliers_of_awarded_briefs as tested_script
-from dmutils.email.exceptions import EmailError, EmailTemplateError
-from dmutils.email.helpers import hash_string
 
 
 AWARDED_BRIEFS = [
@@ -85,10 +82,9 @@ def test_create_context_for_brief():
         assert tested_script._create_context_for_brief('preview', AWARDED_BRIEFS[0]) == EXPECTED_BRIEF_CONTEXT
 
 
-@mock.patch('dmutils.email.DMNotifyClient', autospec=True)
 @mock.patch('dmscripts.notify_suppliers_of_awarded_briefs._create_context_for_brief')
 @mock.patch('dmapiclient.DataAPIClient', autospec=True)
-def test_main_calls_correct_methods(data_api_client, create_context_for_brief, notify_client):
+def test_main_calls_correct_methods(data_api_client, create_context_for_brief):
     data_api_client.find_brief_responses_iter.side_effect = [
         [   # Awarded brief responses for each awarded brief
             _get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True),
@@ -113,7 +109,7 @@ def test_main_calls_correct_methods(data_api_client, create_context_for_brief, n
     tested_script._create_context_for_brief.return_value = EXPECTED_BRIEF_CONTEXT
 
     with freeze_time('2018-01-02'):
-        assert tested_script.main(data_api_client, notify_client, "notify_template_id", "preview", mock.Mock())
+        notifications = list(tested_script.main("notify_template_id", "preview", data_api_client=data_api_client))
 
     assert data_api_client.find_brief_responses_iter.call_args_list == [
         mock.call(awarded_at="2018-01-01"),
@@ -130,30 +126,39 @@ def test_main_calls_correct_methods(data_api_client, create_context_for_brief, n
         mock.call("preview", UNSUCCESSFUL_BRIEFS[0])
     ]
     # Only email if a valid email address is present
-    assert notify_client.send_email.call_args_list == [
-        mock.call(
-            "lucky_winner_4321@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
-        ),
-        mock.call(
-            "sore_loser_4322@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
-        ),
-        mock.call(
-            "lucky_winner_4322@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
-        ),
-        mock.call(
-            "sore_loser_4325@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
-        ),
-        mock.call(
-            "sore_loser_4326@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
-        )
+    assert notifications == [
+        {
+            "email_address": "lucky_winner_4321@example.com",
+            "template_id": "notify_template_id",
+            "personalisation": EXPECTED_BRIEF_CONTEXT
+        },
+        {
+            "email_address": "sore_loser_4322@example.com",
+            "template_id": "notify_template_id",
+            "personalisation": EXPECTED_BRIEF_CONTEXT
+        },
+        {
+            "email_address": "lucky_winner_4322@example.com",
+            "template_id": "notify_template_id",
+            "personalisation": EXPECTED_BRIEF_CONTEXT
+        },
+        {
+            "email_address": "sore_loser_4325@example.com",
+            "template_id": "notify_template_id",
+            "personalisation": EXPECTED_BRIEF_CONTEXT
+        },
+        {
+            "email_address": "sore_loser_4326@example.com",
+            "template_id": "notify_template_id",
+            "personalisation": EXPECTED_BRIEF_CONTEXT
+        }
     ]
     # Single BriefResponse API request not called
     assert data_api_client.get_brief_response.called is False
 
 
-@mock.patch('dmutils.email.DMNotifyClient', autospec=True)
 @mock.patch('dmapiclient.DataAPIClient', autospec=True)
-def test_main_calls_get_brief_response_when_brief_response_ids_specified(data_api_client, notify_client):
+def test_main_calls_get_brief_response_when_brief_response_ids_specified(data_api_client):
     """Script should only look up brief responses for a given list of ids if they are specified."""
     data_api_client.get_brief_response.side_effect = [
         {'briefResponses': _get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True)},
@@ -161,28 +166,31 @@ def test_main_calls_get_brief_response_when_brief_response_ids_specified(data_ap
     ]
 
     with freeze_time('2018-01-02'):
-        assert tested_script.main(
-            data_api_client, notify_client, 'notify_template_id', 'preview', mock.Mock(),
-            brief_response_ids=[4321, 4322]
-        )
+        notifications = list(tested_script.main(
+            'notify_template_id', 'preview',
+            brief_response_ids=[4321, 4322], data_api_client=data_api_client,
+        ))
 
     assert data_api_client.get_brief_response.call_args_list == [
         mock.call(4321),
         mock.call(4322)
     ]
-    assert notify_client.send_email.call_args_list == [
-        mock.call(
-            "lucky_winner_4321@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
-        ),
-        mock.call(
-            "sore_loser_4322@example.com", "notify_template_id", EXPECTED_BRIEF_CONTEXT, allow_resend=False
-        )
+    assert notifications == [
+        {
+            "email_address": "lucky_winner_4321@example.com",
+            "template_id": "notify_template_id",
+            "personalisation": EXPECTED_BRIEF_CONTEXT
+        },
+        {
+            "email_address": "sore_loser_4322@example.com",
+            "template_id": "notify_template_id",
+            "personalisation": EXPECTED_BRIEF_CONTEXT
+        }
     ]
 
 
-@mock.patch('dmutils.email.DMNotifyClient', autospec=True)
 @mock.patch('dmapiclient.DataAPIClient', autospec=True)
-def test_main_uses_awarded_at_date_param_if_provided(data_api_client, notify_client):
+def test_main_uses_awarded_at_date_param_if_provided(data_api_client):
     data_api_client.find_brief_responses_iter.side_effect = [
         [   # Awarded brief response for the awarded brief
             _get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True),
@@ -202,9 +210,12 @@ def test_main_uses_awarded_at_date_param_if_provided(data_api_client, notify_cli
     ]
 
     with freeze_time('2018-02-02'):
-        assert tested_script.main(
-            data_api_client, notify_client, "notify_template_id", "preview", mock.Mock(), awarded_at="2018-01-01"
-        )
+        assert list(tested_script.main(
+            notify_template_id="notify_template_id",
+            stage="preview",
+            awarded_at="2018-01-01",
+            data_api_client=data_api_client
+        ))
 
     assert data_api_client.find_brief_responses_iter.call_args_list == [
         mock.call(awarded_at="2018-01-01"),
@@ -212,72 +223,3 @@ def test_main_uses_awarded_at_date_param_if_provided(data_api_client, notify_cli
         mock.call(brief_id=333),
         mock.call(brief_id=555)
     ]
-
-
-@mock.patch('dmutils.email.DMNotifyClient', autospec=True)
-@mock.patch('dmapiclient.DataAPIClient', autospec=True)
-def test_main_catches_email_errors_and_returns_ids(data_api_client, notify_client):
-    logger = mock.Mock()
-    notify_client.send_email.side_effect = [EmailError, True]
-    data_api_client.find_brief_responses_iter.side_effect = [
-        [_get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True)],
-        [_get_dummy_brief_response(1234, AWARDED_BRIEFS[0], awarded=False)],
-    ]
-
-    assert not tested_script.main(
-        data_api_client, notify_client, 'notify_template_id', 'preview', logger
-    )
-
-    assert logger.error.call_args_list == [
-        mock.call(
-            'Email sending failed for BriefResponse {brief_response_id} (Brief ID {brief_id})',
-            extra={
-                "brief_id": 123,
-                "brief_response_id": 4321
-            }
-        ),
-        mock.call(
-            "Email sending failed for the following {count} BriefResponses: {brief_response_ids}",
-            extra={
-                'brief_response_ids': '4321',
-                'count': 1
-            }
-        )
-    ]
-    assert logger.info.call_args_list == [
-        mock.call(
-            "{dry_run}EMAIL: Award of Brief Response ID: {brief_response_id} to {email_address}",
-            extra={
-                'dry_run': '',
-                'brief_response_id': 1234,
-                'email_address': hash_string('sore_loser_1234@example.com'),
-            }
-        )
-    ]
-
-
-@mock.patch('dmutils.email.DMNotifyClient', autospec=True)
-@mock.patch('dmapiclient.DataAPIClient', autospec=True)
-def test_main_does_not_catch_email_template_errors(data_api_client, notify_client):
-    logger = mock.Mock()
-    notify_client.send_email.side_effect = EmailTemplateError
-    data_api_client.find_brief_responses_iter.side_effect = [
-        [_get_dummy_brief_response(4321, AWARDED_BRIEFS[0], awarded=True)],
-        [_get_dummy_brief_response(1234, AWARDED_BRIEFS[0], awarded=False)],
-    ]
-
-    with pytest.raises(EmailTemplateError):
-        tested_script.main(
-            data_api_client, notify_client, 'notify_template_id', 'preview', logger
-        )
-
-    assert logger.error.call_args_list == [
-        mock.call(
-            'Email sending failed for BriefResponse {brief_response_id} (Brief ID {brief_id})',
-            extra={
-                "brief_id": 123,
-                "brief_response_id": 4321
-            }
-        ),
-    ]
-    assert logger.info.call_args_list == []


### PR DESCRIPTION
Adds a framework for writing scripts that send emails that aims to be

- Reliable
- Repeatable
- Auditable

The theory is based around a suggestion from @alex9smith and @bjgill, when running the email engine logs email notifications that are outstanding and sent are recorded in a human readable log file. If the script fails partway through sending emails, it can read back its own log file to pick up where it left off.

To use the email engine, the script provides a [generator function](https://wiki.python.org/moin/Generators) that calls the Digital Marketplace API and yields notifications to be sent; `dmscripts.email_engine.email_engine` handles everything else, including resuming failed runs, logging, and command line argument handling:

```python
from dmapiclient import DataAPIClient
from dmscripts.email_engine import email_engine

def notifications(stage, **kwargs):
    # generate emails to be sent by calling the DMp API
    data_api_client = DataAPIClient.from_stage(stage)
    for ... in data_api_client.find_some_iter(...):
        yield {
            "email_address": ...,
            "template_id": ...,
            "personalisation": ...
        }

if __name__ == "__main__":
    email_engine(notifications)
```

More examples and details are in the [docstring for `dmscripts.email_engine.__init__`](https://github.com/alphagov/digitalmarketplace-scripts/pull/660/files#diff-ee887f99f520d6592d7f5ba6a1df87ac4376e2a062b8807ff373b00996eb4901).

### Implementation notes

Most of the logic is in the module [dmscripts.email_engine.queue](https://github.com/alphagov/digitalmarketplace-scripts/pull/660/files#diff-9287bcd73e3dca0c283d89224b5f28404ae67b890df97b9576ce400028d56dca), encapsulated in a function called `run`.

### Outstanding

- [x] Add documentation to modules
- [x] Add proper commit messages
- [x] Add example email script using email engine
- [ ] Add example Jenkins job