### PR TITLE
Create a script to make Dependabot PRs easier to handle

### DIFF
--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -68,8 +68,11 @@ def eligible_for_semiautomated_merge(pr):
     if not pr["statusCheckRollup"]:
         print(f'Wrong statusCheckRollup: {pr["statusCheckRollup"]}')
         return False
-    if any(
-        check["status"] != "COMPLETED" or check["conclusion"] != "SUCCESS"
+    if not all(
+        (
+            check["status"] == "COMPLETED" and check["conclusion"] == "SUCCESS"
+        )  # Github Actions
+        or check.get("state") == "SUCCESS"  # Snyk
         for check in pr["statusCheckRollup"]
     ):
         print("Wrong check status")

--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """
 Show a human all Dependabot PRs that look ready to be merged. If the human accepts, approve and merge the PRs.
+
+Requires GitHub's CLI tool: https://github.com/cli/cli
 """
 
 import json

--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+"""
+Show a human all Dependabot PRs that look ready to be merged. If the human accepts, approve and merge the PRs.
+"""
 
 import json
 import subprocess

--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -85,6 +85,7 @@ if __name__ == "__main__":
 
     for pr in dependabot_prs:
         print(f"\n# {pr['title']}")
+        print(pr['url'])
 
         if not eligible_for_semiautomated_merge(pr):
             print("Skipping")

--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -5,43 +5,21 @@ Show a human all Dependabot PRs that look ready to be merged. If the human accep
 
 import json
 import subprocess
+import requests
+import yaml
+
 from distutils.spawn import find_executable
 
-# From https://github.com/alphagov/seal/blob/main/config/alphagov.yml
-DIGITAL_MARKETPLACE_REPOS = [
-    "digitalmarketplace-admin-frontend",
-    "digitalmarketplace-agreements",
-    "digitalmarketplace-antivirus-api",
-    "digitalmarketplace-api",
-    "digitalmarketplace-apiclient",
-    "digitalmarketplace-aws",
-    "digitalmarketplace-bad-words",
-    "digitalmarketplace-brief-responses-frontend",
-    "digitalmarketplace-briefs-frontend",
-    "digitalmarketplace-buyer-frontend",
-    "digitalmarketplace-content-loader",
-    "digitalmarketplace-credentials",
-    "digitalmarketplace-developer-tools",
-    "digitalmarketplace-docker-base",
-    "digitalmarketplace-frameworks",
-    "digitalmarketplace-frontend-toolkit",
-    "digitalmarketplace-functional-tests",
-    "digitalmarketplace-govuk-frontend",
-    "digitalmarketplace-jenkins",
-    "digitalmarketplace-logdia",
-    "digitalmarketplace-manual",
-    "digitalmarketplace-performance-testing",
-    "digitalmarketplace-router",
-    "digitalmarketplace-runner",
-    "digitalmarketplace-scripts",
-    "digitalmarketplace-search-api",
-    "digitalmarketplace-supplier-frontend",
-    "digitalmarketplace-test-utils",
-    "digitalmarketplace-user-frontend",
-    "digitalmarketplace-utils",
-    "digitalmarketplace-visual-regression",
-    "govuk-frontend-jinja",
-]
+
+
+
+def get_digital_marketplace_repos():
+    response = requests.get(
+        "https://raw.githubusercontent.com/alphagov/seal/main/config/alphagov.yml"
+    )
+    response.raise_for_status()
+
+    return yaml.safe_load(response.text)["digitalmarketplace"]["include_repos"]
 
 
 def open_url_in_browser(url):
@@ -85,7 +63,7 @@ def eligible_for_semiautomated_merge(pr):
 
 if __name__ == "__main__":
     github_repo_string = " ".join(
-        f"repo:alphagov/{repo}" for repo in DIGITAL_MARKETPLACE_REPOS
+        f"repo:alphagov/{repo}" for repo in get_digital_marketplace_repos()
     )
 
     output = subprocess.run(

--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -2,6 +2,7 @@
 
 import json
 import subprocess
+from distutils.spawn import find_executable
 
 # From https://github.com/alphagov/seal/blob/main/config/alphagov.yml
 DIGITAL_MARKETPLACE_REPOS = [
@@ -38,6 +39,17 @@ DIGITAL_MARKETPLACE_REPOS = [
     "digitalmarketplace-visual-regression",
     "govuk-frontend-jinja",
 ]
+
+
+def open_url_in_browser(url):
+    if find_executable("open"):
+        # MacOS
+        subprocess.run(["open", url])
+    elif find_executable("xdg-open"):
+        # Linux
+        subprocess.run(["xdg-open", url])
+    else:
+        raise Exception("Unable to find tool to open the URL with")
 
 
 def eligible_for_semiautomated_merge(pr):
@@ -100,6 +112,7 @@ if __name__ == "__main__":
             continue
 
         print(f"Approve and merge '{pr['title']}'?")
+        open_url_in_browser(pr["url"])
         approve = input("Enter 'y' to approve and merge ")
 
         if approve == "y":

--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -100,6 +100,5 @@ if __name__ == "__main__":
             print("Approving and merging")
             subprocess.run(["gh", "pr", "review", "--approve", pr["url"]], check=True)
             subprocess.run(["gh", "pr", "merge", "--merge", pr["url"]], check=True)
-            print("Done")
         else:
             print("Skipping")

--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -84,13 +84,14 @@ if __name__ == "__main__":
     repos_merged_to = set()
 
     for pr in dependabot_prs:
-        print(f"\n# {pr['title']}")
+        repository = pr["headRepository"]["name"]
+
+        print(f"\n# {repository}: {pr['title']}")
         print(pr["url"])
 
         if not eligible_for_semiautomated_merge(pr):
             print("Skipping")
             continue
-        repository = pr["headRepository"]["name"]
         if repository in repos_merged_to:
             print(f"Skipping: already merged a PR to {repository}")
             continue

--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -11,8 +11,6 @@ import yaml
 from distutils.spawn import find_executable
 
 
-
-
 def get_digital_marketplace_repos():
     response = requests.get(
         "https://raw.githubusercontent.com/alphagov/seal/main/config/alphagov.yml"

--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -56,8 +56,11 @@ def eligible_for_semiautomated_merge(pr):
     if not pr["statusCheckRollup"]:
         print(f'Wrong statusCheckRollup: {pr["statusCheckRollup"]}')
         return False
-    if any(check["status"] != "COMPLETED" or check["conclusion"] != "SUCCESS" for check in pr["statusCheckRollup"]):
-        print('Wrong check status')
+    if any(
+        check["status"] != "COMPLETED" or check["conclusion"] != "SUCCESS"
+        for check in pr["statusCheckRollup"]
+    ):
+        print("Wrong check status")
         return False
     return True
 
@@ -86,12 +89,12 @@ if __name__ == "__main__":
 
     for pr in dependabot_prs:
         print(f"\n# {pr['title']}")
-        print(pr['url'])
+        print(pr["url"])
 
         if not eligible_for_semiautomated_merge(pr):
             print("Skipping")
             continue
-        repository = pr['headRepository']['name']
+        repository = pr["headRepository"]["name"]
         if repository in repos_merged_to:
             print(f"Skipping: already merged a PR to {repository}")
             continue


### PR DESCRIPTION
Currently, we need to review, approve and merge some tens of Dependabot PRs each week. The actual reviewing is not very hard - its usually obvious whether to approve a Dependabot PR.

The main problem is that the process involves so many manual clicks. To go from the search page to the PR, approve, and the merge takes at least 4 clicks across 3 pages.

Thus, I'm creating this script to automate the parts of this process that can be automated. It searches for Dependabot PRs, skipping those that are obviously not ready for merging. It then opens the PR in the browser for a human to do the review. The human then just needs to enter 'y' for the PR to be approved and merged.

I think this will cut down quite significantly on the time and effort of dealing with Dependabot PRs.