### PR TITLE
Tidy up scripts/create_test_users.py

### DIFF
--- a/scripts/create_test_users.py
+++ b/scripts/create_test_users.py
@@ -8,15 +8,16 @@ from dmapiclient import DataAPIClient
 
 sys.path.insert(0, '.')
 from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.updated_by_helpers import get_user
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
 NUMBER_OF_SUPPLIERS = 300
 FINAL_DUNS_NUMBER = 123456789
 
-PASSWORD = 'Password1234'
+PASSWORD = 'Password1234'  # pragma: allowlist secret
 
 stage = 'development'
-data_api_client = DataAPIClient(get_api_endpoint_from_stage(stage), get_auth_token('api', stage))
+data_api_client = DataAPIClient(get_api_endpoint_from_stage(stage), get_auth_token('api', stage), user=get_user())
 
 
 def ensure_supplier_exists(data_api_client, duns_number):
@@ -50,7 +51,6 @@ def ensure_supplier_exists(data_api_client, duns_number):
             'tradingStatus': 'limited company (LTD)',
             'vatNumber': '123456788'
         },
-        user='benjamin.gill'
     )
 
     return data_api_client.find_suppliers(duns_number=duns_number)['suppliers'][0]

--- a/scripts/create_test_users.py
+++ b/scripts/create_test_users.py
@@ -6,7 +6,7 @@ import sys
 
 from dmapiclient import DataAPIClient
 
-sys.path.insert(0, '.')
+sys.path.insert(0, ".")
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmscripts.helpers.updated_by_helpers import get_user
 from dmutils.env_helpers import get_api_endpoint_from_stage
@@ -14,46 +14,57 @@ from dmutils.env_helpers import get_api_endpoint_from_stage
 NUMBER_OF_SUPPLIERS = 300
 FINAL_DUNS_NUMBER = 123456789
 
-PASSWORD = 'Password1234'  # pragma: allowlist secret
+PASSWORD = "Password1234"  # pragma: allowlist secret
 
-stage = 'development'
-data_api_client = DataAPIClient(get_api_endpoint_from_stage(stage), get_auth_token('api', stage), user=get_user())
+stage = "development"
+data_api_client = DataAPIClient(
+    get_api_endpoint_from_stage(stage), get_auth_token("api", stage), user=get_user()
+)
 
 
 def ensure_supplier_exists(data_api_client, duns_number):
     try:
-        [supplier] = data_api_client.find_suppliers(duns_number=duns_number)['suppliers']
+        [supplier] = data_api_client.find_suppliers(duns_number=duns_number)[
+            "suppliers"
+        ]
     except ValueError:
         data_api_client.create_supplier(
-            {'companiesHouseNumber': '12345678',
-             'contactInformation': [{'address1': 'Supplier Contact Address 1',
-                                     'city': 'Supplier Contact City',
-                                     'contactName': 'Supplier Contact',
-                                     'email': 'simulate-delivered@notifications.service.gov.uk',
-                                     'personalDataRemoved': False,
-                                     'phoneNumber': '555123456788',
-                                     'postcode': 'AA11 1AA'}],
-             'description': 'Test supplier',
-             'dunsNumber': str(duns_number),
-             'name': 'Test Supplier',
-             }
+            {
+                "companiesHouseNumber": "12345678",
+                "contactInformation": [
+                    {
+                        "address1": "Supplier Contact Address 1",
+                        "city": "Supplier Contact City",
+                        "contactName": "Supplier Contact",
+                        "email": "simulate-delivered@notifications.service.gov.uk",
+                        "personalDataRemoved": False,
+                        "phoneNumber": "555123456788",
+                        "postcode": "AA11 1AA",
+                    }
+                ],
+                "description": "Test supplier",
+                "dunsNumber": str(duns_number),
+                "name": "Test Supplier",
+            }
         )
-        [supplier] = data_api_client.find_suppliers(duns_number=duns_number)['suppliers']
+        [supplier] = data_api_client.find_suppliers(duns_number=duns_number)[
+            "suppliers"
+        ]
 
     data_api_client.update_supplier(
-        supplier['id'],
+        supplier["id"],
         {
-            'companyDetailsConfirmed': True,
-            'organisationSize': 'small',
-            'otherCompanyRegistrationNumber': 'Test',
-            'registeredName': 'Test Supplier LIMITED',
-            'registrationCountry': 'country:GB',
-            'tradingStatus': 'limited company (LTD)',
-            'vatNumber': '123456788'
+            "companyDetailsConfirmed": True,
+            "organisationSize": "small",
+            "otherCompanyRegistrationNumber": "Test",
+            "registeredName": "Test Supplier LIMITED",
+            "registrationCountry": "country:GB",
+            "tradingStatus": "limited company (LTD)",
+            "vatNumber": "123456788",
         },
     )
 
-    return data_api_client.find_suppliers(duns_number=duns_number)['suppliers'][0]
+    return data_api_client.find_suppliers(duns_number=duns_number)["suppliers"][0]
 
 
 def ensure_user_exists_for_supplier(data_api_client, supplier_id, duns_number):
@@ -61,20 +72,24 @@ def ensure_user_exists_for_supplier(data_api_client, supplier_id, duns_number):
 
     user = data_api_client.get_user(email_address=email_address)
     if user:
-        return user['users']
+        return user["users"]
 
-    data_api_client.create_user({
-        "emailAddress": email_address,
-        "name": "Test",
-        "password": PASSWORD,
-        'role': 'supplier',
-        'phoneNumber': '555123456788',
-        'supplierId': supplier_id,
-    })
-    return data_api_client.get_user(email_address=email_address)['users']
+    data_api_client.create_user(
+        {
+            "emailAddress": email_address,
+            "name": "Test",
+            "password": PASSWORD,
+            "role": "supplier",
+            "phoneNumber": "555123456788",
+            "supplierId": supplier_id,
+        }
+    )
+    return data_api_client.get_user(email_address=email_address)["users"]
 
 
-for duns_number in range(FINAL_DUNS_NUMBER - NUMBER_OF_SUPPLIERS + 1, FINAL_DUNS_NUMBER + 1):
+for duns_number in range(
+    FINAL_DUNS_NUMBER - NUMBER_OF_SUPPLIERS + 1, FINAL_DUNS_NUMBER + 1
+):
     supplier = ensure_supplier_exists(data_api_client, duns_number)
-    user = ensure_user_exists_for_supplier(data_api_client, supplier['id'], duns_number)
+    user = ensure_user_exists_for_supplier(data_api_client, supplier["id"], duns_number)
     print(f"{user['emailAddress']},{PASSWORD}")


### PR DESCRIPTION
Tidy up a script we used for the DOS 5 performance testing. Stop hard-coding the user - it's no longer necessary, and is confusing people.

Also run a formatter, and mark a potential secret as safe.