### PR TITLE
Add initial script to generate data for the DMp

### DIFF
--- a/dmscripts/generate_database_data.py
+++ b/dmscripts/generate_database_data.py
@@ -1,6 +1,5 @@
 import random
 import string
-import os
 from dmapiclient import DataAPIClient
 
 from typing import Optional
@@ -17,7 +16,7 @@ USER_ROLES = [
 ]
 
 
-DEFAULT_PASSWORD = os.getenv("DM_DEFAULT_PASSWORD", default=None)
+DEFAULT_PASSWORD = "Password1234"
 
 
 def generate_email_address(username: Optional[int] = None) -> str:

--- a/dmscripts/generate_database_data.py
+++ b/dmscripts/generate_database_data.py
@@ -1,0 +1,48 @@
+import random
+import string
+import os
+from dmapiclient import DataAPIClient
+
+from typing import Optional
+
+USER_ROLES = [
+    'admin',
+    'admin-ccs-category',
+    'admin-ccs-sourcing',
+    'admin-manager',
+    'admin-framework-manager',
+    'admin-ccs-data-controller',
+    'buyer',
+    'supplier',
+]
+
+
+DEFAULT_PASSWORD = os.getenv("DM_DEFAULT_PASSWORD", default=None)
+
+
+def generate_email_address(username: Optional[int] = None) -> str:
+    """Generate an email of the form 123456@user.marketplace.team"""
+    if username is not None:
+        return f"{username}@user.marketplace.team"
+    else:
+        return f"{random.randrange(1, 10 ** 6):06}@user.marketplace.team"
+
+
+def random_string_of_length(n: int = 10) -> str:
+    return ''.join(random.choice(string.ascii_letters) for _ in range(n))
+
+
+def generate_user(data: DataAPIClient, role: Optional[str] = None) -> dict:
+    """Generate a new user with randomised data and store it in the API"""
+
+    if role not in USER_ROLES:
+        raise ValueError(f"role: {role} not a valid user role")
+    user = {
+        "name": random_string_of_length(10),
+        "email_address": generate_email_address(),
+        "password": DEFAULT_PASSWORD,
+        "role": role,
+    }
+
+    data.create_user(user=user)
+    return user

--- a/dmscripts/generate_database_data.py
+++ b/dmscripts/generate_database_data.py
@@ -32,7 +32,7 @@ def random_string_of_length(n: int = 10) -> str:
     return ''.join(random.choice(string.ascii_letters) for _ in range(n))
 
 
-def generate_user(data: DataAPIClient, role: Optional[str] = None) -> dict:
+def generate_user(data: DataAPIClient, role: str) -> dict:
     """Generate a new user with randomised data and store it in the API"""
 
     if role not in USER_ROLES:

--- a/scripts/generate-database-data.py
+++ b/scripts/generate-database-data.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Fill a PostgresSQL database with enough randomly generated data to run the DMp. Currently only creates a single buyer
-user account.
+Populate your local database with enough randomly generated data to run the DMp using the API. Currently only creates a
+single buyer user account.
 
 You must set the environment variable "DM_DEFAULT_PASSWORD" for this script to run.
 

