### PR TITLE
Pass notification hash to Notify

### DIFF
--- a/dmscripts/email_engine/__init__.py
+++ b/dmscripts/email_engine/__init__.py
@@ -208,10 +208,9 @@ def email_engine(
         def send_email_notification(
             notification: EmailNotification,
         ) -> NotificationResponse:
-            # note that all notifications will have the same reference
             return notify_client.send_email_notification(
                 **notification,
-                reference=reference,
+                reference=f"{reference}-{notification.sha256_hash}",
             )
 
     try:

--- a/dmscripts/email_engine/typing.py
+++ b/dmscripts/email_engine/typing.py
@@ -10,6 +10,8 @@ reading it back into memory in a human readable fashion.
 from ast import literal_eval
 from typing import Callable, Dict, Generator, Union
 
+from dmutils.email.helpers import hash_string
+
 
 class EmailNotification(dict):
     """A typed, hashable, serder-able, frozen dict subclass
@@ -60,6 +62,23 @@ class EmailNotification(dict):
     def from_str(cls, s: str) -> "EmailNotification":
         """Parse a dict literal representation of a notification"""
         return cls(**literal_eval(s))
+
+    @property
+    def sha256_hash(self) -> str:
+        # Calculate the SHA256 hash of the string representation. This is reproducible and allows us to generate a
+        # unique reference for an email that can be stored in our logs and checked to see an email's status
+        # The order of keys is important for the hash, so make it explicit
+        return (
+            hash_string(
+                str(
+                    dict(
+                        email_address=self["email_address"],
+                        template_id=self["template_id"],
+                        personalisation=self["personalisation"],
+                    )
+                )
+            )
+        )
 
 
 class NotificationResponse(dict):

--- a/tests/email_engine/test_email_engine.py
+++ b/tests/email_engine/test_email_engine.py
@@ -56,13 +56,13 @@ class TestEmailEngine:
                 email_address="test1@example.com",
                 template_id="000-001",
                 personalisation={"name": "test1"},
-                reference="test_email_engine",
+                reference="test_email_engine-giOMmd3dhc52GqVUTRNFoXDGIfAeC5wLZFnPV9rM5L4=",
             ),
             mock.call(
                 email_address="test2@example.com",
                 template_id="000-001",
                 personalisation={"name": "test2"},
-                reference="test_email_engine",
+                reference="test_email_engine-bVPjXSd-Joerdai08PbodN0WxjLvWhRaOgiehCsIXew=",
             ),
         ]
         

--- a/tests/email_engine/test_typing.py
+++ b/tests/email_engine/test_typing.py
@@ -61,3 +61,20 @@ class TestEmailNotification:
         b = EmailNotification.from_str(str(a))
 
         assert a == b
+
+    def test_sha256_hash(self):
+        a = EmailNotification(
+            email_address="hello@example.com",
+            template_id="0000-0000",
+            personalisation={"name": "Hello"},
+        )
+
+        assert a.sha256_hash == "Zx8N_Nk8MWw6EGGpYcY5JLLc4dwSBvfQDXu3rhYQx2c="
+
+        b = EmailNotification(
+            email_address="hello@example.com",
+            template_id="0000-0000",
+            personalisation={"name": "Hello"},
+        )
+
+        assert a.sha256_hash == b.sha256_hash


### PR DESCRIPTION
We want to send a unique reference to Notify for every email we send. The reference should be reproducible to allow us to re-create and look up an email's status in our logs at a future date. This is useful when investigating 2nd line requests, or in the face of a potential legal challenge from a supplier.

Scripts not using the email engine already construct this unique reference.

Add a property `EmailNotification.sha256_hash` which computes the SHA256 hash on the string representation of the object.

`EmailNotification` already implements the `__hash__()` method, however this is salted with a random value which changes between Python processes[[1]] and therefore cannot be used to re-create a reference at a future date.

https://trello.com/c/jsjBYAIm/1572-emailengine-does-not-use-unique-reference-hash-per-email

[1]:https://docs.python.org/3/reference/datamodel.html#object.__hash__