### PR TITLE
Create script to add external collaborator

### DIFF
--- a/scripts/oneoff/add-external-collaborator.py
+++ b/scripts/oneoff/add-external-collaborator.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+Add an external collaborator to all our repos. Must be run by a GitHub admin.
+
+Usage:
+    add-external-collaborator.py <username>
+
+See https://docs.github.com/en/rest/reference/orgs#outside-collaborators for removal instructions.
+
+Requires GitHub's CLI tool: https://github.com/cli/cli
+"""
+import subprocess
+
+import requests
+import yaml
+from docopt import docopt
+
+
+def get_digital_marketplace_repos():
+    response = requests.get(
+        "https://raw.githubusercontent.com/alphagov/seal/main/config/alphagov.yml"
+    )
+    response.raise_for_status()
+
+    return yaml.safe_load(response.text)["digitalmarketplace"]["include_repos"]
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+    username = arguments["<username>"]
+
+    for repository in get_digital_marketplace_repos():
+        print(f"Adding {username} to {repository}")
+        # Follows https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator.
+        subprocess.run(
+            [
+                "gh",
+                "api",
+                "--silent",
+                "--method",
+                "PUT",
+                f"repos/alphagov/digitalmarketplace-credentials/collaborators/{username}",
+            ],
+            check=True,
+        )


### PR DESCRIPTION
We have a lot of repos, so manually adding an external collaborator for each is painful. Create this script to invite someone as an external collaborator to all Digital Marketplace repositories. We'll use this to give CCS techops people the ability to create/merge PRs to our repos before we move the repos over to their organisation.

Whilst this will save us a bunch of time, it will still be painful for the person we've invited, since they'll need to accept each invitation manually. Though they could automate this if they wanted to (https://docs.github.com/en/rest/reference/repos#list-repository-invitations-for-the-authenticated-user).