### PR TITLE
Stop using python 3.9-only features

### DIFF
--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
             "--search",
             f"label:dependencies state:open is:pr {github_repo_string}",
         ],
-        capture_output=True,
+        stdout=subprocess.PIPE,
         check=True,
     )
 


### PR DESCRIPTION
In review-dependabot-prs.py, we were using a new parameter that was not available in Python 3.6 (https://docs.python.org/3.6/library/subprocess.html). Revert to the old way of capturing output (that still works in 3.9).

I can confirm that the script now runs on Python 3.6