### PR TITLE
Automate process to remove a user's personal information

### DIFF
--- a/dmscripts/data_retention_remove_user_data.py
+++ b/dmscripts/data_retention_remove_user_data.py
@@ -7,6 +7,55 @@ class MailchimpRemovalFailed(EnvironmentError):
     pass
 
 
+def remove_user_from_mailchimp(dm_mailchimp_client, logger, user, dry_run=True):
+    prefix = "[DRY RUN]: " if dry_run else ""
+
+    email_hash = dm_mailchimp_client.get_email_hash(user["emailAddress"])
+    logger.info(
+        "Checking mailing list membership for email with hash %s (user %s)",
+        email_hash,
+        user["id"],
+    )
+    mailing_lists = dm_mailchimp_client.get_lists_for_email(user["emailAddress"])
+    if mailing_lists:
+        for mailing_list in mailing_lists:
+            logger.warn(
+                "%sRemoving email with hash %s from list %s ('%s')",
+                prefix,
+                email_hash,
+                mailing_list["list_id"],
+                mailing_list["name"],
+            )
+            if not dry_run:
+                rm_result = dm_mailchimp_client.permanently_remove_email_from_list(
+                    email_address=user["emailAddress"],
+                    list_id=mailing_list["list_id"],
+                )
+                if not rm_result:
+                    raise MailchimpRemovalFailed(
+                        "Mailchimp failure trying to permanently_remove_email_from_list"
+                    )
+
+
+def remove_user_data(
+    data_api_client,
+    logger,
+    user,
+    dm_mailchimp_client=None,
+    dry_run=True,
+):
+    prefix = "[DRY RUN]: " if dry_run else ""
+
+    if dm_mailchimp_client is not None:
+        remove_user_from_mailchimp(dm_mailchimp_client, logger, user, dry_run)
+
+    logger.warn(f"{prefix}Removing personal data in API for user: {user['id']}")
+    if not dry_run:
+        data_api_client.remove_user_personal_data(
+            user["id"], "Data Retention Script {}".format(datetime.now().isoformat())
+        )
+
+
 def data_retention_remove_user_data(
     data_api_client,
     logger,
@@ -14,49 +63,10 @@ def data_retention_remove_user_data(
     dry_run=True,
 ):
     cutoff_date = datetime.now() - timedelta(days=365 * 3)
-    prefix = '[DRY RUN]: ' if dry_run else ''
 
     for user in data_api_client.find_users_iter(personal_data_removed=False):
-        last_logged_in_at = datetime.strptime(user['loggedInAt'], DATETIME_FORMAT)
+        last_logged_in_at = datetime.strptime(user["loggedInAt"], DATETIME_FORMAT)
         if last_logged_in_at < cutoff_date:
-            if dm_mailchimp_client is not None:
-                email_hash = dm_mailchimp_client.get_email_hash(user["emailAddress"])
-                logger.info(
-                    "Checking mailing list membership for email with hash %s (user %s)",
-                    email_hash,
-                    user["id"],
-                )
-                mailing_lists = dm_mailchimp_client.get_lists_for_email(user["emailAddress"])
-                if mailing_lists:
-                    for mailing_list in mailing_lists:
-                        logger.warn(
-                            f"%sRemoving email with hash %s from list %s ('%s')",
-                            prefix,
-                            email_hash,
-                            mailing_list["list_id"],
-                            mailing_list["name"],
-                        )
-                        if not dry_run:
-                            rm_result = dm_mailchimp_client.permanently_remove_email_from_list(
-                                email_address=user["emailAddress"],
-                                list_id=mailing_list["list_id"],
-                            )
-                            if not rm_result:
-                                raise MailchimpRemovalFailed(
-                                    "Mailchimp failure trying to permanently_remove_email_from_list"
-                                )
-                else:
-                    logger.info(
-                        "%s (user %s) not a member of any mailing lists",
-                        email_hash,
-                        user["id"],
-                    )
-
-            logger.warn(
-                f"{prefix}Removing personal data in API for user: {user['id']}"
+            remove_user_data(
+                data_api_client, logger, user, dm_mailchimp_client, dry_run
             )
-            if not dry_run:
-                data_api_client.remove_user_personal_data(
-                    user['id'],
-                    'Data Retention Script {}'.format(datetime.now().isoformat())
-                )

--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -26,7 +26,7 @@ def get_auth_token(api, stage):
     if not auth_token:
         DM_CREDENTIALS_REPO = os.environ.get('DM_CREDENTIALS_REPO', '../digitalmarketplace-credentials')
         token_prefix = 'J' if subprocess.check_output(["whoami"]) == 'jenkins' else 'D'
-        creds_json = _decrypt_yaml_file_with_sops(DM_CREDENTIALS_REPO, "vars/{}.yaml".format(stage))
+        creds_json = _decrypt_yaml_file_with_sops(DM_CREDENTIALS_REPO, f"vars/{stage}.yaml")
         auth_tokens = creds_json[api]['auth_tokens']
         auth_token = next(token for token in auth_tokens if token.startswith(token_prefix))
 
@@ -75,7 +75,7 @@ def get_jenkins_env_variable(jenkins_var_name):
 
 def get_mailchimp_credentials(stage):
     credentials_repo = os.environ.get('DM_CREDENTIALS_REPO', '../digitalmarketplace-credentials')
-    credentials = _decrypt_yaml_file_with_sops(credentials_repo, "vars/{}.yaml".format(stage))
+    credentials = _decrypt_yaml_file_with_sops(credentials_repo, f"vars/{stage}.yaml")
     return (
         credentials['supplier_frontend']['mailchimp_username'],
         credentials['supplier_frontend']['mailchimp_api_key']

--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -71,3 +71,12 @@ def get_jenkins_env_variable(jenkins_var_name):
         )
 
     return value
+
+
+def get_mailchimp_credentials(stage):
+    credentials_repo = os.environ.get('DM_CREDENTIALS_REPO', '../digitalmarketplace-credentials')
+    credentials = _decrypt_yaml_file_with_sops(credentials_repo, "vars/{}.yaml".format(stage))
+    return (
+        credentials['supplier_frontend']['mailchimp_username'],
+        credentials['supplier_frontend']['mailchimp_api_key']
+    )

--- a/scripts/remove-user-personal-information.py
+++ b/scripts/remove-user-personal-information.py
@@ -6,12 +6,12 @@ This script should be run in response to a user requesting that we delete their 
 data from both our database and mailchimp.
 
 Usage:
-    scripts/remove-user-personal-information.py <stage> <mailchimp_api_key> <mailchimp_username> <user_email> [options]
+    scripts/remove-user-personal-information.py <stage> <user_email> [options]
 
 Options:
-    --dry-run                                             List account that would have data stripped
+    --dry-run    List account that would have data stripped
     --verbose
-    -h, --help                                            Show this screen
+    -h, --help   Show this screen
 """
 import logging
 import sys
@@ -24,7 +24,7 @@ sys.path.insert(0, ".")
 from dmutils.email.dm_mailchimp import DMMailChimpClient
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
-from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.auth_helpers import get_auth_token, get_mailchimp_credentials
 from dmscripts.helpers import logging_helpers
 from dmscripts.data_retention_remove_user_data import remove_user_data
 
@@ -42,9 +42,10 @@ if __name__ == "__main__":
         base_url=get_api_endpoint_from_stage(stage),
         auth_token=get_auth_token("api", stage),
     )
+    (username, api_key) = get_mailchimp_credentials(stage)
     dm_mailchimp_client = DMMailChimpClient(
-        arguments["<mailchimp_username>"],
-        arguments["<mailchimp_api_key>"],
+        username,
+        api_key,
         logger,
     )
 

--- a/scripts/remove-user-personal-information.py
+++ b/scripts/remove-user-personal-information.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Remove a user's personal information from the Digital Marketplace.
+
+This script should be run in response to a user requesting that we delete their personal information. It removes their
+data from both our database and mailchimp.
+
+Usage:
+    scripts/remove-user-personal-information.py <stage> <mailchimp_api_key> <mailchimp_username> <user_email> [options]
+
+Options:
+    --dry-run                                             List account that would have data stripped
+    --verbose
+    -h, --help                                            Show this screen
+"""
+import logging
+import sys
+from docopt import docopt
+
+from dmapiclient import DataAPIClient
+
+sys.path.insert(0, ".")
+
+from dmutils.email.dm_mailchimp import DMMailChimpClient
+from dmutils.env_helpers import get_api_endpoint_from_stage
+
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers import logging_helpers
+from dmscripts.data_retention_remove_user_data import remove_user_data
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    logger = logging_helpers.configure_logger(
+        {"dmapiclient": logging.INFO}
+        if arguments["--verbose"]
+        else {"dmapiclient": logging.WARN}
+    )
+
+    stage = arguments["<stage>"]
+    data_api_client = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(stage),
+        auth_token=get_auth_token("api", stage),
+    )
+    dm_mailchimp_client = DMMailChimpClient(
+        arguments["<mailchimp_username>"],
+        arguments["<mailchimp_api_key>"],
+        logger,
+    )
+
+    user = data_api_client.get_user(email_address=arguments["<user_email>"])
+    if not user:
+        raise Exception("User not found")
+
+    remove_user_data(
+        data_api_client=data_api_client,
+        logger=logger,
+        user=user["users"],
+        dm_mailchimp_client=dm_mailchimp_client,
+        dry_run=arguments["--dry-run"],
+    )


### PR DESCRIPTION
https://trello.com/c/LUM3xADl/1552-2-script-manually-triggered-deletion-of-a-users-pii

Create a script to automate the [process](https://alphagov.github.io/digitalmarketplace-manual/2nd-line-runbook/support-tasks.html#removing-personal-data) which we've previously done manually.

This should save significant time by removing the need for developers to log in to mailchimp to perform the removal manually.

Do some refactoring to allow us to re-use existing PII deletion functionality.

From my testing, this seems to work on Preview. Once it's been reviewed, I'll test it using [a real deletion request](https://govuk.zendesk.com/agent/tickets/4582433) against production before merging.