### PR TITLE
Include employment status in brief export

### DIFF
--- a/dmscripts/export_dos_opportunities.py
+++ b/dmscripts/export_dos_opportunities.py
@@ -17,7 +17,7 @@ DOS_OPPORTUNITY_HEADERS = [
     "Organisation Name", "Buyer Domain", "Location Of The Work",
     "Published At", "Open For", "Expected Contract Length", "Applications from SMEs",
     "Applications from Large Organisations", "Total Organisations", "Status", "Winning supplier",
-    "Size of supplier", "Contract amount", "Contract start date", "Clarification questions"
+    "Size of supplier", "Contract amount", "Contract start date", "Clarification questions", "Employment status"
 ]
 
 DOWNLOAD_FILE_NAME = "opportunity-data.csv"
@@ -68,7 +68,8 @@ def _build_row(
         winner['supplierOrganisationSize'] if winner else '',
         winner['awardDetails']['awardedContractValue'] if winner else '',
         winner['awardDetails']['awardedContractStartDate'] if winner else '',
-        len(brief['clarificationQuestions'])
+        len(brief['clarificationQuestions']),
+        brief.get('employmentStatus', ''),
     ]))
 
     if include_buyer_user_details:
@@ -103,7 +104,7 @@ def get_brief_data(client, logger, include_buyer_user_details: bool = False) -> 
     return rows
 
 
-def write_rows_to_csv(rows: List[Mapping[str, Any]], file_path: str, logger) -> None:
+def write_rows_to_csv(rows: List[Mapping[str, Any]], file_path: Path, logger) -> None:
     logger.info(f"Writing rows to {file_path}")
 
     # assumes all rows have the same keys

--- a/tests/test_export_dos_opportunities.py
+++ b/tests/test_export_dos_opportunities.py
@@ -28,6 +28,7 @@ example_brief = {
     "location": "London",
     "publishedAt": "2019-01-01T00:00:00.123456Z",
     "contractLength": "6 months",
+    "employmentStatus": "Contracted out service: the off-payroll rules do not apply",
     "status": "awarded",
     "users": [
         {
@@ -156,6 +157,7 @@ class TestGetBriefData:
                 ("Contract amount", "2345678"),
                 ("Contract start date", "2019-06-02"),
                 ("Clarification questions", 1),
+                ("Employment status", "Contracted out service: the off-payroll rules do not apply"),
             ))
         ]
 


### PR DESCRIPTION
https://trello.com/c/sFKzViM7/55-track-the-ir35-determination-of-dos-opportunities

We recently added this new field to briefs, so should add it to the data export as well. CCS have explicitly asked for it. It's already public information, so fine to include here.

Also incidentally fixed a minor type error.

~In draft until late afternoon on the 25th, when we'll have some closed opportunities with employment statuses to test this with. It's a pretty simple change, so I'm not expecting any problems, though.~