### PR TITLE
restore testing on 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.6, 3.9]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Follow-up to #679 
Restore this whilst we work out if script on Jenkins still use it, or if Jenkins can be updated.