### PR TITLE
Set all frameworks to expired

### DIFF
--- a/dmscripts/generate_database_data.py
+++ b/dmscripts/generate_database_data.py
@@ -50,3 +50,9 @@ def generate_user(data: DataAPIClient, role: str) -> dict:
 def create_buyer_email_domain_if_not_present(data: DataAPIClient, email_domain: str):
     if email_domain not in data.get_buyer_email_domains_iter():
         data.create_buyer_email_domain(email_domain)
+
+
+def set_all_frameworks_to_expired(data: DataAPIClient) -> None:
+    for framework in data.find_frameworks().get("frameworks", []):
+        if framework["status"] != "expired":
+            data.update_framework(framework_slug=framework["slug"], data={"status": "expired"})

--- a/scripts/generate-database-data.py
+++ b/scripts/generate-database-data.py
@@ -12,7 +12,11 @@ from docopt import docopt
 from dmapiclient import DataAPIClient
 
 sys.path.insert(0, '.')
-from dmscripts.generate_database_data import generate_user, create_buyer_email_domain_if_not_present
+from dmscripts.generate_database_data import (
+    create_buyer_email_domain_if_not_present,
+    generate_user,
+    set_all_frameworks_to_expired,
+)
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.updated_by_helpers import get_user
 from dmutils.env_helpers import get_api_endpoint_from_stage
@@ -30,6 +34,10 @@ if __name__ == "__main__":
         auth_token=api_token,
         user=user,
     )
+
+    # Applying only the database migrations to an empty database creates several frameworks in various states. Set
+    # them all to expired before we start adding new data
+    set_all_frameworks_to_expired(data)
 
     create_buyer_email_domain_if_not_present(data, "user.marketplace.team")
 


### PR DESCRIPTION
Applying only the database migrations to an empty database creates several old frameworks in various states. This causes problems when the frontend apps try to load content for frameworks we don't have content for (eg. G-Cloud 5).

Set all existing frameworks  to expired before we start adding new data.

https://trello.com/c/ZAbcTEKR/106-3-create-script-to-generate-test-data-without-dependency-on-any-private-asset