### PR TITLE
Create script to redact data in a brief response

### DIFF
--- a/scripts/oneoff/redact_brief_response.sql
+++ b/scripts/oneoff/redact_brief_response.sql
@@ -1,0 +1,36 @@
+/*
+This script is to redact a brief response and also all related audit messages.
+
+This is very dangerous - you should only run it after testing on non-production environments, and with the agreement of
+IA.
+
+To apply this script, target the correct environment with `cf target -s <desired environment>`, then run
+`cf conduit digitalmarketplace_api_db -- psql -v id=<brief response ID> < ./scripts/oneoff/redact_brief_response.sql`
+*/
+
+UPDATE brief_responses
+SET data = data::jsonb
+    || '{"respondToEmailAddress": "<REMOVED>"}'::jsonb
+    || '{"essentialRequirements": [{"evidence": "<REMOVED>"}, {"evidence": "<REMOVED>"}, {"evidence": "<REMOVED>"}, {"evidence": "<REMOVED>"}, {"evidence": "<REMOVED>"}, {"evidence": "<REMOVED>"}]}'::jsonb
+    || '{"niceToHaveRequirements": [{"yesNo": false}, {"yesNo": false}]}'::jsonb
+WHERE id=:id;
+
+UPDATE audit_events
+SET data = data::jsonb
+        || '{"briefResponseData":"<REMOVED>"}'::jsonb
+        || ('{"redaction": {"reason": "Security - see Zendesk ticket https://govuk.zendesk.com/agent/tickets/4540337", "timestamp": "' || now() || '"}}')::jsonb
+WHERE object_id=:id and object_type='BriefResponse' and type='update_brief_response';
+
+INSERT INTO
+   audit_events (type, created_at, "user", data, object_type, object_id, acknowledged, acknowledged_by, acknowledged_at)
+VALUES (
+  'update_brief_response',
+  now(),
+  'DM Developers',
+  '{"what": "Redacted respondToEmailAddress, essentialRequirements, and niceToHaveRequirements", "reason": "Security - see Zendesk ticket https://govuk.zendesk.com/agent/tickets/4540337"}'::json,
+  'BriefResponse',
+  :id,
+  't',
+  'DM Developers',
+  now()
+);


### PR DESCRIPTION
A brief response has data that we need to redact - see https://govuk.zendesk.com/agent/tickets/4540337. To ensure the data is completely removed, we also need to redact all related audit events.

There is no way to do this via the API. We don't want to introduce such a mechanism because it would be a dangerous back-door.

We have agreed this with CDIO IA and also CCS. See the linked Zendesk ticket above for the paper trail.

Note - this is very dangerous. If you want to run this in future, you should only run it after testing on non-production environments, and with the agreement of
IA.