### PR TITLE
Parse reference using sys.argv

### DIFF
--- a/dmscripts/email_engine/cli.py
+++ b/dmscripts/email_engine/cli.py
@@ -57,13 +57,13 @@ def argument_parser_factory(
         include a required flag to specify the template ID (default: false).
     """
 
+    def has_custom_reference():
+        return any(arg.startswith('--reference') for arg in sys.argv)
+
     # Generate the default reference from sys.argv. This does mean you will
     # need to mock sys.argv when calling argument_parser_factory in tests.
     if reference is None:
         reference = Path(sys.argv[0]).stem
-        reference_is_default = True
-    else:
-        reference_is_default = False
 
     p = _ArgumentParser(
         description=kwargs.get("description"),
@@ -108,7 +108,7 @@ def argument_parser_factory(
     p.add_argument(
         "--reference",
         default=reference,
-        type=append_hash_of_argv if reference_is_default else None,  # Only append hash if no reference specified
+        type=append_hash_of_argv if not has_custom_reference() else None,  # Only append hash if no reference specified
         help=(
             "Identifer to reference all the emails sent by this script (sent to Notify)."
             " Defaults to the name of the script, plus a hash of the arguments."

--- a/dmscripts/email_engine/cli.py
+++ b/dmscripts/email_engine/cli.py
@@ -108,6 +108,8 @@ def argument_parser_factory(
     p.add_argument(
         "--reference",
         default=reference,
+        # TODO: figure out a way of determining this which also works when reference is specified directly
+        #  in email_engine args only
         type=append_hash_of_argv if not has_custom_reference() else None,  # Only append hash if no reference specified
         help=(
             "Identifer to reference all the emails sent by this script (sent to Notify)."

--- a/tests/email_engine/test_cli.py
+++ b/tests/email_engine/test_cli.py
@@ -73,13 +73,13 @@ class TestArgumentParser:
         assert args.reference == "foobar-6a2639d8"
 
     def test_reference_default_prefix_overridable_by_factory_arg(self, argument_parser_factory):
-        with mock.patch("sys.argv", ["foo"]):
+        with mock.patch("sys.argv", ["foo", "--reference=bar"]):
             args = argument_parser_factory(reference="bar").parse_args([])
 
         assert args.reference == "bar"
 
     def test_reference_cli_argument_overrides_factory_arg(self, argument_parser_factory):
-        with mock.patch("sys.argv", ["foo"]):
+        with mock.patch("sys.argv", ["foo", "--reference=baz"]):
             args = argument_parser_factory(reference="bar").parse_args(
                 ["--reference=baz"]
             )
@@ -92,7 +92,7 @@ class TestArgumentParser:
 
         assert args.logfile == Path("/tmp/foo-f55be76c.log")
 
-        with mock.patch("sys.argv", ["foo"]):
+        with mock.patch("sys.argv", ["foo", "--reference=bar"]):
             args = argument_parser_factory(reference="bar").parse_args([])
 
         assert args.logfile == Path("/tmp/bar.log")

--- a/tests/email_engine/test_email_engine.py
+++ b/tests/email_engine/test_email_engine.py
@@ -1,6 +1,6 @@
 # this file needs a lot of long lines because we are testing examples of logfiles
 # flake8: noqa E501
-
+import sys
 from unittest import mock
 
 import pytest
@@ -39,12 +39,13 @@ class TestEmailEngine:
 
         notifications_generator = mock.Mock(wraps=notifications_generator)
 
-        email_engine(
-            notifications_generator,
-            argv=[],
-            reference="test_email_engine",
-            logfile=logfile,
-        )
+        with mock.patch.object(sys, 'argv', ['--reference=test_email_engine']):
+            email_engine(
+                notifications_generator,
+                argv=[],
+                reference="test_email_engine",
+                logfile=logfile,
+            )
 
         assert notifications_generator.called
         assert notifications_api_client.call_args == mock.call("test-api-key")
@@ -123,12 +124,13 @@ class TestEmailEngine:
             "test_api_key"
         ).send_email_notification.return_value = {}
 
-        email_engine(
-            notifications_generator,
-            argv=[],
-            reference="test_email_engine_logfile",
-            logfile=logfile,
-        )
+        with mock.patch.object(sys, 'argv', ['--reference=test_email_engine_logfile']):
+            email_engine(
+                notifications_generator,
+                argv=[],
+                reference="test_email_engine_logfile",
+                logfile=logfile,
+            )
 
         loglines = logfile.read_text().splitlines()
         assert loglines == [


### PR DESCRIPTION
https://trello.com/c/3hLue99t/919-1-finish-creating-a-system-for-bulk-email-scripts-that-is-reliable-repeatable-and-auditable
Bug-fix after #665
Previously although the tests passed in #665 the reference was still being appended erroneously at runtime. Reading `sys.argv` during initialisation resolves this.