### PR TITLE
Fix data generation script

### DIFF
--- a/dmscripts/generate_database_data.py
+++ b/dmscripts/generate_database_data.py
@@ -38,7 +38,7 @@ def generate_user(data: DataAPIClient, role: str) -> dict:
         raise ValueError(f"role: {role} not a valid user role")
     user = {
         "name": random_string_of_length(10),
-        "email_address": generate_email_address(),
+        "emailAddress": generate_email_address(),
         "password": DEFAULT_PASSWORD,
         "role": role,
     }

--- a/dmscripts/generate_database_data.py
+++ b/dmscripts/generate_database_data.py
@@ -45,3 +45,8 @@ def generate_user(data: DataAPIClient, role: str) -> dict:
 
     data.create_user(user=user)
     return user
+
+
+def create_buyer_email_domain_if_not_present(data: DataAPIClient, email_domain: str):
+    if email_domain not in data.get_buyer_email_domains_iter():
+        data.create_buyer_email_domain(email_domain)

--- a/scripts/generate-database-data.py
+++ b/scripts/generate-database-data.py
@@ -12,7 +12,7 @@ from docopt import docopt
 from dmapiclient import DataAPIClient
 
 sys.path.insert(0, '.')
-from dmscripts.generate_database_data import generate_user
+from dmscripts.generate_database_data import generate_user, create_buyer_email_domain_if_not_present
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.updated_by_helpers import get_user
 from dmutils.env_helpers import get_api_endpoint_from_stage
@@ -30,5 +30,7 @@ if __name__ == "__main__":
         auth_token=api_token,
         user=user,
     )
+
+    create_buyer_email_domain_if_not_present(data, "user.marketplace.team")
 
     generate_user(data, "buyer")

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -1,6 +1,6 @@
 import pytest
 import mock
-from dmscripts.generate_database_data import generate_user, USER_ROLES
+from dmscripts.generate_database_data import generate_user, USER_ROLES, create_buyer_email_domain_if_not_present
 
 
 class TestGenerateUser:
@@ -23,3 +23,22 @@ class TestGenerateUser:
     def test_generate_user_doesnt_allow_invalid_role(self):
         with pytest.raises(ValueError):
             generate_user(self.api_client, role="not-a-role")
+
+
+class TestBuyerEmailDomain:
+
+    def setup_method(self, method):
+        self.api_client_patch = mock.patch("dmapiclient.DataAPIClient", autospec=True)
+        self.api_client = self.api_client_patch.start()
+
+    def teardown_method(self, method):
+        self.api_client_patch.stop()
+
+    def test_adds_domain(self):
+        create_buyer_email_domain_if_not_present(data=self.api_client, email_domain="user.marketplace.team")
+        self.api_client.create_buyer_email_domain.assert_called_with("user.marketplace.team")
+
+    def test_doesnt_add_domain_twice(self):
+        self.api_client.get_buyer_email_domains_iter.return_value = ["user.marketplace.team"]
+        create_buyer_email_domain_if_not_present(data=self.api_client, email_domain="user.marketplace.team")
+        assert not self.api_client.create_buyer_email_domain.called

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -14,7 +14,7 @@ class TestGenerateUser:
 
     def test_generate_user_has_correct_keys(self):
         buyer = generate_user(data=self.api_client, role="buyer")
-        assert buyer.keys() == {"name", "email_address", "password", "role"}
+        assert buyer.keys() == {"name", "emailAddress", "password", "role"}
 
     @pytest.mark.parametrize("role", [role for role in USER_ROLES])
     def test_generate_user_allows_valid_roles(self, role):


### PR DESCRIPTION
This PR makes two changes that mean `scripts/generate-database-data.py` can now run against a database with tables set up but no data.

Firstly, fix a mistake with the email address key when using the API client to create a user.

Secondly, add a new function to add a domain to the list of approved buyer email domains. This has to happen before we try to add any buyer user accounts.

https://trello.com/c/ZAbcTEKR/106-3-create-script-to-generate-test-data-without-dependency-on-any-private-asset