### PR TITLE
Sort approved service edits in the API

### DIFF
--- a/scripts/export-approved-service-edits.py
+++ b/scripts/export-approved-service-edits.py
@@ -17,7 +17,7 @@ Example:
 
     Count approved service edits in October 2020
 
-    ./scripts/oneoff/export-approved-service-edits.py 2020-10 2020-11
+    ./scripts/export-approved-service-edits.py 2020-10 2020-11
 """
 
 

--- a/scripts/export-approved-service-edits.py
+++ b/scripts/export-approved-service-edits.py
@@ -23,7 +23,7 @@ Example:
 
 import itertools
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Iterator, Optional
 
 from docopt import docopt

--- a/scripts/oneoff/export-approved-service-edits.py
+++ b/scripts/oneoff/export-approved-service-edits.py
@@ -46,7 +46,7 @@ def find_approved_service_edits(
     """Find service edits approved by users in a period"""
 
     audit_events = data_api_client.find_audit_events_iter(
-        acknowledged="true", latest_first=True, audit_type=AuditTypes.update_service
+        acknowledged="true", latest_first=True, audit_type=AuditTypes.update_service, sort_by="acknowledged_at"
     )
 
     # use datetimes to make our life easier
@@ -61,25 +61,9 @@ def find_approved_service_edits(
     if to_datetime:
         audit_events = filter(lambda e: e["acknowledgedAt"] < to_datetime, audit_events)
 
-    # Audit events can be acknowledged at any point after they are created, and
-    # because the server response is sorted by `createdAt` this means in theory
-    # we would need to search every page of the response to find all
-    # acknowledged in a time period. In practice service edits tend to get approved
-    # by admins in fairly regular blocks, so we just fudge it a bit.
-    # TODO: add an option to the api to return results sorted by `acknowledgedAt`
-
-    search_until: datetime = from_datetime - timedelta(
-        # anything more than 5 days takes a very long time
-        days=5
-    )
     audit_events = itertools.takewhile(
-        lambda e: e["acknowledgedAt"] > search_until, audit_events
+        lambda e: e["acknowledgedAt"] > from_datetime, audit_events
     )
-    audit_events = filter(lambda e: from_datetime < e["acknowledgedAt"], audit_events)
-
-    # sort by acknowledgedAt, this can take a while
-    audit_events = sorted(audit_events, key=lambda e: e["acknowledgedAt"])
-
     return audit_events
 
 


### PR DESCRIPTION
Previously, we had to do some rather hacky search to get audit events acknowledged in the interval of interest. This was because they were sorted by creation date by default. We made an assumption that events would always be acknowledged within 5 days, which might be a risky assumption over the end of year holiday period.

Take advantage of a new API feature (https://github.com/alphagov/digitalmarketplace-api/pull/1147) to get the audit events already sorted by the date they were acknowledged. This significantly simplifies the logic, slightly improves performance, and removes some potential edge cases.

Just finishing off something I noticed last time I was on support. I've tested this locally, and it doesn't obviously break anything.

Also move the script to a more sensible directory.