--- a/scripts/generate-database-data.py
+++ b/scripts/generate-database-data.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+Fill a PostgresSQL database with enough randomly generated data to run the DMp. Currently only creates a single buyer
+user account.
+
+You must set the environment variable "DM_DEFAULT_PASSWORD" for this script to run.
+
+Usage:
+./scripts/generate-database-data.py
+"""
+
+import sys
+from docopt import docopt
+from dmapiclient import DataAPIClient
+
+sys.path.insert(0, '.')
+from dmscripts.generate_database_data import generate_user
+from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.updated_by_helpers import get_user
+from dmutils.env_helpers import get_api_endpoint_from_stage
+
+STAGE = 'development'
+
+if __name__ == "__main__":
+    args = docopt(__doc__)
+
+    user = get_user()
+    api_token = get_auth_token('api', STAGE)
+
+    data = DataAPIClient(
+        base_url=get_api_endpoint_from_stage(STAGE),
+        auth_token=api_token,
+        user=user,
+    )
+
+    generate_user(data, "buyer")

--- a/scripts/generate-database-data.py
+++ b/scripts/generate-database-data.py
@@ -3,8 +3,6 @@
 Populate your local database with enough randomly generated data to run the DMp using the API. Currently only creates a
 single buyer user account.
 
-You must set the environment variable "DM_DEFAULT_PASSWORD" for this script to run.
-
 Usage:
 ./scripts/generate-database-data.py
 """

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -1,0 +1,29 @@
+import pytest
+import mock
+from dmscripts.generate_database_data import generate_user, USER_ROLES
+
+TEST_ROLES = USER_ROLES + ["not-a-role"]
+
+
+class TestGenerateUser:
+
+    def setup_method(self, method):
+        self.api_client_patch = mock.patch("dmapiclient.DataAPIClient", autospec=True)
+        self.api_client = self.api_client_patch.start()
+
+    def teardown_method(self, method):
+        self.api_client_patch.stop()
+
+    def test_generate_user_has_correct_keys(self):
+        buyer = generate_user(data=self.api_client, role="buyer")
+        assert set(buyer.keys()) == {"name", "email_address", "password", "role"}
+
+    @pytest.mark.parametrize(
+        "role,expected_error", [(role, None if role in USER_ROLES else ValueError) for role in TEST_ROLES])
+    def test_generate_user_validates_roles(self, role, expected_error):
+        if expected_error is not None:
+            with pytest.raises(expected_error):
+                generate_user(self.api_client, role=role)
+
+        else:
+            generate_user(self.api_client, role=role)

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -2,8 +2,6 @@ import pytest
 import mock
 from dmscripts.generate_database_data import generate_user, USER_ROLES
 
-TEST_ROLES = USER_ROLES + ["not-a-role"]
-
 
 class TestGenerateUser:
 
@@ -18,12 +16,10 @@ class TestGenerateUser:
         buyer = generate_user(data=self.api_client, role="buyer")
         assert set(buyer.keys()) == {"name", "email_address", "password", "role"}
 
-    @pytest.mark.parametrize(
-        "role,expected_error", [(role, None if role in USER_ROLES else ValueError) for role in TEST_ROLES])
-    def test_generate_user_validates_roles(self, role, expected_error):
-        if expected_error is not None:
-            with pytest.raises(expected_error):
-                generate_user(self.api_client, role=role)
+    @pytest.mark.parametrize("role", [role for role in USER_ROLES])
+    def test_generate_user_allows_valid_roles(self, role):
+        generate_user(self.api_client, role=role)
 
-        else:
-            generate_user(self.api_client, role=role)
+    def test_generate_user_doesnt_allow_invalid_role(self):
+        with pytest.raises(ValueError):
+            generate_user(self.api_client, role="not-a-role")

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -14,7 +14,7 @@ class TestGenerateUser:
 
     def test_generate_user_has_correct_keys(self):
         buyer = generate_user(data=self.api_client, role="buyer")
-        assert set(buyer.keys()) == {"name", "email_address", "password", "role"}
+        assert buyer.keys() == {"name", "email_address", "password", "role"}
 
     @pytest.mark.parametrize("role", [role for role in USER_ROLES])
     def test_generate_user_allows_valid_roles(self, role):


### PR DESCRIPTION
The first stage of my firebreak project.

We've discovered that the API will start against a local database as long as the required tables exist - it doesn't matter if there's no data in any of the tables. This means we can use the API client to insert our randomised data and benefit from all the validation and error handling that the API brings.

Currently this script only adds a single buyer user account, but it sets up a proof of concept for future steps.

https://trello.com/c/RNssJN4U/99-generate-data-for-locally-developing-the-dmp-rather-than-importing-cleaned-production-data