### PR TITLE
Change test data to open GCloud12 before making it live

### DIFF
--- a/dmscripts/generate_database_data.py
+++ b/dmscripts/generate_database_data.py
@@ -73,7 +73,7 @@ G_CLOUD_FRAMEWORK = {
             'unitSingular': 'service'
         }
     ],
-    'status': '[STATUS]',
+    'status': 'live',
     'name': 'G-Cloud 12',
     'slug': 'g-cloud-12',
     'variations': {}
@@ -125,7 +125,7 @@ def make_gcloud_12_live(data: DataAPIClient) -> None:
     data.update_framework(
         framework_slug=G_CLOUD_FRAMEWORK["slug"],
         data={
-            "status": "live"
+            "status": G_CLOUD_FRAMEWORK["status"]
         }
     )
 

--- a/dmscripts/generate_database_data.py
+++ b/dmscripts/generate_database_data.py
@@ -125,8 +125,7 @@ def make_gcloud_12_live(data: DataAPIClient) -> None:
     data.update_framework(
         framework_slug=G_CLOUD_FRAMEWORK["slug"],
         data={
-            "status": "live",
-            "clarificationQuestionsOpen": False
+            "status": "live"
         }
     )
 

--- a/scripts/generate-database-data.py
+++ b/scripts/generate-database-data.py
@@ -13,7 +13,8 @@ from dmapiclient import DataAPIClient
 
 sys.path.insert(0, '.')
 from dmscripts.generate_database_data import (
-    add_live_g_cloud_framework,
+    open_gcloud_12,
+    make_gcloud_12_live,
     create_buyer_email_domain_if_not_present,
     generate_user,
     set_all_frameworks_to_expired,
@@ -26,6 +27,8 @@ STAGE = 'development'
 
 if __name__ == "__main__":
     args = docopt(__doc__)
+
+    print("Generating test data...")
 
     user = get_user()
     api_token = get_auth_token('api', STAGE)
@@ -40,8 +43,12 @@ if __name__ == "__main__":
     # them all to expired before we start adding new data
     set_all_frameworks_to_expired(data)
 
+    open_gcloud_12(data)
+
     create_buyer_email_domain_if_not_present(data, "user.marketplace.team")
 
     generate_user(data, "buyer")
 
-    add_live_g_cloud_framework(data)
+    make_gcloud_12_live(data)
+
+    print("Generation has been completed.")

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -117,7 +117,6 @@ class TestMakeGCloud12Live(TestGenerateDataBase):
         self.api_client.update_framework.assert_called_with(
             framework_slug=G_CLOUD_FRAMEWORK["slug"],
             data={
-                "status": "live",
-                "clarificationQuestionsOpen": False
+                "status": "live"
             }
         )

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -71,7 +71,7 @@ class TestSetFrameworksToExpired(TestGenerateDataBase):
         self.api_client.update_framework.assert_any_call("g-cloud-7", {"status": "expired"})
 
 
-class TestOpenGcloud12(TestGenerateDataBase):
+class TestOpenGCloud12(TestGenerateDataBase):
 
     def test_passed_valid_data(self):
         open_gcloud_12(self.api_client)

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -117,6 +117,6 @@ class TestMakeGCloud12Live(TestGenerateDataBase):
         self.api_client.update_framework.assert_called_with(
             framework_slug=G_CLOUD_FRAMEWORK["slug"],
             data={
-                "status": "live"
+                "status": G_CLOUD_FRAMEWORK["status"]
             }
         )

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -1,7 +1,8 @@
 import pytest
 import mock
 from dmscripts.generate_database_data import (
-    add_live_g_cloud_framework,
+    open_gcloud_12,
+    make_gcloud_12_live,
     create_buyer_email_domain_if_not_present,
     G_CLOUD_FRAMEWORK,
     generate_user,
@@ -70,10 +71,10 @@ class TestSetFrameworksToExpired(TestGenerateDataBase):
         self.api_client.update_framework.assert_any_call("g-cloud-7", {"status": "expired"})
 
 
-class TestCreateGCloudFramework(TestGenerateDataBase):
+class TestOpenGcloud12(TestGenerateDataBase):
 
     def test_passed_valid_data(self):
-        add_live_g_cloud_framework(self.api_client)
+        open_gcloud_12(self.api_client)
         self.api_client.create_framework.assert_called_with(
             slug=G_CLOUD_FRAMEWORK["slug"],
             name=G_CLOUD_FRAMEWORK["name"],
@@ -81,23 +82,16 @@ class TestCreateGCloudFramework(TestGenerateDataBase):
             lots=[lot["slug"] for lot in G_CLOUD_FRAMEWORK["lots"]],
             has_further_competition=False,
             has_direct_award=True,
-            status="live"
+            status="open"
         )
-
         self.api_client.update_framework.assert_called_with(
             framework_slug=G_CLOUD_FRAMEWORK["slug"],
             data={
-                "allowDeclarationReuse": G_CLOUD_FRAMEWORK["allowDeclarationReuse"],
-                "applicationsCloseAtUTC": G_CLOUD_FRAMEWORK["applicationsCloseAtUTC"],
-                "intentionToAwardAtUTC": G_CLOUD_FRAMEWORK["intentionToAwardAtUTC"],
-                "clarificationsCloseAtUTC": G_CLOUD_FRAMEWORK["clarificationsCloseAtUTC"],
-                "clarificationsPublishAtUTC": G_CLOUD_FRAMEWORK["clarificationsPublishAtUTC"],
-                "frameworkLiveAtUTC": G_CLOUD_FRAMEWORK["frameworkLiveAtUTC"],
-                "frameworkExpiresAtUTC": G_CLOUD_FRAMEWORK["frameworkExpiresAtUTC"]
+                "clarificationQuestionsOpen": True
             }
         )
 
-    def test_doesnt_add_if_already_created(self):
+    def test_doesnt_add_gcloud_if_already_present(self):
         self.api_client.find_frameworks.return_value = {
             "frameworks": [
                 {
@@ -105,5 +99,25 @@ class TestCreateGCloudFramework(TestGenerateDataBase):
                 }
             ]
         }
-        add_live_g_cloud_framework(self.api_client)
+        open_gcloud_12(self.api_client)
         assert not self.api_client.create_framework.called
+
+        self.api_client.update_framework.assert_called_with(
+            framework_slug=G_CLOUD_FRAMEWORK["slug"],
+            data={
+                "clarificationQuestionsOpen": True
+            }
+        )
+
+
+class TestMakeGcloud12Live(TestGenerateDataBase):
+
+    def test_update_framework_is_called(self):
+        make_gcloud_12_live(self.api_client)
+        self.api_client.update_framework.assert_called_with(
+            framework_slug=G_CLOUD_FRAMEWORK["slug"],
+            data={
+                "status": "live",
+                "clarificationQuestionsOpen": False
+            }
+        )

--- a/tests/test_generate_database_data.py
+++ b/tests/test_generate_database_data.py
@@ -110,7 +110,7 @@ class TestOpenGCloud12(TestGenerateDataBase):
         )
 
 
-class TestMakeGcloud12Live(TestGenerateDataBase):
+class TestMakeGCloud12Live(TestGenerateDataBase):
 
     def test_update_framework_is_called(self):
         make_gcloud_12_live(self.api_client)


### PR DESCRIPTION
Problem we faced: with GCloud being live we couldn't add suppliers to the framework. This PR first opens GCloud12 and then make it live. This lays the ground for being able to add suppliers to the framework between the framework being open and live.

I have added/edited unit tests. I've also tested this on an empty db and it seems to work.