### PR TITLE
Sort dependabot PRs by title

### DIFF
--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -81,6 +81,7 @@ if __name__ == "__main__":
     )
 
     dependabot_prs = json.loads(output.stdout)
+    dependabot_prs.sort(key=lambda pr: pr['title'])
     repos_merged_to = set()
 
     for pr in dependabot_prs:


### PR DESCRIPTION
Dependabot PR titles are of the form "Bump X from Y to Z". So by sorting by title, we'll group together updates to the same dependency. This should make it easier to handle all PRs for one common dependency at the same time.