### PR TITLE
only include hash in reference where no reference specified in args

### DIFF
--- a/dmscripts/email_engine/__init__.py
+++ b/dmscripts/email_engine/__init__.py
@@ -23,9 +23,8 @@ default (see email_engine.cli) this is the name of the script. Alternatively,
 you can override the reference with a command line argument. The reference is
 also used as the name of the logfile by default.
 
-A hash of the command line arguments is always appended to the reference,
-whether provided on the command line or not. This means running the same script
-with the same arguments will always have the same hash, but the same script
+If no reference argument is specified, a hash of the command line arguments is appended to the default reference,
+This means running the same script with the same arguments will always have the same hash, but the same script
 with different arguments will have a slightly different reference.
 
 How to use as a script runner

--- a/dmscripts/email_engine/cli.py
+++ b/dmscripts/email_engine/cli.py
@@ -39,7 +39,7 @@ def argument_parser_factory(
     can avoid duplication by not adding them to the function signature though.
 
     :param reference: default reference if none is supplied at command line,
-        if None the script name will be used
+        if None the script name will be used, plus a hash of the arguments
     :param logfile: default path to the logfile if none is supplied at command line,
         if None /tmp/<reference>.log will be used
 
@@ -61,6 +61,9 @@ def argument_parser_factory(
     # need to mock sys.argv when calling argument_parser_factory in tests.
     if reference is None:
         reference = Path(sys.argv[0]).stem
+        reference_is_default = True
+    else:
+        reference_is_default = False
 
     p = _ArgumentParser(
         description=kwargs.get("description"),
@@ -105,10 +108,10 @@ def argument_parser_factory(
     p.add_argument(
         "--reference",
         default=reference,
-        type=append_hash_of_argv,
+        type=append_hash_of_argv if reference_is_default else None,  # Only append hash if no reference specified
         help=(
             "Identifer to reference all the emails sent by this script (sent to Notify)."
-            " Defaults to the name of the script."
+            " Defaults to the name of the script, plus a hash of the arguments."
         ),
     )
 

--- a/tests/email_engine/test_cli.py
+++ b/tests/email_engine/test_cli.py
@@ -76,7 +76,7 @@ class TestArgumentParser:
         with mock.patch("sys.argv", ["foo"]):
             args = argument_parser_factory(reference="bar").parse_args([])
 
-        assert args.reference == "bar-d5af0203"
+        assert args.reference == "bar"
 
     def test_reference_cli_argument_overrides_factory_arg(self, argument_parser_factory):
         with mock.patch("sys.argv", ["foo"]):
@@ -84,7 +84,7 @@ class TestArgumentParser:
                 ["--reference=baz"]
             )
 
-        assert args.reference == "baz-e4c8b7f6"
+        assert args.reference == "baz"
 
     def test_default_logfile_path_is_derived_from_reference(self, argument_parser_factory):
         with mock.patch("sys.argv", ["foo"]):
@@ -95,4 +95,4 @@ class TestArgumentParser:
         with mock.patch("sys.argv", ["foo"]):
             args = argument_parser_factory(reference="bar").parse_args([])
 
-        assert args.logfile == Path("/tmp/bar-d5af0203.log")
+        assert args.logfile == Path("/tmp/bar.log")

--- a/tests/email_engine/test_email_engine.py
+++ b/tests/email_engine/test_email_engine.py
@@ -55,15 +55,16 @@ class TestEmailEngine:
                 email_address="test1@example.com",
                 template_id="000-001",
                 personalisation={"name": "test1"},
-                reference="test_email_engine-f558d11a",
+                reference="test_email_engine",
             ),
             mock.call(
                 email_address="test2@example.com",
                 template_id="000-001",
                 personalisation={"name": "test2"},
-                reference="test_email_engine-f558d11a",
+                reference="test_email_engine",
             ),
         ]
+        
 
         caplog.messages[
             -1
@@ -138,5 +139,5 @@ class TestEmailEngine:
             "queue update: generator is exhausted, read 2 notifications into queue",
             "queue update: send notification {'email_address': 'test1@example.com', 'template_id': '000-001', 'personalisation': {'name': 'test1'}} response {}",
             "queue update: send notification {'email_address': 'test2@example.com', 'template_id': '000-001', 'personalisation': {'name': 'test2'}} response {}",
-            "sent 2 email notifications with reference test_email_engine_logfile-a16feb2f",
+            "sent 2 email notifications with reference test_email_engine_logfile",
         ]


### PR DESCRIPTION
https://trello.com/c/3hLue99t/919-1-finish-creating-a-system-for-bulk-email-scripts-that-is-reliable-repeatable-and-auditable

In order to make it easier to retry jobs when run on CI, only include the argument hash when no reference is specified.

This supports the changes in https://github.com/alphagov/digitalmarketplace-jenkins/pull/422/commits/c6eda3be1a958cc1cfe9ef9b299f463dce3976ab to allow re-running of jobs on Jenkins.