### PR TITLE
Upgrade python-json-logger to unblock lib upgrades

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,6 @@ itsdangerous==2.0.1
 digitalmarketplace-apiclient
 digitalmarketplace-content-loader
 digitalmarketplace-utils
-git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8
 
 backoff==1.10.0
 docopt==0.6.2
@@ -15,6 +14,7 @@ jsonschema==3.2.0
 lorem==0.1.1
 pypdf2==1.26.0
 python-dateutil==2.8.1
+python-json-logger==0.1.11
 unicodecsv==0.14.1
 xeger==0.3.5
 yq==2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,9 +36,9 @@ defusedxml==0.6.0
     # via odfpy
 digitalmarketplace-apiclient==22.0.0
     # via -r requirements.in
-digitalmarketplace-content-loader==8.0.0
+digitalmarketplace-content-loader==8.1.1
     # via -r requirements.in
-digitalmarketplace-utils==58.1.0
+digitalmarketplace-utils==59.0.0
     # via
     #   -r requirements.in
     #   digitalmarketplace-content-loader
@@ -125,7 +125,7 @@ python-dateutil==2.8.1
     # via
     #   -r requirements.in
     #   botocore
-git+https://github.com/madzak/python-json-logger.git@v0.1.8#egg=python-json-logger==0.1.8
+python-json-logger==0.1.11
     # via
     #   -r requirements.in
     #   digitalmarketplace-utils
@@ -162,9 +162,7 @@ urllib3==1.25.10
     #   botocore
     #   requests
 werkzeug==1.0.0
-    # via
-    #   digitalmarketplace-utils
-    #   flask
+    # via flask
 workdays==1.4
     # via digitalmarketplace-utils
 wtforms==2.2.1


### PR DESCRIPTION
Pinning to python-json-logger 0.1.8 was blocking us from upgrading content loader and utils. Upgrade them. Also switch to the version in pypi.org since that's faster to install/pull than git.

No changes that look scary: https://github.com/madzak/python-json-logger

Includes https://github.com/alphagov/digitalmarketplace-scripts/pull/676 and https://github.com/alphagov/digitalmarketplace-scripts/pull/675