### PR TITLE
Fix adding a buyer email domain

### DIFF
--- a/dmscripts/generate_database_data.py
+++ b/dmscripts/generate_database_data.py
@@ -48,7 +48,7 @@ def generate_user(data: DataAPIClient, role: str) -> dict:
 
 
 def create_buyer_email_domain_if_not_present(data: DataAPIClient, email_domain: str):
-    if email_domain not in data.get_buyer_email_domains_iter():
+    if email_domain not in {d["domainName"] for d in data.get_buyer_email_domains_iter()}:
         data.create_buyer_email_domain(email_domain)
 
 

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -40,7 +40,7 @@ class TestBuyerEmailDomain(TestGenerateDataBase):
         self.api_client.create_buyer_email_domain.assert_called_with("user.marketplace.team")
 
     def test_doesnt_add_domain_twice(self):
-        self.api_client.get_buyer_email_domains_iter.return_value = ["user.marketplace.team"]
+        self.api_client.get_buyer_email_domains_iter.return_value = [{"domainName": "user.marketplace.team", "id": 1}]
         create_buyer_email_domain_if_not_present(data=self.api_client, email_domain="user.marketplace.team")
         assert not self.api_client.create_buyer_email_domain.called
 


### PR DESCRIPTION
`data.get_buyer_email_domains_iter` returns a list of dictionaries, not just approved domains, so this function raised an error if the domain name was already in the database.

The structure of the returned dictionary: 
```
IPython 7.12.0 -- An enhanced Interactive Python. Type '?' for help.

local rw
In [1]: [i for i in data.get_buyer_email_domains_iter()]
Out[1]: [{'domainName': 'user.marketplace.team', 'id': 1}]
```